### PR TITLE
Add a "My CCAs" nav link so CCA heads can reach /cca

### DIFF
--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   Calendar,
   User,
+  Users,
   LogOut,
   UserCircle,
   ShieldCheck,
@@ -44,10 +45,26 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
   const roles = session?.user?.roles ?? [];
   const canReachAdmin = roles.includes("admin") || roles.includes("jcrc");
 
+  /**
+   * Same sanctioned exception as canReachAdmin above, for the same reason.
+   *
+   * Gated on `cca_head` ONLY, deliberately — NOT on the reachCcaDashboard
+   * capability, which also admits admin/jcrc. /cca answers "the CCAs YOU head",
+   * so a manager who heads nothing would get a link to a permanently empty
+   * page; they have the CCAs tab in /admin instead. An admin who genuinely
+   * heads a CCA holds `cca_head` and sees this link like anyone else.
+   *
+   * Without this the page is unreachable for its actual audience: /cca is a
+   * top-level route, and the /admin tab row it would otherwise live in is
+   * closed to a plain CCA head.
+   */
+  const isCcaHead = roles.includes("cca_head");
+
   const navLinks = [
     { name: "Home", href: "/", icon: Home },
     { name: "My Bookings", href: "/bookings", icon: Calendar },
     // { name: "Facilities", href: "/facilities", icon: Box },
+    ...(isCcaHead ? [{ name: "My CCAs", href: "/cca", icon: Users }] : []),
     ...(canReachAdmin
       ? [{ name: "Admin", href: "/admin", icon: ShieldCheck }]
       : []),

--- a/src/app/cca/layout.tsx
+++ b/src/app/cca/layout.tsx
@@ -54,7 +54,9 @@ export default async function CcaLayout({
 
   return (
     <div className="mb-14 min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      <Header currentPage="CCA" />
+      {/* Must match the nav link's `name` in header.tsx — isActive() compares
+          currentPage to link.name before falling back to the pathname. */}
+      <Header currentPage="My CCAs" />
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </main>


### PR DESCRIPTION
`/cca` shipped in #52 with a working guard and **no way in**. It's a top-level route, and the `/admin` tab row where a link would otherwise live is closed to anyone without `admin` or `jcrc` — so a plain CCA head, the page's entire audience, could only reach it by typing the URL.

Adds a **My CCAs** link to the main header nav.

## Why it's gated on the role, not the capability

`reachCcaDashboard` also admits admin/jcrc, but `/cca` means *"the CCAs you head"*. A manager who heads nothing would get a link to a permanently empty page — they have the **CCAs** tab in `/admin` for browsing. An admin who genuinely heads a CCA holds `cca_head` and gets the link like anyone else.

## Why a role string in a component

`header.tsx` already documents this as the single sanctioned exception to the no-role-branching rule, for the existing Admin link: the header renders on every page for every user, so it must not pull in the capability module or issue a `whoAmI` query just to decide whether to draw one link. This follows that pattern exactly.

Nothing is authorised from it — `session.user.roles` is render-only, and the server guard in `cca/layout.tsx` is unchanged and untouched.

`tsc --noEmit` and `next lint` pass.

---

> **Note:** the dashboard redesign that briefly appeared in this description is **not** in this PR — it was pushed to this branch after the merge and never landed here. It lives in its own PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
