### PR TITLE
CCA surfaces: head dashboard, JCRC viewer, admin management

### DIFF
--- a/scripts/remediation/verify-cca-roster.mjs
+++ b/scripts/remediation/verify-cca-roster.mjs
@@ -1,0 +1,311 @@
+/**
+ * CCA roster resolution — pre-flight and drift census. READ-ONLY.
+ *
+ *   node scripts/remediation/verify-cca-roster.mjs            # all CCAs
+ *   node scripts/remediation/verify-cca-roster.mjs --cca 12   # one CCA, verbose
+ *
+ * TOUCHES THE DATABASE: reads only. No write, no index build, no delete.
+ *
+ * GATES the assumptions src/server/api/services/ccaRoster.ts is built on. It is
+ * deliberately NOT a "drift must be zero" check — drift is EXPECTED here, and
+ * the UI surfaces it in amber on purpose. It exits non-zero only for the things
+ * that make a roster WRONG rather than merely incomplete.
+ *
+ * RUN THIS BEFORE TRUSTING THE ROSTER. Checks [1] and [4] can invalidate the
+ * resolver's design; learning that from this script costs an hour, learning it
+ * from the UI costs a week.
+ *
+ * EXIT CODES
+ *   0  assumptions hold. Drift counts printed as warnings.
+ *   1  a BLOCKING assumption failed:
+ *      [1] findRaw scalar-vs-array matching disagrees with $elemMatch
+ *      [2] an unprojected typed read threw (I-2 regression)
+ *      [4] a membership key is claimed by >1 User row (attribution hazard)
+ *      [6] a CcaHead key is not a canonical userID (I-1)
+ *      [10] a CCA row holds the RESERVED ccaID 0 (cascade.ts / 07 §5)
+ *   2  could not connect, or an unexpected throw.
+ */
+import { PrismaClient } from "@prisma/client";
+import { countWhere, aggregateAll } from "./lib/rbac.mjs";
+import { canonicalUserID, isCanonicalResidentID } from "./lib/identity.mjs";
+
+const db = new PrismaClient();
+let failed = 0;
+const fail = (m) => {
+  console.error(`  FAIL  ${m}`);
+  failed++;
+};
+const warn = (m) => console.log(`  warn  ${m}`);
+
+const onlyCca = (() => {
+  const i = process.argv.indexOf("--cca");
+  return i === -1 ? null : Number(process.argv[i + 1]);
+})();
+
+async function main() {
+  console.log(`\n=== verify-cca-roster.mjs (READ-ONLY) ===\n`);
+
+  /* [1] THE LOAD-BEARING MONGO SEMANTIC ----------------------------------- */
+  // ccaRoster.ts reads the embedded User.userCCA array with
+  // findRaw({ filter: { userCCA: ccaID } }), relying on Mongo matching a scalar
+  // element-wise against an array field. `userCCA` is not declared in
+  // `model User`, so nothing else in the codebase asserts this. If it is ever
+  // false, Source A silently returns nothing and rosters under-report with no
+  // error anywhere.
+  console.log(`[1] findRaw scalar-vs-array matching (blocking)`);
+  const sampleCcas = await db.cCA.findMany({
+    select: { ccaID: true },
+    orderBy: { ccaID: "asc" },
+    take: 5,
+  });
+  for (const { ccaID } of sampleCcas) {
+    const plain = await countWhere(db, "User", { userCCA: ccaID });
+    const elem = await countWhere(db, "User", {
+      userCCA: { $elemMatch: { $eq: ccaID } },
+    });
+    const agree = plain === elem;
+    console.log(
+      `  ccaID ${String(ccaID).padStart(4)}  scalar=${String(plain).padStart(4)}  $elemMatch=${String(elem).padStart(4)}  ${agree ? "agree" : "DISAGREE"}`,
+    );
+    if (!agree) {
+      fail(
+        `{ userCCA: ${ccaID} } returned ${plain} but $elemMatch returned ${elem}. ` +
+          `ccaRoster.ts Source A is unsound — switch it to $elemMatch.`,
+      );
+    }
+  }
+
+  /* [2] I-2 REGRESSION GUARD ---------------------------------------------- */
+  console.log(`\n[2] unprojected typed reads (I-2 guard, blocking)`);
+  try {
+    const ccas = await db.cCA.findMany();
+    const uc = await db.userCCA.findMany();
+    const ch = await db.ccaHead.findMany();
+    console.log(`  CCA:     ${ccas.length}`);
+    console.log(`  UserCCA: ${uc.length}`);
+    console.log(`  CcaHead: ${ch.length}`);
+  } catch (e) {
+    fail(
+      `a typed read THREW — a document is missing a required scalar (I-2). ${e.message}`,
+    );
+  }
+
+  /* [3] KEY FORMAT CENSUS -------------------------------------------------- */
+  console.log(`\n[3] UserCCA.userID format census`);
+  const allUserCca = await db.userCCA.findMany({
+    select: { ccaID: true, userID: true },
+  });
+  const eFmt = allUserCca.filter((r) => /^E\d{7}$/i.test(r.userID)).length;
+  const aFmt = allUserCca.filter((r) => /^A\d{7}[A-Z]$/i.test(r.userID)).length;
+  console.log(`  total rows: ${allUserCca.length}`);
+  console.log(`  E-format:   ${eFmt}`);
+  console.log(`  A-format:   ${aFmt}`);
+  console.log(`  other:      ${allUserCca.length - eFmt - aFmt}`);
+  const perCca = new Map();
+  for (const r of allUserCca)
+    perCca.set(r.ccaID, (perCca.get(r.ccaID) ?? 0) + 1);
+  const maxRows = Math.max(0, ...perCca.values());
+  console.log(`  max rows for one CCA: ${maxRows}`);
+  if (aFmt > 0) {
+    warn(
+      `mixed key formats confirmed. @@unique([ccaID,userID]) stays DEFERRED ` +
+        `(07 §0.3); @@index([ccaID]) alone is still safe to add.`,
+    );
+  }
+
+  /* [4] AMBIGUOUS KEYS — THE ATTRIBUTION HAZARD ---------------------------- */
+  // If one membership key is claimed by two User rows, any resolver that picks
+  // the first attributes one person's membership to another — a failure
+  // indistinguishable from success. ccaRoster.ts refuses to pick; this check
+  // reports whether the situation exists at all.
+  console.log(`\n[4] membership keys claimed by >1 User row (blocking)`);
+  const keys = [
+    ...new Set([
+      ...allUserCca.map((r) => r.userID),
+      ...(await db.ccaHead.findMany({ select: { userID: true } })).map(
+        (r) => r.userID,
+      ),
+    ]),
+  ].filter(Boolean);
+
+  const users = await db.user.findMany({
+    select: { id: true, email: true, userID: true },
+  });
+  const claims = new Map();
+  const claim = (k, id) => {
+    if (!k) return;
+    const s = claims.get(k) ?? new Set();
+    s.add(id);
+    claims.set(k, s);
+  };
+  for (const u of users) {
+    claim(canonicalUserID(u.email), u.id);
+    if (u.userID) claim(u.userID, u.id);
+  }
+
+  let ambiguous = 0;
+  let unresolvable = 0;
+  for (const k of keys) {
+    const c = claims.get(k);
+    if (!c || c.size === 0) unresolvable++;
+    else if (c.size > 1) {
+      ambiguous++;
+      fail(
+        `key "${k}" is claimed by ${c.size} User rows (${[...c].join(", ")}). ` +
+          `Merge the duplicates — see scripts/remediation/dedupe-users.mjs.`,
+      );
+    }
+  }
+  console.log(`  distinct membership keys: ${keys.length}`);
+  console.log(`  ambiguous:                ${ambiguous}`);
+  console.log(`  unresolvable:             ${unresolvable}`);
+  if (unresolvable > 0) {
+    warn(
+      `${unresolvable} key(s) match no account. These render AMBER in the ` +
+        `roster and are not dropped — expected, not a failure.`,
+    );
+  }
+
+  /* [5] DUPLICATE MEMBERSHIP ROWS ------------------------------------------ */
+  console.log(`\n[5] duplicate (ccaID, userID) pairs`);
+  const seen = new Set();
+  const dups = [];
+  for (const r of allUserCca) {
+    const k = `${r.ccaID}|${r.userID}`;
+    if (seen.has(k)) dups.push(k);
+    seen.add(k);
+  }
+  console.log(`  duplicates: ${dups.length}`);
+  if (dups.length > 0) {
+    warn(`e.g. ${dups.slice(0, 5).join(", ")}`);
+    warn(
+      `the roster collapses these into one row with a count. @@unique is ` +
+        `blocked until they are deduped.`,
+    );
+  }
+
+  /* [6] I-1 — CcaHead KEYS ARE CANONICAL ----------------------------------- */
+  // NOT an E-format assertion: "G.S_SAMUEL" is a real canonical key here, and
+  // asserting /^E\d{7}$/ is lockout mode L-27.
+  console.log(`\n[6] CcaHead.userID is canonical (I-1, blocking)`);
+  const headRows = await db.ccaHead.findMany({
+    select: { userID: true, ccaID: true },
+  });
+  let badKeys = 0;
+  for (const h of headRows) {
+    if (!isCanonicalResidentID(h.userID)) {
+      badKeys++;
+      fail(`CcaHead row for ccaID ${h.ccaID} has non-canonical userID "${h.userID}"`);
+    }
+  }
+  console.log(`  head rows: ${headRows.length}, non-canonical: ${badKeys}`);
+
+  /* [7] HEADS THAT RESOLVE TO NO ACCOUNT ----------------------------------- */
+  console.log(`\n[7] heads with no matching account`);
+  const orphanHeads = headRows.filter((h) => !claims.get(h.userID)?.size);
+  console.log(`  ${orphanHeads.length}`);
+  if (orphanHeads.length > 0) {
+    warn(
+      `these render amber WITH a Head pill: ` +
+        `${orphanHeads.slice(0, 5).map((h) => h.userID).join(", ")}`,
+    );
+  }
+
+  /* [8] CH-1 DRIFT, BOTH DIRECTIONS ---------------------------------------- */
+  console.log(`\n[8] CH-1 (cca_head string <-> CcaHead row)`);
+  const stringWithoutScope = await aggregateAll(db, "UserRole", [
+    { $match: { roles: "cca_head" } },
+    {
+      $lookup: {
+        from: "CcaHead",
+        localField: "userID",
+        foreignField: "userID",
+        as: "h",
+      },
+    },
+    { $match: { h: { $size: 0 } } },
+    { $project: { userID: 1 } },
+  ]);
+  const scopeWithoutString = await aggregateAll(db, "CcaHead", [
+    {
+      $lookup: {
+        from: "UserRole",
+        localField: "userID",
+        foreignField: "userID",
+        as: "r",
+      },
+    },
+    { $match: { "r.roles": { $ne: "cca_head" } } },
+    { $project: { userID: 1, ccaID: 1 } },
+  ]);
+  console.log(`  string without scope: ${stringWithoutScope.length}`);
+  console.log(`  scope without string: ${scopeWithoutString.length}`);
+  if (stringWithoutScope.length > 0) {
+    warn(
+      `these users reach /cca and see an EMPTY list — the intended failure ` +
+        `direction, but the string should be revoked.`,
+    );
+  }
+
+  /* [9] ORPHANED HEADSHIPS ------------------------------------------------- */
+  console.log(`\n[9] CcaHead rows pointing at a deleted CCA`);
+  const liveCcaIDs = new Set(
+    (await db.cCA.findMany({ select: { ccaID: true } })).map((c) => c.ccaID),
+  );
+  const orphanScope = headRows.filter((h) => !liveCcaIDs.has(h.ccaID));
+  console.log(`  ${orphanScope.length}`);
+  if (orphanScope.length > 0) {
+    warn(
+      `deleteCcaCascade now removes CcaHead rows, so these predate that fix.`,
+    );
+  }
+
+  /* [10] THE RESERVED ccaID ------------------------------------------------ */
+  // BookingModal hardcodes ccaID 0 on every booking, and deleteCcaCascade
+  // deletes bookings by ccaID. A CCA row holding 0 is a live hazard even with
+  // the guard in place, because the guard makes it undeletable rather than safe.
+  console.log(`\n[10] reserved ccaID 0 (blocking)`);
+  const zero = await db.cCA.findFirst({ where: { ccaID: 0 } });
+  if (zero) {
+    fail(
+      `a CCA row holds the RESERVED ccaID 0: ${JSON.stringify(zero)}. ` +
+        `Re-key it before anything else — every booking created by the current ` +
+        `UI carries ccaID 0.`,
+    );
+  } else {
+    console.log(`  none — good`);
+  }
+
+  /* [11] INDEX REPORT ------------------------------------------------------ */
+  console.log(`\n[11] UserCCA index report`);
+  try {
+    const probe = onlyCca ?? sampleCcas[0]?.ccaID;
+    const t0 = Date.now();
+    await db.userCCA.findMany({ where: { ccaID: probe } });
+    const ms = Date.now() - t0;
+    const idx = await db.$runCommandRaw({ listIndexes: "UserCCA" });
+    const names = (idx?.cursor?.firstBatch ?? []).map((i) => i.name);
+    console.log(`  indexes: ${names.join(", ") || "(none)"}`);
+    console.log(`  roster read for ccaID ${probe}: ${ms}ms`);
+    if (!names.some((n) => n.toLowerCase().includes("ccaid"))) {
+      warn(
+        `no ccaID index — roster reads are a COLLSCAN. Safe to add ` +
+          `@@index([ccaID]) (non-unique, so duplicates do not block it).`,
+      );
+    }
+  } catch (e) {
+    warn(`index report unavailable: ${e.message}`);
+  }
+
+  console.log(
+    `\n=== ${failed === 0 ? "PASS" : `FAIL (${failed} blocking)`} ===\n`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main()
+  .catch((e) => {
+    console.error(`\nUNEXPECTED: ${e?.stack ?? e}\n`);
+    process.exit(2);
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/_components/RosterDriftNote.tsx
+++ b/src/app/_components/RosterDriftNote.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { RosterDrift } from "~/server/api/services/ccaRoster";
+
+/**
+ * A summary of what the roster could NOT cleanly resolve, shown above the table
+ * so the counts are visible without scanning every row.
+ *
+ * Renders NOTHING when everything resolved — a permanently-present "0 problems"
+ * banner trains people to ignore the space it occupies, which is exactly where
+ * the real warning will later appear.
+ *
+ * Written for the reader, not the schema: no key formats, no collection names.
+ * A CCA head does not know what UserCCA is and should not have to.
+ */
+export default function RosterDriftNote({ drift }: { drift: RosterDrift }) {
+  const notes: string[] = [];
+
+  if (drift.unresolvedCount > 0) {
+    notes.push(
+      `${drift.unresolvedCount} membership ${
+        drift.unresolvedCount === 1 ? "record" : "records"
+      } could not be matched to an account`,
+    );
+  }
+  if (drift.ambiguousCount > 0) {
+    notes.push(
+      `${drift.ambiguousCount} of those match more than one account, so they have not been guessed`,
+    );
+  }
+  if (drift.duplicateUserCcaRows > 0) {
+    notes.push(
+      `${drift.duplicateUserCcaRows} duplicate membership ${
+        drift.duplicateUserCcaRows === 1 ? "record" : "records"
+      }`,
+    );
+  }
+  if (drift.headsUnresolved > 0) {
+    notes.push(
+      `${drift.headsUnresolved} head ${
+        drift.headsUnresolved === 1 ? "record has" : "records have"
+      } no matching account`,
+    );
+  }
+
+  if (notes.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3">
+      <p className="text-sm font-medium text-amber-900">
+        Some records need attention
+      </p>
+      <ul className="mt-1 list-inside list-disc text-sm text-amber-800">
+        {notes.map((n) => (
+          <li key={n}>{n}</li>
+        ))}
+      </ul>
+      <p className="mt-2 text-xs text-amber-700">
+        Everyone below is still a member — these records just can&rsquo;t be
+        linked to an account. Contact the JCRC if a name looks wrong.
+      </p>
+    </div>
+  );
+}

--- a/src/app/_components/RosterPanel.tsx
+++ b/src/app/_components/RosterPanel.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import RosterTable from "./RosterTable";
+import RosterDriftNote from "./RosterDriftNote";
+
+/**
+ * The roster for one CCA. Rendered by /cca/[ccaID] and by /admin/ccas.
+ *
+ * NEITHER PAGE PRE-GUARDS. cca.getRoster is the one policy site — a client can
+ * call it from the console on any page in the app, so a duplicate check in the
+ * page would be a second place to keep in step while buying no protection
+ * (I-7). This component renders the denial the procedure returns.
+ */
+export default function RosterPanel({ ccaID }: { ccaID: number }) {
+  const { data, isPending, error } = api.cca.getRoster.useQuery(
+    { ccaID },
+    {
+      // A FORBIDDEN is a settled answer, not a transient failure. Retrying it
+      // three times is log noise and a slow, ambiguous UI.
+      retry: false,
+    },
+  );
+
+  if (isPending) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <div className="h-6 w-48 animate-pulse rounded bg-gray-200" />
+        <div className="h-32 animate-pulse rounded-lg bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error) {
+    if (error.message === "NOT_A_HEAD_OF_THIS_CCA") {
+      return (
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-6">
+          <p className="text-sm font-medium text-gray-900">
+            You don&rsquo;t have access to this CCA
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            You can only view CCAs you&rsquo;re listed as a head of. If that
+            should include this one, contact the JCRC.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-6">
+        <p className="text-sm font-medium text-red-900">
+          This roster couldn&rsquo;t be loaded
+        </p>
+        <p className="mt-1 text-sm text-red-700">
+          Reload the page. If it keeps happening, contact the JCRC.
+        </p>
+      </div>
+    );
+  }
+
+  const { cca, heads, members, drift, via } = data;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {cca.ccaName ?? `Unknown CCA (#${cca.ccaID})`}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {cca.category ?? "Uncategorised"}
+          {via === "manageCcaHeads" && (
+            <span className="ml-2 text-gray-400">· viewing as JCRC</span>
+          )}
+        </p>
+      </header>
+
+      {/* The CCA record itself is missing — the CcaBadges amber idiom, applied
+          to the whole page rather than one row. */}
+      {drift.ccaMissing && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          There is no CCA with this id any more, but these membership records
+          still point at it.
+        </div>
+      )}
+
+      <RosterDriftNote drift={drift} />
+
+      <RosterTable
+        title="Heads"
+        entries={heads}
+        emptyCopy="Nobody is currently listed as a head of this CCA."
+      />
+      <RosterTable
+        title="Members"
+        entries={members}
+        emptyCopy="No members are listed for this CCA yet."
+      />
+    </div>
+  );
+}

--- a/src/app/_components/RosterTable.tsx
+++ b/src/app/_components/RosterTable.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import type { RosterEntry } from "~/server/api/services/ccaRoster";
+
+/**
+ * DISPLAY ONLY — the same rule CcaBadges and RoleBadges state. Nothing here is
+ * the basis of a permission decision.
+ *
+ * Rendered by BOTH /cca/[ccaID] (a head viewing their own CCA) and
+ * /admin/ccas (a manager viewing any CCA). One component, because the two
+ * surfaces show the same thing to different audiences — if this ever needs to
+ * fork, that is a signal something upstream was designed wrong.
+ *
+ * THE AMBER ROWS ARE THE POINT. A membership record that resolves to no account
+ * is real data drift, and this is the only place anyone will ever see it. It is
+ * NOT filtered out: 07-cca-future.md §3 names the client-side .filter() as the
+ * anti-pattern that hides the problem it is hiding from.
+ */
+
+/** Head vs member, labelled on BOTH states — see the note in CcaBadges. */
+function RoleLabel({ isHead }: { isHead: boolean }) {
+  return isHead ? (
+    <span className="shrink-0 rounded-full border border-indigo-300 bg-indigo-100 px-2.5 py-0.5 text-xs font-medium text-indigo-800">
+      Head
+    </span>
+  ) : (
+    <span className="shrink-0 text-xs text-gray-400">Member</span>
+  );
+}
+
+/**
+ * The copy here is load-bearing. It must say "we cannot match this record to an
+ * account" and must NOT imply the person is absent — a member whose NUS email
+ * doesn't match the canonical guess (a Google sign-in on a personal address, a
+ * merged account) lands here, and "Unknown" alone reads as "Jane isn't in the
+ * roster", which is a different and wrong conclusion.
+ */
+function unresolvedCopy(entry: Extract<RosterEntry, { kind: "unresolved" }>) {
+  return entry.reason === "AMBIGUOUS_KEY"
+    ? {
+        label: `Ambiguous record (${entry.key})`,
+        detail: `${entry.candidateUserIds.length} accounts claim this membership record, so we can't tell which person it belongs to. It has not been guessed. Contact the JCRC to have the duplicate accounts merged.`,
+      }
+    : {
+        label: `Unmatched record (${entry.key})`,
+        detail:
+          "This membership record doesn't match any account we can find. It may predate the account migration, or the member may sign in with a different address. They are still a member — we just can't show their details.",
+      };
+}
+
+function EntryRow({ entry }: { entry: RosterEntry }) {
+  const duplicate = entry.userCcaRowCount > 1;
+
+  if (entry.kind === "unresolved") {
+    const { label, detail } = unresolvedCopy(entry);
+    return (
+      <TableRow className="border-amber-200 bg-amber-50">
+        <TableCell className="font-medium text-amber-900">
+          <span title={detail}>{label}</span>
+          {duplicate && (
+            <span className="ml-2 text-xs font-normal text-amber-700">
+              · {entry.userCcaRowCount} membership records
+            </span>
+          )}
+        </TableCell>
+        <TableCell className="text-amber-700">—</TableCell>
+        <TableCell className="text-right">
+          <RoleLabel isHead={entry.isHead} />
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium text-gray-900">
+        {entry.displayName ?? (
+          <span className="text-gray-500">No name on file</span>
+        )}
+        {duplicate && (
+          <span
+            className="ml-2 text-xs font-normal text-amber-700"
+            title="This person has more than one membership record for this CCA. Harmless, but worth cleaning up."
+          >
+            · {entry.userCcaRowCount} membership records
+          </span>
+        )}
+      </TableCell>
+      <TableCell className="text-gray-600">{entry.email}</TableCell>
+      <TableCell className="text-right">
+        <RoleLabel isHead={entry.isHead} />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function RosterTable({
+  title,
+  entries,
+  emptyCopy,
+}: {
+  title: string;
+  entries: RosterEntry[];
+  emptyCopy: string;
+}) {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        {title}
+        <span className="ml-2 font-normal normal-case tracking-normal text-gray-400">
+          {entries.length}
+        </span>
+      </h2>
+
+      {entries.length === 0 ? (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-sm text-gray-500">
+          {emptyCopy}
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead className="text-right">Role</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map((e) => (
+                <EntryRow key={e.kind === "resolved" ? e.userId : e.key} entry={e} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/admin/_components/AdminShell.tsx
+++ b/src/app/admin/_components/AdminShell.tsx
@@ -5,9 +5,11 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   Users,
+  Users2,
   Upload,
   DoorOpen,
   ScrollText,
+  Settings2,
 } from "lucide-react";
 
 import Header from "~/app/_components/header";
@@ -35,6 +37,21 @@ const ADMIN_TABS = [
   },
   { href: "/admin/users", label: "Users", icon: Users, requires: "listUsers" },
   { href: "/admin/bulk", label: "Bulk", icon: Upload, requires: "bulkAssign" },
+  // Read-only roster viewer — admin + jcrc.
+  {
+    href: "/admin/ccas",
+    label: "CCAs",
+    icon: Users2,
+    requires: "viewAnyCcaRoster",
+  },
+  // CCA create/rename, heads and members — admin only, and additionally behind
+  // the cca.management.enabled kill switch checked in the procedures.
+  {
+    href: "/admin/manage-ccas",
+    label: "Manage CCAs",
+    icon: Settings2,
+    requires: "manageCcas",
+  },
   {
     href: "/admin/facilities",
     label: "Facilities",

--- a/src/app/admin/ccas/layout.tsx
+++ b/src/app/admin/ccas/layout.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Narrower than ../layout.tsx, so it ships its own gate (03 §3): a hidden tab
+ * is not a guard. Without this, anyone who could reach /admin at all could type
+ * /admin/ccas and read every roster.
+ *
+ * It RECOMPUTES from its own live read rather than taking a prop from the
+ * parent layout. The duplication with ../layout.tsx is the point.
+ */
+export default async function AdminCcasLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRoles(db, session.user.userID); // I-5 live read
+  } catch {
+    redirect("/admin"); // fail CLOSED
+  }
+
+  if (!computeCapabilities(roles).viewAnyCcaRoster) redirect("/admin");
+
+  return <>{children}</>;
+}

--- a/src/app/admin/ccas/page.tsx
+++ b/src/app/admin/ccas/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+import CcaPicker, {
+  type CcaOption,
+} from "~/app/admin/_components/bulk/CcaPicker";
+import RosterPanel from "~/app/_components/RosterPanel";
+
+/**
+ * Browse any CCA's roster. READ-ONLY.
+ *
+ * Reuses CcaPicker (built for the bulk head wizard) and RosterPanel (built for
+ * /cca/[ccaID]) verbatim, and calls the SAME cca.getRoster procedure — the
+ * object-scope guard simply passes on the manageCcaHeads capability here rather
+ * than on a headship row.
+ *
+ * No new query, no new table, no new guard. If this page ever needs its own,
+ * that is a signal something upstream was designed wrong.
+ */
+export default function AdminCcasPage() {
+  const [selected, setSelected] = useState<CcaOption | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">CCAs</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Pick a CCA to see its heads and members.
+        </p>
+      </header>
+
+      <CcaPicker
+        value={selected?.ccaID ?? null}
+        onChange={(cca) => setSelected(cca)}
+      />
+
+      {selected ? (
+        <RosterPanel ccaID={selected.ccaID} />
+      ) : (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-sm text-gray-500">
+          Choose a CCA above to see who&rsquo;s in it.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/manage-ccas/_components/CreateCcaForm.tsx
+++ b/src/app/admin/manage-ccas/_components/CreateCcaForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+/**
+ * Create a CCA.
+ *
+ * The ccaID is allocated SERVER-SIDE (max + 1) and is deliberately not an input
+ * — it is the join key for Bookings, UserCCA and CcaHead, and letting an
+ * operator type it invites a collision with a live one.
+ */
+export default function CreateCcaForm({ enabled }: { enabled: boolean }) {
+  const [ccaName, setCcaName] = useState("");
+  const [category, setCategory] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const utils = api.useUtils();
+  const create = api.ccaAdmin.create.useMutation({
+    onSuccess: async () => {
+      setCcaName("");
+      setCategory("");
+      setOpen(false);
+      await utils.ccaAdmin.listAll.invalidate();
+    },
+  });
+
+  const message =
+    create.error?.message === "CCA_NAME_ALREADY_EXISTS"
+      ? "A CCA with that name already exists."
+      : create.error?.message === "CCA_MANAGEMENT_DISABLED"
+        ? "CCA management is turned off."
+        : create.error
+          ? "That didn't save. Try again."
+          : null;
+
+  if (!open) {
+    return (
+      <Button
+        variant="outline"
+        disabled={!enabled}
+        onClick={() => setOpen(true)}
+      >
+        Add a CCA
+      </Button>
+    );
+  }
+
+  return (
+    <form
+      className="space-y-4 rounded-lg border border-gray-200 bg-white p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        create.mutate({ ccaName: ccaName.trim(), category: category.trim() });
+      }}
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="cca-name">Name</Label>
+          <Input
+            id="cca-name"
+            value={ccaName}
+            onChange={(e) => setCcaName(e.target.value)}
+            placeholder="Photography Club"
+            maxLength={120}
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="cca-category">Category</Label>
+          <Input
+            id="cca-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            placeholder="Interest Group"
+            maxLength={120}
+            required
+          />
+        </div>
+      </div>
+
+      {message && <p className="text-sm text-red-600">{message}</p>}
+
+      <div className="flex gap-2">
+        <Button
+          type="submit"
+          disabled={
+            !enabled ||
+            create.isPending ||
+            !ccaName.trim() ||
+            !category.trim()
+          }
+        >
+          {create.isPending ? "Adding…" : "Add CCA"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            setOpen(false);
+            create.reset();
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/manage-ccas/_components/ManageCcaDetail.tsx
+++ b/src/app/admin/manage-ccas/_components/ManageCcaDetail.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useState } from "react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import RosterDriftNote from "~/app/_components/RosterDriftNote";
+
+/**
+ * Everything you can do to one CCA: rename it, manage its heads, add and remove
+ * members.
+ *
+ * NO DELETE. See the note at the top of the page component.
+ *
+ * Head management calls admin.grantCcaHead / revokeCcaHead / transferCcaHead —
+ * the procedures that already exist and already maintain invariant CH-1 in one
+ * transaction. This panel is a UI over them and adds no new writer of the
+ * `cca_head` string, which I-14 forbids.
+ */
+
+function friendlyError(message: string | undefined): string | null {
+  if (!message) return null;
+  const map: Record<string, string> = {
+    CCA_MANAGEMENT_DISABLED: "CCA management is turned off.",
+    ALREADY_A_MEMBER: "They're already a member of this CCA.",
+    NO_SUCH_CCA: "That CCA no longer exists. Reload the page.",
+    NO_SUCH_USER: "That account no longer exists. Reload the page.",
+    SAME_USER: "Pick two different people.",
+    NOT_A_HEAD_OF_THIS_CCA: "They aren't a head of this CCA.",
+    CANNOT_MODIFY_AN_ADMIN: "You can't change an admin's roles.",
+  };
+  if (map[message]) return map[message]!;
+  if (message.startsWith("CAPABILITY_REQUIRED"))
+    return "You don't have permission to do that.";
+  if (message.includes("canonical"))
+    return "That doesn't look like an NUS email or NUSNET ID.";
+  return "That didn't save. Try again.";
+}
+
+/* -- heads ----------------------------------------------------------------- */
+
+function HeadsPanel({ ccaID, enabled }: { ccaID: number; enabled: boolean }) {
+  const [newHead, setNewHead] = useState("");
+  const utils = api.useUtils();
+
+  const heads = api.admin.listCcaHeads.useQuery({ ccaID }, { retry: false });
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.admin.listCcaHeads.invalidate({ ccaID }),
+      utils.cca.getRoster.invalidate({ ccaID }),
+      utils.ccaAdmin.listAll.invalidate(),
+    ]);
+  };
+
+  const grant = api.admin.grantCcaHead.useMutation({
+    onSuccess: async () => {
+      setNewHead("");
+      await refresh();
+    },
+  });
+  const revoke = api.admin.revokeCcaHead.useMutation({ onSuccess: refresh });
+
+  const rows = heads.data ?? [];
+  const error = friendlyError(grant.error?.message ?? revoke.error?.message);
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Heads
+        <span className="ml-2 font-normal normal-case tracking-normal text-gray-400">
+          {rows.length}
+        </span>
+      </h3>
+
+      {/* Soft warning, never a block. A hard cap is a guess about org structure
+          that will be wrong for some CCA, and unrecoverable in-app. */}
+      {rows.length > 3 && (
+        <p className="text-xs text-amber-700">
+          This CCA has {rows.length} heads. That&rsquo;s allowed, but worth a
+          double-check.
+        </p>
+      )}
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          Nobody heads this CCA, so nobody can see its roster from their own CCA
+          page. Add a head below.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((h) => (
+            <li
+              key={h.userID}
+              className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2"
+            >
+              <span className="font-mono text-sm text-gray-900">
+                {h.userID}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={!enabled || revoke.isPending}
+                onClick={() =>
+                  revoke.mutate({ ccaID, userID: h.userID })
+                }
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form
+        className="flex flex-wrap items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          grant.mutate({ ccaID, userID: newHead.trim().toUpperCase() });
+        }}
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor={`head-${ccaID}`}>Add a head</Label>
+          <Input
+            id={`head-${ccaID}`}
+            value={newHead}
+            onChange={(e) => setNewHead(e.target.value)}
+            placeholder="E0425010"
+            className="sm:w-64"
+          />
+        </div>
+        <Button
+          type="submit"
+          variant="outline"
+          disabled={!enabled || grant.isPending || !newHead.trim()}
+        >
+          {grant.isPending ? "Adding…" : "Add head"}
+        </Button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </section>
+  );
+}
+
+/* -- members --------------------------------------------------------------- */
+
+function MembersPanel({ ccaID, enabled }: { ccaID: number; enabled: boolean }) {
+  const [newMember, setNewMember] = useState("");
+  const utils = api.useUtils();
+
+  // The SAME roster procedure /cca and /admin/ccas use. An admin passes its
+  // object-scope guard on the manageCcaHeads capability.
+  const roster = api.cca.getRoster.useQuery({ ccaID }, { retry: false });
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.cca.getRoster.invalidate({ ccaID }),
+      utils.ccaAdmin.listAll.invalidate(),
+    ]);
+  };
+
+  const add = api.ccaAdmin.addMember.useMutation({
+    onSuccess: async () => {
+      setNewMember("");
+      await refresh();
+    },
+  });
+  const remove = api.ccaAdmin.removeMember.useMutation({ onSuccess: refresh });
+
+  const error = friendlyError(add.error?.message ?? remove.error?.message);
+  const members = roster.data?.members ?? [];
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Members
+        <span className="ml-2 font-normal normal-case tracking-normal text-gray-400">
+          {members.length}
+        </span>
+      </h3>
+
+      {roster.data && <RosterDriftNote drift={roster.data.drift} />}
+
+      {roster.isPending ? (
+        <div className="h-24 animate-pulse rounded-lg bg-gray-200" />
+      ) : members.length === 0 ? (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+          No members listed yet.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {members.map((m) => {
+            const unmatched = m.kind === "unresolved";
+            return (
+              <li
+                key={m.kind === "resolved" ? m.userId : m.key}
+                className={`flex items-center justify-between gap-3 rounded-lg border px-3 py-2 ${
+                  unmatched
+                    ? "border-amber-300 bg-amber-50"
+                    : "border-gray-200 bg-white"
+                }`}
+              >
+                <span className="min-w-0">
+                  <span
+                    className={`block truncate text-sm ${
+                      unmatched ? "text-amber-900" : "text-gray-900"
+                    }`}
+                  >
+                    {m.kind === "resolved"
+                      ? (m.displayName ?? m.email)
+                      : `Unmatched record (${m.key})`}
+                  </span>
+                  {m.kind === "resolved" && (
+                    <span className="block truncate text-xs text-gray-500">
+                      {m.email}
+                    </span>
+                  )}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!enabled || remove.isPending}
+                  onClick={() =>
+                    remove.mutate({
+                      ccaID,
+                      // Server-derived keys: we name a User document (or a raw
+                      // unresolved key) and the procedure recomputes every
+                      // membership key itself. Never client-supplied keys.
+                      target:
+                        m.kind === "resolved"
+                          ? { kind: "user", userObjectId: m.userId }
+                          : { kind: "key", key: m.key },
+                    })
+                  }
+                >
+                  Remove
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <form
+        className="flex flex-wrap items-end gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          add.mutate({ ccaID, userID: newMember.trim().toUpperCase() });
+        }}
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor={`member-${ccaID}`}>Add a member</Label>
+          <Input
+            id={`member-${ccaID}`}
+            value={newMember}
+            onChange={(e) => setNewMember(e.target.value)}
+            placeholder="E0425010"
+            className="sm:w-64"
+          />
+        </div>
+        <Button
+          type="submit"
+          variant="outline"
+          disabled={!enabled || add.isPending || !newMember.trim()}
+        >
+          {add.isPending ? "Adding…" : "Add member"}
+        </Button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </section>
+  );
+}
+
+/* -- the record ------------------------------------------------------------ */
+
+function RenamePanel({
+  ccaID,
+  enabled,
+  initialName,
+  initialCategory,
+}: {
+  ccaID: number;
+  enabled: boolean;
+  initialName: string;
+  initialCategory: string;
+}) {
+  const [ccaName, setCcaName] = useState(initialName);
+  const [category, setCategory] = useState(initialCategory);
+  const utils = api.useUtils();
+
+  const rename = api.ccaAdmin.rename.useMutation({
+    onSuccess: async () => {
+      await utils.ccaAdmin.listAll.invalidate();
+    },
+  });
+
+  const dirty = ccaName !== initialName || category !== initialCategory;
+  const error = friendlyError(rename.error?.message);
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Details
+      </h3>
+      <form
+        className="space-y-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          rename.mutate({
+            ccaID,
+            ccaName: ccaName.trim(),
+            category: category.trim(),
+          });
+        }}
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor={`name-${ccaID}`}>Name</Label>
+            <Input
+              id={`name-${ccaID}`}
+              value={ccaName}
+              onChange={(e) => setCcaName(e.target.value)}
+              maxLength={120}
+              required
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`cat-${ccaID}`}>Category</Label>
+            <Input
+              id={`cat-${ccaID}`}
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              maxLength={120}
+              required
+            />
+          </div>
+        </div>
+        <p className="text-xs text-gray-400">
+          Renaming keeps the CCA&rsquo;s id, so its members, heads and bookings
+          stay attached.
+        </p>
+        <Button
+          type="submit"
+          variant="outline"
+          disabled={!enabled || rename.isPending || !dirty}
+        >
+          {rename.isPending ? "Saving…" : "Save changes"}
+        </Button>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {rename.isSuccess && !dirty && (
+          <p className="text-sm text-emerald-700">Saved.</p>
+        )}
+      </form>
+    </section>
+  );
+}
+
+/* -- shell ----------------------------------------------------------------- */
+
+export default function ManageCcaDetail({
+  ccaID,
+  enabled,
+  cca,
+}: {
+  ccaID: number;
+  enabled: boolean;
+  cca: { ccaName: string; category: string };
+}) {
+  return (
+    <div className="space-y-8 rounded-lg border border-gray-200 bg-gray-50 p-5">
+      <header>
+        <h2 className="text-lg font-semibold text-gray-900">{cca.ccaName}</h2>
+        <p className="text-sm text-gray-500">
+          {cca.category} · id {ccaID}
+        </p>
+      </header>
+
+      <RenamePanel
+        ccaID={ccaID}
+        enabled={enabled}
+        initialName={cca.ccaName}
+        initialCategory={cca.category}
+      />
+      <HeadsPanel ccaID={ccaID} enabled={enabled} />
+      <MembersPanel ccaID={ccaID} enabled={enabled} />
+    </div>
+  );
+}

--- a/src/app/admin/manage-ccas/layout.tsx
+++ b/src/app/admin/manage-ccas/layout.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * ADMIN ONLY, and the narrowest gate in the app after /admin/audit. Ships its
+ * own live role read for the same reason every narrow segment does: a hidden
+ * tab is not a guard, and a jcrc typing this URL must not reach a surface that
+ * creates and renames CCAs.
+ *
+ * The kill switch is NOT checked here. This layout answers "may you be in this
+ * room"; the switch answers "is the machinery live", and that belongs in the
+ * procedures — a page-level switch check would leave the mutations reachable
+ * from the console.
+ */
+export default async function ManageCcasLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRoles(db, session.user.userID); // I-5 live read
+  } catch {
+    redirect("/admin"); // fail CLOSED
+  }
+
+  if (!computeCapabilities(roles).manageCcas) redirect("/admin");
+
+  return <>{children}</>;
+}

--- a/src/app/admin/manage-ccas/page.tsx
+++ b/src/app/admin/manage-ccas/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+
+import { api } from "~/trpc/react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import CreateCcaForm from "./_components/CreateCcaForm";
+import ManageCcaDetail from "./_components/ManageCcaDetail";
+
+/**
+ * CCA management. Admin only (enforced by ./layout.tsx and again in every
+ * procedure), and behind the `cca.management.enabled` kill switch.
+ *
+ * THERE IS NO DELETE AFFORDANCE ANYWHERE ON THIS PAGE, and no delete procedure
+ * behind it. Deleting a CCA cascades into Bookings by ccaID — see the guards in
+ * services/cascade.ts before you consider adding one.
+ */
+export default function ManageCcasPage() {
+  const [selected, setSelected] = useState<number | null>(null);
+  const { data, isPending, error } = api.ccaAdmin.listAll.useQuery(undefined, {
+    retry: false,
+  });
+
+  if (isPending) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <div className="h-8 w-56 animate-pulse rounded bg-gray-200" />
+        <div className="h-64 animate-pulse rounded-lg bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-6">
+        <p className="text-sm font-medium text-red-900">
+          The CCA list couldn&rsquo;t be loaded
+        </p>
+        <p className="mt-1 text-sm text-red-700">Reload the page.</p>
+      </div>
+    );
+  }
+
+  const { ccas, enabled } = data;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">Manage CCAs</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Create and rename CCAs, manage their heads, and add or remove members.
+        </p>
+      </header>
+
+      {/* The switch state is shown, not hidden: an admin who finds every button
+          disabled deserves to know why and what to do about it. */}
+      {!enabled && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3">
+          <p className="text-sm font-medium text-amber-900">
+            CCA management is turned off
+          </p>
+          <p className="mt-1 text-sm text-amber-800">
+            You can look, but nothing can be changed yet. To turn it on, set the{" "}
+            <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">
+              cca.management.enabled
+            </code>{" "}
+            system flag to{" "}
+            <code className="rounded bg-amber-100 px-1 py-0.5 text-xs">on</code>.
+          </p>
+        </div>
+      )}
+
+      <CreateCcaForm enabled={enabled} />
+
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+          All CCAs
+          <span className="ml-2 font-normal normal-case tracking-normal text-gray-400">
+            {ccas.length}
+          </span>
+        </h2>
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead className="text-right">Heads</TableHead>
+                <TableHead
+                  className="text-right"
+                  title="Membership records, not distinct people — duplicates are possible and are named in the roster."
+                >
+                  Records
+                </TableHead>
+                <TableHead className="text-right">ID</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {ccas.map((c) => (
+                <TableRow
+                  key={c.ccaID}
+                  onClick={() =>
+                    setSelected(selected === c.ccaID ? null : c.ccaID)
+                  }
+                  className={`cursor-pointer ${
+                    selected === c.ccaID ? "bg-emerald-50" : ""
+                  }`}
+                >
+                  <TableCell className="font-medium text-gray-900">
+                    {c.ccaName}
+                  </TableCell>
+                  <TableCell className="text-gray-600">{c.category}</TableCell>
+                  <TableCell className="text-right text-gray-600">
+                    {c.headCount === 0 ? (
+                      <span
+                        className="text-amber-700"
+                        title="This CCA has no head. Members can still be listed, but nobody can view its roster from /cca."
+                      >
+                        0
+                      </span>
+                    ) : (
+                      c.headCount
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right text-gray-600">
+                    {c.membershipRows}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs text-gray-400">
+                    {c.ccaID}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <p className="mt-2 text-xs text-gray-400">
+          Select a CCA to manage its heads and members.
+        </p>
+      </section>
+
+      {selected !== null && (
+        <ManageCcaDetail
+          key={selected}
+          ccaID={selected}
+          enabled={enabled}
+          cca={ccas.find((c) => c.ccaID === selected)!}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/cca/[ccaID]/page.tsx
+++ b/src/app/cca/[ccaID]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+
+import RosterPanel from "~/app/_components/RosterPanel";
+
+/**
+ * One CCA's roster.
+ *
+ * NO SERVER-SIDE PRE-GUARD, deliberately. cca.getRoster carries the
+ * object-scoped check and is the one policy site; duplicating it here would be
+ * a second place to keep in step for no additional protection, since a client
+ * can call the procedure directly regardless (I-7).
+ *
+ * Next 14.2: `params` is a PLAIN OBJECT, not a Promise. Do not await it.
+ */
+export default function CcaRosterPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  // BOTH checks are required. z.coerce-style parsing accepts "12.0", " 12" and
+  // "+12", and Number("") is 0 — and ccaID 0 is RESERVED (see cascade.ts), so a
+  // permissive parse turns an empty segment into a real-looking lookup.
+  if (!/^\d+$/.test(params.ccaID)) notFound();
+  const ccaID = Number(params.ccaID);
+  if (!Number.isSafeInteger(ccaID) || ccaID <= 0) notFound();
+
+  return <RosterPanel ccaID={ccaID} />;
+}

--- a/src/app/cca/_components/CcaIndex.tsx
+++ b/src/app/cca/_components/CcaIndex.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { Users } from "lucide-react";
+
+import { api } from "~/trpc/react";
+
+/**
+ * The CCAs you head. Only reached when there is NOT exactly one — a single
+ * headship is redirected straight through by the server component above.
+ */
+export default function CcaIndex() {
+  const { data, isPending, error } = api.cca.listMine.useQuery(undefined, {
+    retry: false,
+  });
+
+  if (isPending) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <div className="h-8 w-40 animate-pulse rounded bg-gray-200" />
+        <div className="h-20 animate-pulse rounded-lg bg-gray-200" />
+        <div className="h-20 animate-pulse rounded-lg bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-6">
+        <p className="text-sm font-medium text-red-900">
+          Your CCAs couldn&rsquo;t be loaded
+        </p>
+        <p className="mt-1 text-sm text-red-700">
+          Reload the page. If it keeps happening, contact the JCRC.
+        </p>
+      </div>
+    );
+  }
+
+  const { ccas, canManageAll } = data;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">Your CCAs</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          The CCAs you&rsquo;re listed as a head of.
+        </p>
+      </header>
+
+      {ccas.length === 0 ? (
+        /* CALM, NOT AN ERROR. This is also where CH-1 drift comes to rest: a
+           stale cca_head string with no CcaHead rows lands here, sees an empty
+           list, and is refused every individual CCA. That is the intended
+           failure direction — an empty page, never a leaked roster. */
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-6">
+          <p className="text-sm text-gray-700">
+            You&rsquo;re not currently listed as the head of any CCA.
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            If that&rsquo;s wrong, contact the JCRC and they can add you.
+          </p>
+          {canManageAll && (
+            <p className="mt-3 text-sm text-gray-500">
+              Looking for a different CCA?{" "}
+              <Link
+                href="/admin/ccas"
+                className="font-medium text-emerald-700 underline underline-offset-2"
+              >
+                Browse all CCAs
+              </Link>
+              .
+            </p>
+          )}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {ccas.map((c) => (
+            <li key={c.ccaID}>
+              <Link
+                href={`/cca/${c.ccaID}`}
+                className={`flex items-center justify-between gap-3 rounded-lg border px-4 py-3 transition-colors hover:border-emerald-300 hover:bg-emerald-50 ${
+                  // The only place a bare ccaID reaches the UI — a headship
+                  // pointing at a CCA that no longer exists is real drift and
+                  // is worth seeing rather than hiding.
+                  c.ccaName
+                    ? "border-gray-200 bg-white"
+                    : "border-amber-300 bg-amber-50"
+                }`}
+              >
+                <span className="min-w-0">
+                  <span
+                    className={`block truncate text-sm font-medium ${
+                      c.ccaName ? "text-gray-900" : "text-amber-900"
+                    }`}
+                  >
+                    {c.ccaName ?? `Unknown CCA (#${c.ccaID})`}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500">
+                    {c.category ?? "Uncategorised"}
+                  </span>
+                </span>
+                <span className="flex shrink-0 items-center gap-1.5 text-xs text-gray-500">
+                  <Users className="h-3.5 w-3.5" />
+                  {c.headCount} {c.headCount === 1 ? "head" : "heads"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/cca/layout.tsx
+++ b/src/app/cca/layout.tsx
@@ -1,0 +1,63 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import Header from "~/app/_components/header";
+
+/** Session-dependent. Never static, never ISR — a cached CCA shell would be
+ *  served to whoever asked for it next. */
+export const dynamic = "force-dynamic";
+
+/**
+ * The route guard for the CCA head surface. DEFENCE IN DEPTH, not the security
+ * boundary: a client can call api.cca.getRoster.query() from the console on any
+ * page, so the procedure carries its own object-scoped guard (I-7). What this
+ * buys is that no CCA markup ever streams to someone with no headship at all.
+ *
+ * Structurally a copy of admin/layout.tsx, and DELIBERATELY a copy rather than
+ * a shared helper: each narrow segment recomputes from its own live read. The
+ * duplication is the point — a shared guard is one edit away from being widened
+ * for one caller and silently widened for all of them.
+ *
+ * NOTE what this does NOT establish. `reachCcaDashboard` is true for anyone
+ * holding the cca_head string, which under CH-1 means at least one CcaHead row
+ * — but CH-1 is a code contract MongoDB cannot enforce. So this gate answers
+ * "is this surface for you", never "which CCA". Every ccaID is checked
+ * independently by assertHeadsCca.
+ */
+export default async function CcaLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    // LIVE database read, NOT session.user.roles (I-5). The session copy is
+    // render-only and the JWT lives 30 days; a headship revoked this morning
+    // must close this page now.
+    roles = await getUserRoles(db, session.user.userID);
+  } catch {
+    // Fail CLOSED, and swallow rather than rethrow — a segment's own error.tsx
+    // does NOT catch an error thrown by that segment's layout.tsx, so a rethrow
+    // would blank the whole app shell rather than deny one route.
+    redirect("/");
+  }
+
+  // redirect("/") and not a 403: an unauthorised viewer should not learn that
+  // /cca exists at all.
+  if (!computeCapabilities(roles).reachCcaDashboard) redirect("/");
+
+  return (
+    <div className="mb-14 min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+      <Header currentPage="CCA" />
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/cca/page.tsx
+++ b/src/app/cca/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import CcaIndex from "./_components/CcaIndex";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * A SERVER component, because the single-CCA passthrough is a redirect().
+ * Doing it client-side with router.replace() would stream and paint the index
+ * first, so a head of one CCA would see a pointless one-item list flash past on
+ * every visit.
+ */
+export default async function CcaIndexPage() {
+  const session = await auth();
+  // The layout already established this; repeating it is cheap and keeps this
+  // page correct if it is ever reached another way.
+  if (!session?.user?.userID) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRoles(db, session.user.userID); // I-5 live read
+  } catch {
+    redirect("/");
+  }
+  const capabilities = computeCapabilities(roles);
+
+  const heads = await db.ccaHead.findMany({
+    where: { userID: session.user.userID },
+    select: { ccaID: true },
+  });
+
+  // THE PASSTHROUGH. Note `!capabilities.viewAnyCcaRoster`: an admin or jcrc who
+  // happens to head exactly one CCA must NOT be teleported into it — they have
+  // /admin/ccas for browsing and would otherwise be unable to reach their own
+  // index at all.
+  if (!capabilities.viewAnyCcaRoster && heads.length === 1) {
+    redirect(`/cca/${heads[0]!.ccaID}`);
+  }
+
+  return <CcaIndex />;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,8 @@ import { facilityBookingRouter } from "~/server/api/routers/facilitiesBooking";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { userRouter } from "./routers/user";
 import { adminRouter } from "./routers/admin";
+import { ccaRouter } from "./routers/cca";
+import { ccaAdminRouter } from "./routers/ccaAdmin";
 
 /**
  * This is the primary router for your server.
@@ -14,6 +16,10 @@ export const appRouter = createTRPCRouter({
   bookings: facilityBookingRouter,
   user: userRouter,
   admin: adminRouter,
+  /** Object-scoped CCA reads. Guarded per-ccaID, not per-role — see cca.ts. */
+  cca: ccaRouter,
+  /** Admin-only CCA management, behind the cca.management.enabled switch. */
+  ccaAdmin: ccaAdminRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+
+import { createTRPCRouter, identifiedProcedure } from "~/server/api/trpc";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import { resolveRoster } from "~/server/api/services/ccaRoster";
+
+/**
+ * CCA-head-facing reads. READ-ONLY — every write lives in admin.* or ccaAdmin.*.
+ *
+ * THE ONE RULE IN THIS FILE: every procedure that takes a ccaID FROM THE CLIENT
+ * MUST call assertHeadsCca before touching CCA-scoped data. The procedure
+ * builder does NOT do it for you — identifiedProcedure only narrows identity. A
+ * procedure here that forgets the guard is a full-roster IDOR across all 89
+ * CCAs.
+ *
+ *     grep -n "input.ccaID" src/server/api/routers/cca.ts
+ *     → every hit must sit in a procedure whose body also names assertHeadsCca.
+ *
+ * The gate is on `input.ccaID` SPECIFICALLY, not on the string "ccaID". listMine
+ * touches ccaID a dozen times and needs no guard, because every id it handles
+ * was read back from `ccaHead.findMany({ where: { userID } })` — the caller's
+ * own headships — rather than supplied by the caller. Widening the pattern to
+ * bare "ccaID" would flag that as a violation, and a gate that cries wolf is a
+ * gate people learn to skip.
+ *
+ * Middleware cannot cover this: the ccaID lives in the INPUT, not the context.
+ *
+ * WHY A SEPARATE ROUTER FROM admin.ts. The authorization CLASS differs. Every
+ * procedure in admin.ts is roleManagerProcedure or adminProcedure — a coarse
+ * role gate that fully answers the question. These are object-scoped, where the
+ * builder answers NOTHING and the guard is the entire boundary. Sitting the two
+ * kinds adjacent invites a future procedure that copies its neighbour's builder
+ * and forgets the guard. (admin.ts also imports node:crypto and ~/env for the
+ * bulk plan-token HMAC, which a head-facing route should not pull in.)
+ *
+ * WHY identifiedProcedure. assertHeadsCca needs a non-null canonical userID as a
+ * CcaHead lookup key. trpc.ts warns that adoption of this builder is deliberately
+ * narrow — only procedures that ALREADY refuse an empty identity may take it.
+ * These are new and refuse an empty identity BY CONSTRUCTION: a null userID
+ * matches no CcaHead row, and a null-keyed lookup is the I-8d red line. So this
+ * is not a behaviour change wearing a refactor's clothes.
+ */
+export const ccaRouter = createTRPCRouter({
+  /**
+   * The CCAs this caller heads. Deliberately NOT "all 89 CCAs for a manager" —
+   * this is the head's own surface, and managers have /admin/ccas. A manager
+   * with no headships gets an empty list and `canManageAll: true`, which the
+   * page turns into a pointer rather than a dead end.
+   */
+  listMine: identifiedProcedure.query(async ({ ctx }) => {
+    const userID = ctx.session.user.userID;
+    // I-5: LIVE read. session.user.roles is render-only and up to 30 days stale.
+    const roles = await getUserRoles(ctx.db, userID);
+    const capabilities = computeCapabilities(roles);
+
+    if (!capabilities.reachCcaDashboard) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "CAPABILITY_REQUIRED:reachCcaDashboard",
+      });
+    }
+
+    const mine = await ctx.db.ccaHead.findMany({
+      where: { userID },
+      select: { ccaID: true, grantedAt: true },
+      orderBy: { ccaID: "asc" },
+    });
+
+    const ccaIDs = mine.map((m) => m.ccaID);
+    if (ccaIDs.length === 0) {
+      return { ccas: [], canManageAll: capabilities.viewAnyCcaRoster };
+    }
+
+    const [named, allHeads] = await Promise.all([
+      ctx.db.cCA.findMany({
+        where: { ccaID: { in: ccaIDs } },
+        select: { ccaID: true, ccaName: true, category: true },
+      }),
+      // Indexed on ccaID. Counting co-heads, not resolving them — no hydration.
+      ctx.db.ccaHead.findMany({
+        where: { ccaID: { in: ccaIDs } },
+        select: { ccaID: true },
+      }),
+    ]);
+
+    const byID = new Map(named.map((c) => [c.ccaID, c]));
+    const headCounts = new Map<number, number>();
+    for (const h of allHeads) {
+      headCounts.set(h.ccaID, (headCounts.get(h.ccaID) ?? 0) + 1);
+    }
+
+    const ccas = mine.map((m) => {
+      const row = byID.get(m.ccaID);
+      return {
+        ccaID: m.ccaID,
+        // null when the ccaID has no CCA row — the CcaBadges amber idiom. This
+        // is the only place a bare ccaID reaches the UI.
+        ccaName: row?.ccaName ?? null,
+        category: row?.category ?? null,
+        headCount: headCounts.get(m.ccaID) ?? 1,
+        grantedAt: m.grantedAt,
+      };
+    });
+
+    ccas.sort(
+      (a, b) =>
+        (a.category ?? "￿").localeCompare(b.category ?? "￿") ||
+        (a.ccaName ?? "￿").localeCompare(b.ccaName ?? "￿"),
+    );
+
+    return { ccas, canManageAll: capabilities.viewAnyCcaRoster };
+  }),
+
+  /**
+   * The roster: heads and members of one CCA.
+   *
+   * THE security boundary for both /cca/[ccaID] and /admin/ccas. Neither page
+   * pre-guards — a client can call this from the console on any page, so the
+   * layouts are defence in depth only (I-7).
+   */
+  getRoster: identifiedProcedure
+    // .positive(), not .nonnegative(): ccaID 0 is RESERVED (see cascade.ts) and
+    // is never a real CCA, so it is refused at the boundary rather than
+    // resolving to an empty roster that looks like a legitimate answer.
+    .input(z.object({ ccaID: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+      const roster = await resolveRoster(ctx.db, input.ccaID);
+      return { ...roster, via: scope.via };
+    }),
+});

--- a/src/server/api/routers/ccaAdmin.ts
+++ b/src/server/api/routers/ccaAdmin.ts
@@ -1,0 +1,410 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+
+import { createTRPCRouter, adminProcedure } from "~/server/api/trpc";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import {
+  assertCcaManagementEnabled,
+  isCcaManagementEnabled,
+} from "~/server/api/services/ccaScope";
+import { writeAudit } from "~/server/api/routers/admin";
+import { canonicalUserID, isCanonicalResidentID } from "~/lib/identity";
+
+/**
+ * CCA MANAGEMENT — admin only, and additionally behind the
+ * `cca.management.enabled` kill switch.
+ *
+ * THERE IS NO DELETE PROCEDURE HERE, DELIBERATELY. Nothing in this application
+ * deletes a CCA. deleteCcaCascade (services/cascade.ts) reaches Bookings by
+ * ccaID and is guarded against the reserved ccaID 0 for that reason; it remains
+ * script-only. Do not add a delete endpoint without reading that file first.
+ *
+ * Head management is NOT duplicated here either — admin.grantCcaHead /
+ * revokeCcaHead / transferCcaHead already exist, are audited, and maintain
+ * invariant CH-1 in one transaction. The management UI calls across to them.
+ * Reimplementing them here would create a second writer of the `cca_head`
+ * string, which is precisely what I-14 forbids.
+ *
+ * Separate from admin.ts because that file is past 1600 lines; the gate class
+ * (adminProcedure) is the same, so these could have lived there.
+ */
+
+const KILL_SWITCH_NOTE =
+  "every mutation asserts the kill switch BEFORE doing anything else — the " +
+  "page-level check is cosmetic, this is the boundary";
+void KILL_SWITCH_NOTE;
+
+/**
+ * A canonical userID as produced by canonicalUserID(email).
+ *
+ * DO NOT constrain this to /^E\d{7}$/. Non-E-format @u.nus.edu localparts are
+ * REAL in this database — `g.s_samuel@u.nus.edu` canonicalises to "G.S_SAMUEL".
+ * E-format is a validation rule for pasted grant targets, never an eligibility
+ * gate; reintroducing the regex here re-opens lockout mode L-27.
+ */
+const canonicalUserIDSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .refine(isCanonicalResidentID, "not a canonical @u.nus.edu userID");
+
+/** ccaID 0 is RESERVED — see cascade.ts. It is never a manageable CCA. */
+const ccaIDSchema = z.number().int().positive();
+
+function requireManageCcas(roles: readonly string[]): void {
+  if (!computeCapabilities(roles).manageCcas) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "CAPABILITY_REQUIRED:manageCcas",
+    });
+  }
+}
+
+/**
+ * Every membership key that resolves to one person.
+ *
+ * REMOVAL MUST USE ALL OF THEM. UserCCA.userID is mixed-format: a person can
+ * hold a legacy A-format row AND a canonical row for the same CCA. Deleting
+ * only the canonical one "removes" them while their legacy row keeps them on
+ * the roster — a bug that looks like the delete silently failed.
+ */
+function membershipKeysFor(u: {
+  email: string;
+  userID: string | null;
+}): string[] {
+  const keys = new Set<string>();
+  const cid = canonicalUserID(u.email);
+  if (cid) keys.add(cid);
+  if (u.userID && u.userID.length > 0) keys.add(u.userID);
+  return [...keys];
+}
+
+export const ccaAdminRouter = createTRPCRouter({
+  /** Every CCA, with head and membership-row counts, for the management table. */
+  listAll: adminProcedure.query(async ({ ctx }) => {
+    const roles = await getUserRoles(ctx.db, ctx.session.user.userID); // I-5
+    requireManageCcas(roles);
+
+    // Read, so it is NOT gated on the kill switch — but the switch state ships
+    // with the payload so the page can disable its write affordances without a
+    // second round trip. The switch is still asserted inside every mutation:
+    // a disabled control is cosmetic, the procedure is the boundary.
+    const enabled = await isCcaManagementEnabled(ctx.db);
+
+    const [ccas, heads, memberships] = await Promise.all([
+      ctx.db.cCA.findMany({
+        select: { ccaID: true, ccaName: true, category: true },
+        orderBy: { ccaName: "asc" },
+      }),
+      ctx.db.ccaHead.findMany({ select: { ccaID: true } }),
+      // Whole-collection read. UserCCA has no ccaID index, so a per-CCA query
+      // per row would be 89 collection scans; one scan grouped in memory is
+      // strictly cheaper until the index lands.
+      ctx.db.userCCA.findMany({ select: { ccaID: true } }),
+    ]);
+
+    const headCounts = new Map<number, number>();
+    for (const h of heads) {
+      headCounts.set(h.ccaID, (headCounts.get(h.ccaID) ?? 0) + 1);
+    }
+    const memberCounts = new Map<number, number>();
+    for (const m of memberships) {
+      memberCounts.set(m.ccaID, (memberCounts.get(m.ccaID) ?? 0) + 1);
+    }
+
+    return {
+      enabled,
+      ccas: ccas.map((c) => ({
+        ...c,
+        headCount: headCounts.get(c.ccaID) ?? 0,
+        // Row count, NOT distinct people — duplicates are possible and the
+        // roster is where they get named. Labelled as such in the UI.
+        membershipRows: memberCounts.get(c.ccaID) ?? 0,
+      })),
+    };
+  }),
+
+  /**
+   * Create a CCA.
+   *
+   * ccaID is Int @unique with NO auto-increment, so it must be allocated:
+   * max + 1, insert, and let the unique index turn a concurrent allocation into
+   * a loud P2002 rather than a silent duplicate. Retried once.
+   *
+   * A deleted ccaID is never reused — bookings and posts may still reference
+   * it. Since nothing deletes CCAs, max+1 is monotonic in practice.
+   *
+   * NOTE: the CCA collection carries a DB-level $jsonSchema validator. If this
+   * insert starts failing with a Mongo write error rather than a Prisma
+   * validation error, dump the validator and compare field-for-field — Prisma
+   * surfaces that class of failure opaquely.
+   */
+  create: adminProcedure
+    .input(
+      z.object({
+        ccaName: z.string().trim().min(1).max(120),
+        category: z.string().trim().min(1).max(120),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertCcaManagementEnabled(ctx.db);
+      const actorUserID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireManageCcas(roles);
+
+      const clash = await ctx.db.cCA.findFirst({
+        where: { ccaName: { equals: input.ccaName, mode: "insensitive" } },
+        select: { ccaID: true },
+      });
+      if (clash) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "CCA_NAME_ALREADY_EXISTS",
+        });
+      }
+
+      let created: { ccaID: number; ccaName: string } | null = null;
+      for (let attempt = 0; attempt < 2 && !created; attempt++) {
+        const top = await ctx.db.cCA.findFirst({
+          orderBy: { ccaID: "desc" },
+          select: { ccaID: true },
+        });
+        const nextID = Math.max(1, (top?.ccaID ?? 0) + 1);
+        try {
+          created = await ctx.db.cCA.create({
+            data: {
+              ccaID: nextID,
+              ccaName: input.ccaName,
+              category: input.category,
+            },
+            select: { ccaID: true, ccaName: true },
+          });
+        } catch (e) {
+          // P2002 = unique violation on ccaID: someone allocated the same id
+          // between our read and our write. Recompute and retry once.
+          const code = (e as { code?: string })?.code;
+          if (code !== "P2002" || attempt === 1) throw e;
+        }
+      }
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles: roles,
+        targetCcaID: created!.ccaID,
+        action: "cca.create",
+        reason: `${created!.ccaName} (${input.category})`,
+      });
+      return created!;
+    }),
+
+  /**
+   * Rename / recategorise a CCA.
+   *
+   * AN UPDATE IN PLACE, NEVER A DELETE-AND-RECREATE. ccaID is the join key for
+   * Bookings, UserCCA and CcaHead; recreating the row under a new id silently
+   * orphans every membership in the CCA. scripts/remediation/reconcile-ccas.mjs
+   * renames for exactly this reason — keep the two consistent.
+   */
+  rename: adminProcedure
+    .input(
+      z.object({
+        ccaID: ccaIDSchema,
+        ccaName: z.string().trim().min(1).max(120),
+        category: z.string().trim().min(1).max(120),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertCcaManagementEnabled(ctx.db);
+      const actorUserID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireManageCcas(roles);
+
+      const before = await ctx.db.cCA.findUnique({
+        where: { ccaID: input.ccaID },
+        select: { ccaName: true, category: true },
+      });
+      if (!before) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
+      }
+
+      const updated = await ctx.db.cCA.update({
+        where: { ccaID: input.ccaID },
+        data: { ccaName: input.ccaName, category: input.category },
+        select: { ccaID: true, ccaName: true, category: true },
+      });
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        action: "cca.rename",
+        reason: `"${before.ccaName}" (${before.category}) → "${updated.ccaName}" (${updated.category})`,
+      });
+      return updated;
+    }),
+
+  /**
+   * Add a member.
+   *
+   * NEW ROWS ARE WRITTEN CANONICAL. Every new-collection write in this repo
+   * keys canonical (CcaHead, UserRole, UserMatric — invariant I-1), it is what
+   * account merges produce, and getMyCCAs reads both key formats so the member
+   * still sees the CCA. Writing A-format would deepen the legacy problem.
+   *
+   * Consequence, which is fine: a person may end up with a legacy A-format row
+   * AND this canonical one. That is the same human under two keys, and the
+   * roster's User.id dedupe collapses them into one entry.
+   */
+  addMember: adminProcedure
+    .input(
+      z.object({
+        ccaID: ccaIDSchema,
+        userID: canonicalUserIDSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertCcaManagementEnabled(ctx.db);
+      const actorUserID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireManageCcas(roles);
+
+      const cca = await ctx.db.cCA.findUnique({
+        where: { ccaID: input.ccaID },
+        select: { ccaID: true },
+      });
+      if (!cca) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
+      }
+
+      // Check BOTH key formats before inserting, so we don't add a canonical
+      // row next to an existing legacy one for the same person. UserCCA has no
+      // compound unique, so this check-then-insert can still race — the roster
+      // surfaces any duplicate that slips through rather than hiding it.
+      const target = await ctx.db.user.findFirst({
+        where: {
+          OR: [
+            { email: { equals: `${input.userID.toLowerCase()}@u.nus.edu`, mode: "insensitive" } },
+            { userID: input.userID },
+          ],
+        },
+        select: { email: true, userID: true },
+      });
+      const keys = target
+        ? membershipKeysFor(target)
+        : [input.userID as string];
+
+      const existing = await ctx.db.userCCA.findFirst({
+        where: { ccaID: input.ccaID, userID: { in: keys } },
+        select: { id: true },
+      });
+      if (existing) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "ALREADY_A_MEMBER",
+        });
+      }
+
+      await ctx.db.userCCA.create({
+        data: { ccaID: input.ccaID, userID: input.userID },
+      });
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        targetUserID: input.userID,
+        action: "ccaMember.add",
+      });
+      return { ccaID: input.ccaID, userID: input.userID };
+    }),
+
+  /**
+   * Remove a member.
+   *
+   * MEMBERSHIP LIVES IN THREE PLACES AND THIS MUST CLEAN ALL OF THEM:
+   *   1. UserCCA rows under the CANONICAL key
+   *   2. UserCCA rows under the LEGACY A-format key (same person, other key)
+   *   3. the undeclared User.userCCA Int[] — a roster SOURCE, so a member left
+   *      in the array simply reappears after a "successful" removal
+   *
+   * Adding writes only (1). The asymmetry is deliberate: do not grow the legacy
+   * embedded array, but do clean it.
+   *
+   * The target is identified by SERVER-DERIVED keys, never client-supplied
+   * ones: the caller names a User document (or a raw unresolved key straight
+   * from the roster), and the key set is recomputed here.
+   */
+  removeMember: adminProcedure
+    .input(
+      z.object({
+        ccaID: ccaIDSchema,
+        target: z.discriminatedUnion("kind", [
+          // A resolved roster entry: the User.id the roster deduped on.
+          z.object({ kind: z.literal("user"), userObjectId: z.string().min(1) }),
+          // An UNRESOLVED roster entry — a membership key matching no User row.
+          // Removable so the amber rows can actually be cleaned up.
+          z.object({ kind: z.literal("key"), key: z.string().trim().min(1) }),
+        ]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertCcaManagementEnabled(ctx.db);
+      const actorUserID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireManageCcas(roles);
+
+      let keys: string[];
+      let userObjectId: string | null = null;
+      let label: string;
+
+      if (input.target.kind === "user") {
+        const u = await ctx.db.user.findUnique({
+          where: { id: input.target.userObjectId },
+          select: { id: true, email: true, userID: true },
+        });
+        if (!u) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_USER" });
+        }
+        keys = membershipKeysFor(u);
+        userObjectId = u.id;
+        label = u.email;
+      } else {
+        keys = [input.target.key];
+        label = input.target.key;
+        // An unresolved key matches no User row by definition, so there is no
+        // embedded array to clean — (3) does not apply on this branch.
+      }
+
+      const removed = await ctx.db.userCCA.deleteMany({
+        where: { ccaID: input.ccaID, userID: { in: keys } },
+      });
+
+      // (3) the embedded array. Not declared in `model User`, so Prisma cannot
+      // express this — it has to be a raw command.
+      if (userObjectId) {
+        await ctx.db.$runCommandRaw({
+          update: "User",
+          updates: [
+            {
+              q: { _id: { $oid: userObjectId } },
+              u: { $pull: { userCCA: input.ccaID } },
+            },
+          ],
+        });
+      }
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        targetUserID: keys[0],
+        action: "ccaMember.remove",
+        reason: `${label} — ${removed.count} membership row(s)${
+          userObjectId ? " + embedded array" : ""
+        }`,
+      });
+
+      return { ccaID: input.ccaID, removedRows: removed.count };
+    }),
+});

--- a/src/server/api/services/cascade.ts
+++ b/src/server/api/services/cascade.ts
@@ -24,11 +24,32 @@ export async function deleteFacilityCascade(
   });
 }
 
+/**
+ * NO UI REACHES THIS. CCA deletion is deliberately not exposed by any surface —
+ * not /cca, not /admin/ccas, not /admin/manage-ccas. It remains here for scripts
+ * only, and the two guards below exist because "there is no button" is not a
+ * safety property: a script, a REPL, or a future contributor can still call it.
+ *
+ * GUARD 1 — ccaID 0 IS RESERVED (07-cca-future.md §5).
+ * BookingModal.tsx hardcodes `ccaID: 0` on every booking the current UI creates.
+ * The bookings.deleteMany below matches on ccaID, so deleting a CCA row that
+ * happens to hold ccaID 0 would delete EVERY BOOKING IN THE SYSTEM. There is no
+ * reserved-value constraint on the column, so this is enforced here.
+ *
+ * GUARD 2 — CcaHead must be cleaned up (07-cca-future.md §5.1).
+ * Orphaned CcaHead rows keep an ex-head's `cca_head` string alive permanently:
+ * revokeCcaHead drops the string only when `remaining === 0`, and that count
+ * never reaches zero because the row survives — while the CCA no longer exists
+ * to revoke against. That is CH-1 drift the string↔row detector cannot see,
+ * because it checks string↔row, not row↔CCA.
+ */
 export async function deleteCcaCascade(db: PrismaClient, ccaID: number) {
+  if (ccaID === 0) throw new Error("RESERVED_CCAID");
   return db.$transaction(async (tx) => {
     await tx.posts.deleteMany({ where: { ccaID } });
     await tx.userCCA.deleteMany({ where: { ccaID } });
     await tx.bookings.deleteMany({ where: { ccaID } });
+    await tx.ccaHead.deleteMany({ where: { ccaID } });
     return tx.cCA.delete({ where: { ccaID } });
   });
 }

--- a/src/server/api/services/ccaRoster.ts
+++ b/src/server/api/services/ccaRoster.ts
@@ -1,0 +1,377 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { canonicalUserID } from "~/lib/identity";
+
+/**
+ * CCA ROSTER RESOLUTION — the inversion of getMyCCAs.
+ *
+ * getMyCCAs (routers/user.ts) reads the union of three membership sources keyed
+ * off the CALLER'S OWN session. This does the reverse: given a ccaID, produce
+ * everyone in it. The two are NOT symmetric.
+ *
+ *   CcaHead      indexed on ccaID, canonical userIDs only. Clean.
+ *   UserCCA      NO index on ccaID (collection scan). userID is MIXED — mostly
+ *                A-format matric, canonical E-format only on rows the account
+ *                merge reassigned. NO compound unique, so duplicate rows exist.
+ *   User.userCCA an Int[] that EXISTS in the database but is NOT declared in
+ *                `model User`, so it is reachable only through findRaw.
+ *
+ * And there is NO reverse query from a canonical userID to a User row — see
+ * admin.listUsers, which guesses the email. So resolution can fail, and it can
+ * be AMBIGUOUS (User.userID has no unique index; dedupe-users.mjs exists
+ * because duplicate accounts were real).
+ *
+ * NEITHER FAILURE IS FILTERED AWAY. 07-cca-future.md §3 names the client-side
+ * .filter() as the anti-pattern that hides the real data problem. Unresolved
+ * and ambiguous rows are returned as first-class entries and rendered amber.
+ *
+ * AND AMBIGUITY IS NEVER RESOLVED BY PICKING. Attributing one person's
+ * membership to another is a failure indistinguishable from success.
+ */
+
+export type RosterSource = "ccaHead" | "userCCA" | "embedded";
+
+export type RosterResolved = {
+  kind: "resolved";
+  /** THE dedupe key. Collapses a person's A-format and canonical keys. */
+  userId: string;
+  email: string;
+  displayName: string | null;
+  storedUserID: string | null;
+  isHead: boolean;
+  grantedAt: Date | null;
+  sources: RosterSource[];
+  /** Every membership key that resolved to this user. May legitimately be 2. */
+  membershipKeys: string[];
+  /** UserCCA rows for this CCA naming this person. >1 means duplicate rows. */
+  userCcaRowCount: number;
+};
+
+export type RosterUnresolved = {
+  kind: "unresolved";
+  /** THE dedupe key for this bucket — a raw membership key string. */
+  key: string;
+  isHead: boolean;
+  grantedAt: Date | null;
+  sources: RosterSource[];
+  userCcaRowCount: number;
+  reason: "NO_USER_ROW" | "AMBIGUOUS_KEY";
+  /** For AMBIGUOUS_KEY: the User.ids that claimed it, so it is investigable. */
+  candidateUserIds: string[];
+};
+
+export type RosterEntry = RosterResolved | RosterUnresolved;
+
+export type RosterDrift = {
+  unresolvedCount: number;
+  ambiguousCount: number;
+  duplicateUserCcaRows: number;
+  headsUnresolved: number;
+  ccaMissing: boolean;
+};
+
+export type Roster = {
+  cca: { ccaID: number; ccaName: string | null; category: string | null };
+  heads: RosterEntry[];
+  members: RosterEntry[];
+  counts: { heads: number; members: number; total: number };
+  drift: RosterDrift;
+};
+
+/**
+ * The shape user.findRaw yields under our projection. Untyped BSON: every field
+ * is `unknown` and is narrowed at the use site, never trusted. Same defence
+ * getMyCCAs applies.
+ */
+type RawUserDoc = {
+  _id?: { $oid?: string } | string;
+  email?: unknown;
+  displayName?: unknown;
+  userID?: unknown;
+};
+
+type Hydrated = {
+  id: string;
+  email: string;
+  displayName: string | null;
+  userID: string | null;
+};
+
+const str = (v: unknown): string | null =>
+  typeof v === "string" && v.length > 0 ? v : null;
+
+/**
+ * findRaw returns EXTENDED JSON: _id is { $oid: "..." }, not the plain string a
+ * typed read gives. Forgetting this unwrap is silent and nasty — the User.id
+ * dedupe would never collide, so every embedded-source member would double-list
+ * alongside their UserCCA row, looking like a data problem rather than a bug.
+ */
+const oid = (v: RawUserDoc["_id"]): string | null => {
+  if (typeof v === "string") return v;
+  if (v && typeof v === "object" && typeof v.$oid === "string") return v.$oid;
+  return null;
+};
+
+export async function resolveRoster(
+  db: PrismaClient,
+  ccaID: number,
+): Promise<Roster> {
+  /* ---- the three inversions, plus the CCA record itself ---- */
+
+  const [ccaRow, headRows, ccaRows, embeddedRaw] = await Promise.all([
+    db.cCA.findUnique({
+      where: { ccaID },
+      select: { ccaID: true, ccaName: true, category: true },
+    }),
+
+    // Source C — CcaHead. Indexed. Canonical keys only (CH-1).
+    db.ccaHead.findMany({
+      where: { ccaID },
+      select: { userID: true, grantedAt: true },
+      orderBy: { userID: "asc" },
+    }),
+
+    // Source B — UserCCA. COLLECTION SCAN today (no @@index([ccaID])). `id` is
+    // selected so a duplicate row is COUNTABLE rather than invisible.
+    db.userCCA.findMany({
+      where: { ccaID },
+      select: { id: true, userID: true },
+    }),
+
+    // Source A — the embedded User.userCCA Int[]. Mongo matches a scalar
+    // element-wise against an array field, so { userCCA: ccaID } matches any
+    // document whose array CONTAINS ccaID. (verify-cca-roster.mjs check [1]
+    // cross-checks this against $elemMatch and fails the build if it diverges.)
+    //
+    // The projection is an ALLOWLIST, so this path is STRUCTURALLY incapable of
+    // returning passwordHash — the same property the typed `select` buys
+    // elsewhere, obtained the same way.
+    db.user.findRaw({
+      filter: { userCCA: ccaID },
+      options: {
+        projection: { _id: 1, email: 1, displayName: 1, userID: 1 },
+      },
+    }) as unknown as Promise<RawUserDoc[]>,
+  ]);
+
+  /* ---- hydration: membership key -> User row ---- */
+
+  const keys = [
+    ...new Set([
+      ...headRows.map((r) => r.userID),
+      ...ccaRows.map((r) => r.userID),
+    ]),
+  ].filter((k): k is string => typeof k === "string" && k.length > 0);
+
+  // BOTH lookups run over the FULL key set rather than partitioning by format
+  // first. Partitioning looks tidier and is wrong: UserCCA.userID is mixed AND
+  // User.userID holds an E-format value on merge-reassigned rows, so either
+  // format can land on either side.
+  const guessedEmails = keys.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+
+  const [byEmailRows, byStoredRows] = await Promise.all([
+    keys.length === 0
+      ? Promise.resolve([])
+      : db.user.findMany({
+          where: { email: { in: guessedEmails, mode: "insensitive" } },
+          // NEVER a bare findMany: passwordHash must not reach the client, and
+          // passwordHash-less Google-adapter rows throw on a full read (I-2).
+          select: { id: true, email: true, displayName: true, userID: true },
+        }),
+    keys.length === 0
+      ? Promise.resolve([])
+      : db.user.findMany({
+          where: { userID: { in: keys } },
+          select: { id: true, email: true, displayName: true, userID: true },
+        }),
+  ]);
+
+  // key -> the set of User rows claiming it, keyed by User.id so one row
+  // claiming a key by BOTH paths counts once. A set of size > 1 is AMBIGUOUS
+  // and is surfaced as such rather than resolved.
+  const claims = new Map<string, Map<string, Hydrated>>();
+  const claim = (key: string, u: Hydrated) => {
+    let s = claims.get(key);
+    if (!s) claims.set(key, (s = new Map()));
+    s.set(u.id, u);
+  };
+
+  for (const u of byEmailRows) {
+    // C9: canonicalize and DROP nulls rather than storing under a "" sentinel.
+    // Without this a non-NUS row enters at key "" and matches a ""-keyed
+    // membership row, attributing a stranger to it. listUsers has the same
+    // guard for the same reason.
+    const cid = canonicalUserID(u.email);
+    if (cid !== null) {
+      claim(cid, {
+        id: u.id,
+        email: u.email,
+        displayName: u.displayName,
+        userID: u.userID,
+      });
+    }
+  }
+  for (const u of byStoredRows) {
+    const sid = str(u.userID);
+    if (sid !== null) {
+      claim(sid, {
+        id: u.id,
+        email: u.email,
+        displayName: u.displayName,
+        userID: u.userID,
+      });
+    }
+  }
+
+  /* ---- the merge ---- */
+
+  const resolved = new Map<string, RosterResolved>();
+  const unresolved = new Map<string, RosterUnresolved>();
+
+  const touchResolved = (u: Hydrated, source: RosterSource) => {
+    let e = resolved.get(u.id);
+    if (!e) {
+      e = {
+        kind: "resolved",
+        userId: u.id,
+        email: u.email,
+        displayName: u.displayName,
+        storedUserID: u.userID,
+        isHead: false,
+        grantedAt: null,
+        sources: [],
+        membershipKeys: [],
+        userCcaRowCount: 0,
+      };
+      resolved.set(u.id, e);
+    }
+    if (!e.sources.includes(source)) e.sources.push(source);
+    return e;
+  };
+
+  const touchUnresolved = (key: string, source: RosterSource) => {
+    let e = unresolved.get(key);
+    if (!e) {
+      e = {
+        kind: "unresolved",
+        key,
+        isHead: false,
+        grantedAt: null,
+        sources: [],
+        userCcaRowCount: 0,
+        reason: "NO_USER_ROW",
+        candidateUserIds: [],
+      };
+      unresolved.set(key, e);
+    }
+    if (!e.sources.includes(source)) e.sources.push(source);
+    return e;
+  };
+
+  // Source A FIRST, because it arrives already resolved — it CAME from the User
+  // collection, so no hydration can fail for it.
+  for (const d of embeddedRaw) {
+    const id = oid(d._id);
+    const email = str(d.email);
+    if (!id || !email) continue; // BSON defence, as getMyCCAs does
+    touchResolved(
+      { id, email, displayName: str(d.displayName), userID: str(d.userID) },
+      "embedded",
+    );
+  }
+
+  /** Route a membership key to whichever bucket its resolution lands in. */
+  const route = (
+    key: string,
+    source: RosterSource,
+    rowCount: number,
+    grantedAt: Date | null,
+  ) => {
+    const cands = claims.get(key);
+
+    if (!cands || cands.size === 0) {
+      const e = touchUnresolved(key, source);
+      e.reason = "NO_USER_ROW";
+      e.userCcaRowCount += rowCount;
+      if (grantedAt) {
+        e.isHead = true;
+        e.grantedAt = grantedAt;
+      }
+      return;
+    }
+
+    if (cands.size > 1) {
+      const e = touchUnresolved(key, source);
+      e.reason = "AMBIGUOUS_KEY";
+      e.candidateUserIds = [...cands.keys()];
+      e.userCcaRowCount += rowCount;
+      if (grantedAt) {
+        e.isHead = true;
+        e.grantedAt = grantedAt;
+      }
+      return;
+    }
+
+    const u = [...cands.values()][0]!;
+    const e = touchResolved(u, source);
+    if (!e.membershipKeys.includes(key)) e.membershipKeys.push(key);
+    e.userCcaRowCount += rowCount;
+    if (grantedAt) {
+      e.isHead = true;
+      e.grantedAt = grantedAt;
+    }
+  };
+
+  // Source B — count duplicates PER KEY before resolution, so a duplicate is
+  // reported as one person with two records rather than two people.
+  const ccaKeyCounts = new Map<string, number>();
+  for (const r of ccaRows) {
+    ccaKeyCounts.set(r.userID, (ccaKeyCounts.get(r.userID) ?? 0) + 1);
+  }
+  for (const [key, n] of ccaKeyCounts) route(key, "userCCA", n, null);
+
+  // Source C — heads. Marks isHead on whichever bucket it lands in.
+  for (const h of headRows) route(h.userID, "ccaHead", 0, h.grantedAt);
+
+  /* ---- output ---- */
+
+  const label = (e: RosterEntry) =>
+    e.kind === "resolved" ? (e.displayName ?? e.email) : e.key;
+
+  // Sorted SERVER-side: the union's insertion order is not stable between
+  // renders. Unresolved last, so the amber block reads as a footer rather than
+  // interleaving with real people.
+  const order = (a: RosterEntry, b: RosterEntry) => {
+    if (a.kind !== b.kind) return a.kind === "resolved" ? -1 : 1;
+    return label(a).localeCompare(label(b));
+  };
+
+  const all = [...resolved.values(), ...unresolved.values()];
+  const heads = all.filter((e) => e.isHead).sort(order);
+  const members = all.filter((e) => !e.isHead).sort(order);
+
+  const unresolvedEntries = [...unresolved.values()];
+
+  return {
+    cca: {
+      ccaID,
+      ccaName: ccaRow?.ccaName ?? null,
+      category: ccaRow?.category ?? null,
+    },
+    heads,
+    members,
+    counts: { heads: heads.length, members: members.length, total: all.length },
+    drift: {
+      unresolvedCount: unresolvedEntries.length,
+      ambiguousCount: unresolvedEntries.filter(
+        (e) => e.reason === "AMBIGUOUS_KEY",
+      ).length,
+      duplicateUserCcaRows: [...ccaKeyCounts.values()].reduce(
+        (n, c) => n + Math.max(0, c - 1),
+        0,
+      ),
+      headsUnresolved: unresolvedEntries.filter((e) => e.isHead).length,
+      ccaMissing: ccaRow == null,
+    },
+  };
+}

--- a/src/server/api/services/ccaScope.ts
+++ b/src/server/api/services/ccaScope.ts
@@ -1,0 +1,134 @@
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+import { computeCapabilities } from "./roles";
+
+/* -------------------------------------------------------------------------- */
+/* The object-scoped guard                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type CcaScope = {
+  ccaID: number;
+  /** How the caller got in. Recorded so the UI can say "viewing as JCRC". */
+  via: "headship" | "manageCcaHeads";
+};
+
+export type CcaActor = {
+  userID: string;
+  roles: readonly string[];
+};
+
+/**
+ * THE object-scoped authorization check — this codebase's first
+ * (07-cca-future.md §6.6 names it as the seam that makes self-serve handover
+ * cheap later).
+ *
+ * It answers "may THIS actor act on THIS ccaID", which computeCapabilities
+ * structurally CANNOT: capabilities are computed from roles alone, and a role
+ * carries no object.
+ *
+ * IT READS CcaHead DIRECTLY AND MUST NEVER CONSULT roles.includes("cca_head").
+ * That string is scope-FREE by construction — 07 §1.1 deliberately kept scope
+ * out of UserRole.roles — so it answers "heads something", never "heads this".
+ * Under invariant CH-1 the two agree; CH-1 is a code contract MongoDB cannot
+ * enforce, and not depending on it is the entire point of this function.
+ *
+ * `actor.roles` MUST be a live getUserRoles() read (I-5), never
+ * session.user.roles. The session copy is render-only and can be up to 30 days
+ * stale, which on this path would mean a demoted user still reading rosters.
+ *
+ * ORDER: the capability is checked first because it is in-memory and saves the
+ * query for admin/jcrc. `via` distinguishes an admin who reached a CCA by
+ * override from a genuine head — the fact a future audit row wants.
+ */
+export async function assertHeadsCca(
+  db: PrismaClient,
+  actor: CcaActor,
+  ccaID: number,
+): Promise<CcaScope> {
+  if (computeCapabilities(actor.roles).manageCcaHeads) {
+    return { ccaID, via: "manageCcaHeads" };
+  }
+
+  const row = await db.ccaHead.findUnique({
+    where: { userID_ccaID: { userID: actor.userID, ccaID } },
+    select: { id: true },
+  });
+  if (row) return { ccaID, via: "headship" };
+
+  // Same message grantCcaHead's H4 guard already uses, and the same shape as
+  // requireCapability's CAPABILITY_REQUIRED:<key>. NOT_FOUND would be better
+  // non-disclosure but would lie about a CCA that exists, and a ccaID is not a
+  // secret — it is public in the booking UI.
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message: "NOT_A_HEAD_OF_THIS_CCA",
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* The CCA-management kill switch                                              */
+/* -------------------------------------------------------------------------- */
+
+const MGMT_FLAG_KEY = "cca.management.enabled";
+const FLAG_TTL_MS = 15_000;
+
+let mgmtFlagCache: { at: number; on: boolean } | null = null;
+
+/**
+ * I-11 applied to /admin/manage-ccas, with ONE DELIBERATE DIVERGENCE from the
+ * three switches in access.ts.
+ *
+ * Those switches gate whether NEW enforcement applies to an EXISTING path, so
+ * they fail OPEN — an unreachable flag means "behave as the app did yesterday",
+ * which for them is no gate. That is right for enforcement and WRONG here.
+ *
+ * This switch gates a NEW WRITE SURFACE that creates and renames CCAs and edits
+ * membership. "Behave as yesterday" for a surface that did not exist yesterday
+ * means DISABLED. So an unreachable flag returns false, and the absence of the
+ * row returns false: the surface is inert until someone deliberately writes
+ * `cca.management.enabled = "on"`.
+ *
+ * Not in access.ts because that module's resetEnforcementModeCache() is scoped
+ * to the three RBAC enforcement switches, and this is neither an enforcement
+ * mode nor part of that rollout.
+ */
+export async function isCcaManagementEnabled(
+  db: PrismaClient,
+): Promise<boolean> {
+  if (mgmtFlagCache && Date.now() - mgmtFlagCache.at < FLAG_TTL_MS) {
+    return mgmtFlagCache.on;
+  }
+  try {
+    const row = await db.systemFlag.findUnique({
+      where: { key: MGMT_FLAG_KEY },
+    });
+    const on = row?.value === "on";
+    mgmtFlagCache = { at: Date.now(), on };
+    return on;
+  } catch {
+    // Fail CLOSED, and deliberately NOT cached — the next request retries
+    // rather than pinning "disabled" for 15s on a transient Atlas hiccup.
+    return false;
+  }
+}
+
+/** Test/ops seam: drop the per-lambda cache so the next read hits the row. */
+export function resetCcaManagementCache(): void {
+  mgmtFlagCache = null;
+}
+
+/**
+ * Assert the switch is on. Called at the top of EVERY ccaAdmin mutation — the
+ * page-level check is cosmetic, this one is the boundary.
+ */
+export async function assertCcaManagementEnabled(
+  db: PrismaClient,
+): Promise<void> {
+  if (!(await isCcaManagementEnabled(db))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "CCA_MANAGEMENT_DISABLED",
+    });
+  }
+}

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -110,6 +110,14 @@ export const AUDIT_ACTIONS = [
   "ccaHead.grant",
   "ccaHead.revoke",
   "ccaHead.transfer",
+  // CCA management (/admin/manage-ccas). There is deliberately NO "cca.delete":
+  // no surface deletes a CCA, and deleteCcaCascade is script-only and guarded.
+  // Do not add one without re-reading cascade.ts — a delete that reaches
+  // bookings by ccaID is the most destructive write in this codebase.
+  "cca.create",
+  "cca.rename",
+  "ccaMember.add",
+  "ccaMember.remove",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
@@ -724,6 +732,33 @@ export type Capabilities = {
    * admin AND jcrc.
    */
   manageCcaHeads: boolean;
+  /**
+   * May reach /cca AT ALL — the CCA head's own surface.
+   *
+   * COARSE, exactly like reachDashboard: it answers "is this surface for you",
+   * NEVER "which CCA". Which ccaID is enforced per request by assertHeadsCca
+   * (services/ccaScope.ts), which reads CcaHead directly.
+   *
+   * The first capability in which `cca_head` appears. That couples the route to
+   * CH-1, and it is safe in the failure direction: if the string ever outlives
+   * its CcaHead rows, the holder reaches an index whose CONTENT comes from
+   * CcaHead — so they see an empty list and every [ccaID] is refused. A stale
+   * string yields an empty page, never a leaked roster.
+   *
+   * THIS IS NOT AN AUTHORIZATION STATEMENT. Do not "optimize" cca.getRoster by
+   * trusting it.
+   */
+  reachCcaDashboard: boolean;
+  /** May pick any CCA and read its roster (/admin/ccas). Read-only. */
+  viewAnyCcaRoster: boolean;
+  /**
+   * May create/rename CCAs, manage their heads, and add/remove members
+   * (/admin/manage-ccas). Admin only, and additionally behind the
+   * `cca.management.enabled` kill switch checked in the procedures.
+   *
+   * Deliberately NOT a licence to delete: no surface deletes a CCA.
+   */
+  manageCcas: boolean;
   /** May act on a user who holds `admin` at all. D-2: admin only. */
   modifyAdmins: boolean;
   /** May see WHO holds admin (counts and identities). D-2: admin only. */
@@ -751,6 +786,11 @@ export function computeCapabilities(roles: readonly string[]): Capabilities {
     assignableRoles: [...assignableBy(roles)],
     revocableRoles: [...revocableFromOthersBy(roles)],
     manageCcaHeads: manager,
+    // CCA_HEAD_ROLE's first appearance in a capability. Managers are included
+    // so an admin who also heads a CCA still reaches their own surface.
+    reachCcaDashboard: manager || roles.includes(CCA_HEAD_ROLE),
+    viewAnyCcaRoster: manager,
+    manageCcas: admin,
     modifyAdmins: admin,
     seeAdminIdentities: admin,
     bulkAssign: manager,


### PR DESCRIPTION
CCA heads existed as data but had nowhere to go. This adds one surface per access level, all sharing a single roster resolver and a single scope guard.

| Route | Who | What |
|---|---|---|
| `/cca` | CCA heads | The CCAs you head → roster of heads + members |
| `/admin/ccas` | admin + jcrc | Pick any CCA, read-only |
| `/admin/manage-ccas` | **admin only** | Create/rename, heads, members |

## Nothing deletes a CCA

There is no delete procedure and no delete affordance anywhere. `deleteCcaCascade` stays script-only, and gains the two guards it was designed with in `07-cca-future.md` §5/§5.1 but never given:

- **`ccaID` 0 is now refused.** `BookingModal.tsx` hardcodes `ccaID: 0` on every booking the current UI creates, and the cascade deletes bookings by `ccaID`. Deleting a CCA that held that id would have wiped **every booking in the system**. Latent today because nothing called it from a UI — not latent once a button exists.
- **The cascade now removes `CcaHead` rows.** They previously survived and kept an ex-head's `cca_head` string alive un-revokably: `revokeCcaHead` drops the string only when `remaining === 0`, and that never happened because the row outlived the CCA it pointed at.

## The roster is a reverse lookup the data model doesn't support

`getMyCCAs` reads three membership sources keyed off your own session. Inverting it is not symmetric: `UserCCA` has no `ccaID` index and mixed A-format/canonical keys, `User.userCCA` is an `Int[]` not declared in the Prisma model, and there is no reverse query from a canonical id to a `User` row.

So resolution can fail, and can be **ambiguous** — `User.userID` has no unique index. Both cases are surfaced in amber rather than filtered away, and **an ambiguous key is never resolved by picking a claimant**: attributing one person's membership to another is a failure indistinguishable from success.

## First object-scoped authorization check

`assertHeadsCca` (`services/ccaScope.ts`) reads `CcaHead` directly and never consults `roles.includes("cca_head")` — that string is scope-free by construction, so it answers "heads something", never "heads this".

Three new capabilities gate the segments. Management additionally sits behind a `cca.management.enabled` kill switch that **defaults off and fails closed** — deliberately the opposite direction from the three switches in `access.ts`, which fail open to legacy behaviour. "Behave as yesterday" for a surface that didn't exist yesterday means disabled.

## Member removal touches three places

Membership lives in `UserCCA` under a canonical key, `UserCCA` under a legacy A-format key, and the embedded array. Removal cleans all three; a member cleaned from `UserCCA` alone reappears on the roster. Adding writes only the canonical row — the legacy array is cleaned, never grown.

## Verification

`tsc --noEmit`, `next lint` and `next build` all pass. All four new routes build as dynamic.

This repo has no test framework, so coverage is `scripts/remediation/verify-cca-roster.mjs` (read-only, house style). **Its checks [1] and [4] gate assumptions the resolver is built on and should be run against real data before these surfaces are trusted** — [1] confirms `findRaw`'s scalar-vs-array matching, [4] reports whether any membership key is claimed by two accounts today. Check [10] reports whether a `CCA` row currently holds the reserved `ccaID` 0.

Not done in this PR: `@@index([ccaID])` on `UserCCA` (safe in isolation, but gated on measured timing — roster reads are a collection scan today), and audit-logging roster reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
