### PR TITLE
CCA logos and banners via Vercel Blob

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,30 @@
 await import("./src/env.js");
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  images: {
+    /**
+     * The `cca-images` Vercel Blob store (public, sin1) — CCA logos and banners.
+     *
+     * THIS IS A GLOBAL ALLOWLIST: it governs every next/image in the app, not
+     * just CCA logos. The host is pinned EXACTLY rather than wildcarded to
+     * `**.public.blob.vercel-storage.com`, because that broader pattern would
+     * let any Vercel Blob store on the internet — including someone else's —
+     * be rendered through this app's image optimizer, which is both a
+     * bandwidth-theft vector and a way to launder arbitrary content through
+     * our domain.
+     *
+     * If the store is ever recreated, its id changes and this must change with
+     * it: `vercel blob get-store <id>` prints the Base URL.
+     */
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "inulolpf1lvj86dh.public.blob.vercel-storage.com",
+        pathname: "/**",
+      },
+    ],
+  },
+};
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@trpc/react-query": "^11.0.0-rc.446",
         "@trpc/server": "^11.0.0-rc.446",
         "@types/nodemailer": "^6.4.17",
+        "@vercel/blob": "^2.6.1",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.0",
@@ -3873,6 +3874,68 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4205,6 +4268,15 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5933,6 +6005,35 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6285,6 +6386,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -6553,6 +6666,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6723,6 +6845,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
@@ -6874,6 +7019,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6956,6 +7107,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -7620,6 +7783,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7640,6 +7809,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -7952,6 +8130,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npmlog": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -8128,6 +8318,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
@@ -8168,6 +8373,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -9120,6 +9334,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9792,6 +10015,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10030,6 +10262,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10367,6 +10611,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -11318,6 +11571,31 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@trpc/react-query": "^11.0.0-rc.446",
     "@trpc/server": "^11.0.0-rc.446",
     "@types/nodemailer": "^6.4.17",
+    "@vercel/blob": "^2.6.1",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,6 +451,15 @@ model CcaProfile {
   id          String    @id @default(auto()) @map("_id") @db.ObjectId
   ccaID       Int       @unique(map: "ccaID")
   description String?
+  /// Vercel Blob URLs in the public `cca-images` store.
+  ///
+  /// VALIDATED BEFORE PERSISTING, never trusted. These arrive from the CLIENT
+  /// — the browser uploads directly to Blob and then hands us the resulting
+  /// URL — so `cca.updateProfile` checks the host against the store's and the
+  /// pathname against `cca/{ccaID}/` before writing. Without that a head could
+  /// point their CCA at an arbitrary external image, or at another CCA's blob.
+  logoUrl     String?
+  bannerUrl   String?
   updatedAt   DateTime?
   updatedBy   String?
 }

--- a/src/app/api/cca/upload/route.ts
+++ b/src/app/api/cca/upload/route.ts
@@ -1,0 +1,111 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import {
+  parseCcaUploadPath,
+  UPLOAD_CONTENT_TYPES,
+  UPLOAD_MAX_BYTES,
+} from "~/lib/schemas/cca";
+
+/**
+ * Vercel Blob client-upload token route for CCA logos and banners.
+ *
+ * READ THIS BEFORE TOUCHING IT.
+ *
+ * 1. THIS IS THE APP'S FIRST PUBLIC API ROUTE THAT GRANTS A WRITE.
+ *    It is NOT covered by any tRPC guard — those live in the tRPC middleware
+ *    chain and this is a raw route handler. `onBeforeGenerateToken` is the
+ *    entire authorisation boundary. Vercel's own docs put it plainly: without
+ *    a check there, the route is open to the public and anyone can upload to
+ *    the store.
+ *
+ * 2. IT CANNOT BE A tRPC PROCEDURE. `handleUpload` needs the raw `Request` to
+ *    verify Blob's signature on the callback leg, which tRPC does not expose.
+ *    That is the only reason this lives outside the router.
+ *
+ * 3. WHY THE BROWSER UPLOADS DIRECTLY. The file goes browser → Blob, and this
+ *    route only mints a scoped token. That sidesteps the 4.5 MB serverless
+ *    body limit and, per Vercel's pricing docs, avoids the Fast Data Transfer
+ *    charge a server-side upload would incur.
+ *
+ * 4. `onUploadCompleted` IS NOT THE SOURCE OF TRUTH, and must never become it.
+ *    It is a webhook Vercel calls back into the deployment, and it CANNOT
+ *    reach localhost — so anything that depends on it works in production and
+ *    silently does nothing on every developer's machine. The blob URL is
+ *    persisted by the client calling `cca.updateProfile`, which is guarded,
+ *    audited, and works identically everywhere. This handler only logs.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname) => {
+        const session = await auth();
+        if (!session?.user?.userID) {
+          throw new Error("UNAUTHENTICATED");
+        }
+
+        // `pathname` is CLIENT-SUPPLIED. Parsing it is not the security check
+        // — it only guarantees a well-formed, CCA-scoped path so a token can
+        // never be minted for an arbitrary location in the store. The ccaID it
+        // yields is then authorised below, which IS the check.
+        const target = parseCcaUploadPath(pathname);
+        if (target === null) {
+          throw new Error("BAD_PATHNAME");
+        }
+
+        // I-5: LIVE role read, never session.user.roles. A head revoked this
+        // morning must not be able to mint an upload token this afternoon.
+        const roles = await getUserRoles(db, session.user.userID);
+        await assertHeadsCca(
+          db,
+          { userID: session.user.userID, roles },
+          target.ccaID,
+        );
+
+        return {
+          // Content type is enforced by Vercel against the actual upload, not
+          // the filename — a .pdf renamed to .png does not get through.
+          allowedContentTypes: [...UPLOAD_CONTENT_TYPES],
+          // THE cap that holds. The browser downscales before uploading, but
+          // that runs on the client and is therefore advice, not enforcement.
+          maximumSizeInBytes: UPLOAD_MAX_BYTES,
+          // Immutable, unguessable URLs — which is what makes them safe to
+          // cache forever and stops one CCA overwriting another's blob.
+          addRandomSuffix: true,
+          tokenPayload: JSON.stringify({
+            ccaID: target.ccaID,
+            kind: target.kind,
+            userID: session.user.userID,
+          }),
+        };
+      },
+
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        // Observability only — see note 4 above. Never write to CcaProfile
+        // from here: it does not fire in local development.
+        console.log(
+          JSON.stringify({
+            evt: "cca_image_uploaded",
+            url: blob.url,
+            payload: tokenPayload,
+          }),
+        );
+      },
+    });
+
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "UPLOAD_FAILED";
+    // 400, not 500: every failure here is a rejected request (unauthenticated,
+    // not a head, bad path, oversized), not a server fault.
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/cca/_components/CcaDetailsForm.tsx
+++ b/src/app/cca/_components/CcaDetailsForm.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { api } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import { ccaProfileInput, CCA_DESCRIPTION_MAX } from "~/lib/schemas/cca";
+import CcaImageField from "./CcaImageField";
 
 /**
  * Edit the CCA's description — the only thing a head can currently change.
@@ -24,13 +25,19 @@ export default function CcaDetailsForm({ ccaID }: { ccaID: number }) {
   const profile = api.cca.getProfile.useQuery({ ccaID }, { retry: false });
 
   const [description, setDescription] = useState("");
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [bannerUrl, setBannerUrl] = useState<string | null>(null);
   const [fieldError, setFieldError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
-  // Seed the textarea once the saved value arrives. Keyed on the query data
+  // Seed the fields once the saved values arrive. Keyed on the query data
   // rather than done in render so typing is never clobbered by a refetch.
   useEffect(() => {
-    if (profile.data) setDescription(profile.data.description);
+    if (profile.data) {
+      setDescription(profile.data.description);
+      setLogoUrl(profile.data.logoUrl);
+      setBannerUrl(profile.data.bannerUrl);
+    }
   }, [profile.data]);
 
   const update = api.cca.updateProfile.useMutation({
@@ -72,7 +79,10 @@ export default function CcaDetailsForm({ ccaID }: { ccaID: number }) {
         : "That didn't save. Try again."
     : null;
 
-  const dirty = description !== (profile.data?.description ?? "");
+  const dirty =
+    description !== (profile.data?.description ?? "") ||
+    logoUrl !== (profile.data?.logoUrl ?? null) ||
+    bannerUrl !== (profile.data?.bannerUrl ?? null);
 
   return (
     <form
@@ -82,10 +92,18 @@ export default function CcaDetailsForm({ ccaID }: { ccaID: number }) {
         setSaved(false);
         // Mirror the server's validation client-side using the SAME schema, so
         // the two can never disagree about what is accepted.
-        const parsed = ccaProfileInput.safeParse({ ccaID, description });
+        const parsed = ccaProfileInput.safeParse({
+          ccaID,
+          description,
+          logoUrl,
+          bannerUrl,
+        });
         if (!parsed.success) {
+          const issue = parsed.error.issues[0];
           setFieldError(
-            parsed.error.issues[0]?.message ?? "That description isn't valid.",
+            issue?.message === "NOT_A_VALID_CCA_IMAGE_URL"
+              ? "That image doesn't belong to this CCA. Re-upload it."
+              : (issue?.message ?? "That description isn't valid."),
           );
           return;
         }
@@ -120,6 +138,37 @@ export default function CcaDetailsForm({ ccaID }: { ccaID: number }) {
           {description.length}/{CCA_DESCRIPTION_MAX}
         </p>
       </div>
+
+      <div className="grid gap-5 border-t border-gray-100 pt-5 sm:grid-cols-2">
+        <CcaImageField
+          ccaID={ccaID}
+          kind="logo"
+          label="Logo"
+          help="Square works best. Shown next to your CCA's name."
+          value={logoUrl}
+          onChange={(url) => {
+            setLogoUrl(url);
+            setSaved(false);
+          }}
+          disabled={update.isPending}
+        />
+        <CcaImageField
+          ccaID={ccaID}
+          kind="banner"
+          label="Banner"
+          help="A wide image for the top of your CCA's page."
+          value={bannerUrl}
+          onChange={(url) => {
+            setBannerUrl(url);
+            setSaved(false);
+          }}
+          disabled={update.isPending}
+        />
+      </div>
+
+      <p className="text-xs text-gray-400">
+        Images upload straight away, but only stick once you save.
+      </p>
 
       {fieldError && <p className="text-sm text-red-600">{fieldError}</p>}
       {serverError && <p className="text-sm text-red-600">{serverError}</p>}

--- a/src/app/cca/_components/CcaImageField.tsx
+++ b/src/app/cca/_components/CcaImageField.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useRef } from "react";
+import Image from "next/image";
+import { upload } from "@vercel/blob/client";
+
+import { Button } from "~/components/ui/button";
+import {
+  ccaUploadPath,
+  LOGO_MAX_PX,
+  BANNER_MAX_W,
+  BANNER_MAX_H,
+  UPLOAD_MAX_BYTES,
+  type CcaImageKind,
+} from "~/lib/schemas/cca";
+
+/**
+ * Pick an image, downscale it in the browser, upload it straight to Vercel
+ * Blob, and hand the resulting URL to the parent form.
+ *
+ * THE RESIZE IS CONVENIENCE, NOT A CONTROL. It runs on the client, so it can
+ * be bypassed with devtools. What actually caps the upload is
+ * `maximumSizeInBytes` in /api/cca/upload, enforced by Vercel when it mints
+ * the token. The resize exists so that an honest head uploading a 12 MB phone
+ * photo doesn't consume 12 MB of the store — which, across 89 CCAs, is the
+ * difference between ~60 MB of storage and ~1 GB.
+ *
+ * The upload happens on SELECT, not on save. That means abandoning the form
+ * after choosing a file leaves an orphaned blob. Accepted: it keeps the form
+ * simple, and orphans are reconcilable later by diffing `list()` against
+ * CcaProfile.
+ */
+
+/** Downscale to fit within maxW×maxH, preserving aspect ratio, re-encoded WebP. */
+async function resizeToWebp(
+  file: File,
+  maxW: number,
+  maxH: number,
+): Promise<Blob> {
+  // `imageOrientation: "from-image"` applies EXIF rotation. Without it, photos
+  // taken in portrait on a phone upload sideways — canvas drawImage ignores
+  // EXIF on its own.
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: "from-image",
+  });
+
+  const scale = Math.min(1, maxW / bitmap.width, maxH / bitmap.height);
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("CANVAS_UNAVAILABLE");
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/webp", 0.85),
+  );
+  if (!blob) throw new Error("ENCODE_FAILED");
+  return blob;
+}
+
+export default function CcaImageField({
+  ccaID,
+  kind,
+  label,
+  help,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  ccaID: number;
+  kind: CcaImageKind;
+  label: string;
+  help: string;
+  value: string | null;
+  onChange: (url: string | null) => void;
+  disabled?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLogo = kind === "logo";
+  const maxW = isLogo ? LOGO_MAX_PX : BANNER_MAX_W;
+  const maxH = isLogo ? LOGO_MAX_PX : BANNER_MAX_H;
+
+  async function handleFile(file: File) {
+    setError(null);
+    setBusy(true);
+    try {
+      const resized = await resizeToWebp(file, maxW, maxH);
+
+      // Belt and braces. The server cap is authoritative, but failing here
+      // gives a useful message instead of an opaque rejected upload.
+      if (resized.size > UPLOAD_MAX_BYTES) {
+        throw new Error("TOO_LARGE");
+      }
+
+      const blob = await upload(ccaUploadPath(ccaID, kind), resized, {
+        access: "public",
+        contentType: "image/webp",
+        handleUploadUrl: "/api/cca/upload",
+      });
+
+      onChange(blob.url);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      setError(
+        msg === "TOO_LARGE"
+          ? "That image is still too large after resizing. Try a smaller one."
+          : msg.includes("NOT_A_HEAD")
+            ? "You're no longer a head of this CCA."
+            : "That image couldn't be uploaded. Try again.",
+      );
+    } finally {
+      setBusy(false);
+      // Clear the input so re-picking the SAME file fires onChange again.
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="text-sm font-medium text-gray-700">{label}</p>
+        <p className="text-xs text-gray-500">{help}</p>
+      </div>
+
+      {value ? (
+        <div className="flex items-start gap-3">
+          <div
+            className={`relative overflow-hidden rounded-md border border-gray-200 bg-gray-50 ${
+              isLogo ? "h-20 w-20" : "h-20 w-64"
+            }`}
+          >
+            <Image
+              src={value}
+              alt={`${label} preview`}
+              fill
+              className="object-contain"
+              sizes={isLogo ? "80px" : "256px"}
+              unoptimized
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled || busy}
+              onClick={() => inputRef.current?.click()}
+            >
+              Replace
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || busy}
+              onClick={() => onChange(null)}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          {busy ? "Uploading…" : `Upload ${label.toLowerCase()}`}
+        </Button>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFile(file);
+        }}
+      />
+
+      {busy && <p className="text-xs text-gray-500">Uploading…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/cca/_components/CcaOverview.tsx
+++ b/src/app/cca/_components/CcaOverview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 
 import { api } from "~/trpc/react";
 import RosterDriftNote from "~/app/_components/RosterDriftNote";
@@ -22,6 +23,7 @@ import StatTile from "./StatTile";
 export default function CcaOverview({ ccaID }: { ccaID: number }) {
   const roster = api.cca.getRoster.useQuery({ ccaID }, { retry: false });
   const mine = api.cca.listMine.useQuery(undefined, { retry: false });
+  const profile = api.cca.getProfile.useQuery({ ccaID }, { retry: false });
 
   if (roster.error) {
     if (roster.error.message === "NOT_A_HEAD_OF_THIS_CCA") {
@@ -53,8 +55,56 @@ export default function CcaOverview({ ccaID }: { ccaID: number }) {
   const data = roster.data;
   const membership = mine.data?.ccas.find((c) => c.ccaID === ccaID) ?? null;
 
+  const p = profile.data;
+
   return (
     <div className="space-y-6">
+      {/* Banner. `unoptimized` because these are already downscaled to
+          1600×400 WebP on upload — running them back through the image
+          optimizer would spend transformations to save almost nothing. */}
+      {p?.bannerUrl && (
+        <div className="relative h-36 w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50 sm:h-48">
+          <Image
+            src={p.bannerUrl}
+            alt=""
+            fill
+            className="object-cover"
+            sizes="100vw"
+            unoptimized
+            priority
+          />
+        </div>
+      )}
+
+      {(p?.logoUrl ?? p?.description) && (
+        <section className="flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-5">
+          {p?.logoUrl && (
+            <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-md border border-gray-200 bg-gray-50">
+              <Image
+                src={p.logoUrl}
+                alt=""
+                fill
+                className="object-contain"
+                sizes="64px"
+                unoptimized
+              />
+            </div>
+          )}
+          {p?.description ? (
+            // whitespace-pre-wrap preserves the line breaks a head typed.
+            // React escapes the content, which is what makes rendering
+            // user-authored prose safe without a sanitizer.
+            <p className="min-w-0 whitespace-pre-wrap text-sm leading-relaxed text-gray-700">
+              {p.description}
+            </p>
+          ) : (
+            <p className="text-sm italic text-gray-400">
+              No description yet.
+            </p>
+          )}
+        </section>
+      )}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <StatTile
           label="Heads"

--- a/src/env.js
+++ b/src/env.js
@@ -33,6 +33,16 @@ export const env = createEnv({
     APP_URL: z.string().url().optional(),
     // bcrypt cost factor for password hashing (#3).
     BCRYPT_ROUNDS: z.coerce.number().int().min(10).max(15).default(12),
+    // Vercel Blob (CCA logos and banners). Provisioned by the `cca-images`
+    // store and injected automatically on Vercel; pull it locally with
+    // `vercel env pull`.
+    //
+    // OPTIONAL, unlike RESEND_API_KEY, and deliberately so: it is needed by
+    // exactly one route, and making it required would stop the whole app
+    // building for any contributor who has not pulled it. The upload route
+    // fails loudly on its own if the token is missing, which localises the
+    // breakage to the feature that needs it.
+    BLOB_READ_WRITE_TOKEN: z.string().optional(),
   },
 
   /**
@@ -58,6 +68,7 @@ export const env = createEnv({
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     APP_URL: process.env.APP_URL,
     BCRYPT_ROUNDS: process.env.BCRYPT_ROUNDS,
+    BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/lib/schemas/cca.ts
+++ b/src/lib/schemas/cca.ts
@@ -10,6 +10,110 @@ import { z } from "zod";
 
 export const CCA_DESCRIPTION_MAX = 1000;
 
+/* -------------------------------------------------------------------------- */
+/* Image uploads                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The public `cca-images` Vercel Blob store (region sin1).
+ *
+ * NOT a secret — it is the public origin every CCA logo is served from, and it
+ * is already in next.config.js's remotePatterns. It lives here because the URL
+ * validator below is shared by client and server, and both must agree on
+ * exactly one host.
+ *
+ * If the store is recreated its id changes: `vercel blob get-store <id>` prints
+ * the Base URL, and BOTH this constant and next.config.js must be updated.
+ */
+export const CCA_BLOB_HOST = "inulolpf1lvj86dh.public.blob.vercel-storage.com";
+
+/** What the browser downscales to before uploading. Convenience, not a control. */
+export const LOGO_MAX_PX = 512;
+export const BANNER_MAX_W = 1600;
+export const BANNER_MAX_H = 400;
+
+/**
+ * The cap that actually holds, enforced by Vercel when it mints the upload
+ * token (`maximumSizeInBytes` in onBeforeGenerateToken). The client-side
+ * resize keeps honest uploads far below this; this stops a crafted one.
+ */
+export const UPLOAD_MAX_BYTES = 2 * 1024 * 1024;
+
+export const UPLOAD_CONTENT_TYPES = [
+  "image/webp",
+  "image/png",
+  "image/jpeg",
+] as const;
+
+export const CCA_IMAGE_KINDS = ["logo", "banner"] as const;
+export type CcaImageKind = (typeof CCA_IMAGE_KINDS)[number];
+
+/**
+ * The upload pathname for a CCA's image. Vercel appends a random suffix, so the
+ * stored blob is e.g. `cca/12/logo-Xy7Qa1.webp` — unguessable and immutable,
+ * which is what lets the CDN cache it indefinitely.
+ *
+ * Built here so the client (which requests the token) and the route (which
+ * authorises it) cannot disagree about the shape.
+ */
+export function ccaUploadPath(ccaID: number, kind: CcaImageKind): string {
+  return `cca/${ccaID}/${kind}`;
+}
+
+/**
+ * Inverse of ccaUploadPath, used by the upload route to work out WHICH CCA a
+ * token is being requested for.
+ *
+ * The pathname is client-supplied, so this parse is not itself a security
+ * boundary — the caller must pass the result to assertHeadsCca. What it does
+ * guarantee is that a token can only ever be minted for a well-formed
+ * CCA-scoped path, never for an arbitrary location in the store.
+ */
+export function parseCcaUploadPath(
+  pathname: string,
+): { ccaID: number; kind: CcaImageKind } | null {
+  const m = /^cca\/(\d+)\/(logo|banner)$/.exec(pathname);
+  if (!m) return null;
+  const ccaID = Number(m[1]);
+  if (!Number.isSafeInteger(ccaID) || ccaID <= 0) return null;
+  return { ccaID, kind: m[2] as CcaImageKind };
+}
+
+/**
+ * Is this URL one of OUR blobs, for THIS CCA?
+ *
+ * THE LOAD-BEARING CHECK. Image URLs reach the server from the client: the
+ * browser uploads straight to Blob and then calls updateProfile with whatever
+ * URL it got back. Without this, `updateProfile` is an arbitrary-URL write —
+ * a head could point their CCA at an external image (offsite content served
+ * under our name, and a hotlinking hole) or at another CCA's blob.
+ *
+ * Three things are checked, and all three matter:
+ *   - protocol is https, so `javascript:` and `data:` can never be stored
+ *   - host is EXACTLY the store's, not a suffix match — `evil-inulolpf1lvj86dh
+ *     .public.blob.vercel-storage.com.attacker.test` must not pass
+ *   - the path is under this CCA's own prefix
+ */
+export function isOwnCcaBlobUrl(
+  url: string,
+  ccaID: number,
+  kind: CcaImageKind,
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.host !== CCA_BLOB_HOST) return false;
+  return parsed.pathname.startsWith(`/${ccaUploadPath(ccaID, kind)}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* The mutation payload                                                        */
+/* -------------------------------------------------------------------------- */
+
 /**
  * SECURITY: this schema must NEVER gain a `ccaName`, `category`, `userID` or
  * `roles` key.
@@ -23,31 +127,55 @@ export const CCA_DESCRIPTION_MAX = 1000;
  * zod strips unknown keys, so the only way a head writes something they
  * shouldn't is if someone ADDS the key here.
  */
-export const ccaProfileInput = z.object({
-  // .positive(), not .nonnegative(): ccaID 0 is RESERVED — see the guards in
-  // src/server/api/services/cascade.ts.
-  ccaID: z.number().int().positive(),
+export const ccaProfileInput = z
+  .object({
+    // .positive(), not .nonnegative(): ccaID 0 is RESERVED — see the guards in
+    // src/server/api/services/cascade.ts.
+    ccaID: z.number().int().positive(),
 
-  /**
-   * Trim and length ONLY — no sanitization, matching `bio` in profile.ts.
-   *
-   * React escapes this on render, which is what prevents XSS. `sanitizeName`
-   * exists for `displayName` alone, because that value is rendered AS AN
-   * IDENTITY on other people's bookings and is therefore an impersonation
-   * vector (homoglyphs, bidi overrides). A CCA description is prose displayed
-   * as prose; stripping format characters from it would corrupt legitimate
-   * text for no security gain. Do not copy sanitizeName here.
-   *
-   * "" is allowed and means "no description" — clearing one is a normal edit,
-   * not an error.
-   */
-  description: z
-    .string()
-    .trim()
-    .max(
-      CCA_DESCRIPTION_MAX,
-      `Description must be ${CCA_DESCRIPTION_MAX} characters or fewer`,
-    ),
-});
+    /**
+     * Trim and length ONLY — no sanitization, matching `bio` in profile.ts.
+     *
+     * React escapes this on render, which is what prevents XSS. `sanitizeName`
+     * exists for `displayName` alone, because that value is rendered AS AN
+     * IDENTITY on other people's bookings and is therefore an impersonation
+     * vector (homoglyphs, bidi overrides). A CCA description is prose displayed
+     * as prose; stripping format characters from it would corrupt legitimate
+     * text for no security gain. Do not copy sanitizeName here.
+     *
+     * "" is allowed and means "no description" — clearing one is a normal edit.
+     */
+    description: z
+      .string()
+      .trim()
+      .max(
+        CCA_DESCRIPTION_MAX,
+        `Description must be ${CCA_DESCRIPTION_MAX} characters or fewer`,
+      ),
+
+    // null means "remove the image". Checked against isOwnCcaBlobUrl below —
+    // z.string().url() alone would happily accept https://evil.example/x.png.
+    logoUrl: z.string().url().nullable().default(null),
+    bannerUrl: z.string().url().nullable().default(null),
+  })
+  .superRefine((val, ctx) => {
+    if (val.logoUrl !== null && !isOwnCcaBlobUrl(val.logoUrl, val.ccaID, "logo")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["logoUrl"],
+        message: "NOT_A_VALID_CCA_IMAGE_URL",
+      });
+    }
+    if (
+      val.bannerUrl !== null &&
+      !isOwnCcaBlobUrl(val.bannerUrl, val.ccaID, "banner")
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["bannerUrl"],
+        message: "NOT_A_VALID_CCA_IMAGE_URL",
+      });
+    }
+  });
 
 export type CcaProfileInput = z.input<typeof ccaProfileInput>;

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -6,6 +6,7 @@ import { getUserRoles } from "~/server/api/services/access";
 import { computeCapabilities } from "~/server/api/services/roles";
 import { assertHeadsCca } from "~/server/api/services/ccaScope";
 import { resolveRoster } from "~/server/api/services/ccaRoster";
+import { del } from "@vercel/blob";
 import { writeAudit } from "~/server/api/routers/admin";
 import { ccaProfileInput } from "~/lib/schemas/cca";
 
@@ -157,13 +158,21 @@ export const ccaRouter = createTRPCRouter({
 
       const row = await ctx.db.ccaProfile.findUnique({
         where: { ccaID: input.ccaID },
-        select: { description: true, updatedAt: true, updatedBy: true },
+        select: {
+          description: true,
+          logoUrl: true,
+          bannerUrl: true,
+          updatedAt: true,
+          updatedBy: true,
+        },
       });
 
       // No row is the normal state for a CCA nobody has described yet — an
       // empty profile, not an error.
       return {
         description: row?.description ?? "",
+        logoUrl: row?.logoUrl ?? null,
+        bannerUrl: row?.bannerUrl ?? null,
         updatedAt: row?.updatedAt ?? null,
         updatedBy: row?.updatedBy ?? null,
       };
@@ -200,7 +209,7 @@ export const ccaRouter = createTRPCRouter({
 
       const before = await ctx.db.ccaProfile.findUnique({
         where: { ccaID: input.ccaID },
-        select: { description: true },
+        select: { description: true, logoUrl: true, bannerUrl: true },
       });
 
       const saved = await ctx.db.ccaProfile.upsert({
@@ -208,16 +217,64 @@ export const ccaRouter = createTRPCRouter({
         create: {
           ccaID: input.ccaID,
           description: input.description,
+          logoUrl: input.logoUrl,
+          bannerUrl: input.bannerUrl,
           updatedAt: new Date(),
           updatedBy: userID,
         },
         update: {
           description: input.description,
+          logoUrl: input.logoUrl,
+          bannerUrl: input.bannerUrl,
           updatedAt: new Date(),
           updatedBy: userID,
         },
-        select: { description: true, updatedAt: true, updatedBy: true },
+        select: {
+          description: true,
+          logoUrl: true,
+          bannerUrl: true,
+          updatedAt: true,
+          updatedBy: true,
+        },
       });
+
+      /**
+       * Delete blobs this save replaced, so a CCA that re-uploads its logo ten
+       * times doesn't leave nine paying tenants in the store. `del()` is free
+       * per Vercel's pricing docs.
+       *
+       * AFTER the upsert and deliberately non-fatal: an orphaned blob costs
+       * fractions of a cent, while a delete failure that rolled back the save
+       * would lose the user's edit. Logged rather than swallowed so a
+       * persistent failure is visible.
+       *
+       * The input URLs are already proven to be ours and this CCA's by
+       * ccaProfileInput's superRefine, and `before` came from our own row —
+       * so nothing here can be pointed at another CCA's blob.
+       */
+      const replaced = [
+        before?.logoUrl && before.logoUrl !== saved.logoUrl
+          ? before.logoUrl
+          : null,
+        before?.bannerUrl && before.bannerUrl !== saved.bannerUrl
+          ? before.bannerUrl
+          : null,
+      ].filter((u): u is string => u !== null);
+
+      if (replaced.length > 0) {
+        try {
+          await del(replaced);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              evt: "cca_blob_delete_failed",
+              ccaID: input.ccaID,
+              urls: replaced,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      }
 
       // Audited on ctx.db, outside any transaction (I-15). `via` records
       // whether this was the CCA's own head or a manager acting over the top.
@@ -226,7 +283,18 @@ export const ccaRouter = createTRPCRouter({
         actorRoles: roles,
         targetCcaID: input.ccaID,
         action: "ccaProfile.update",
-        reason: `${scope.via}: description ${before?.description ? "updated" : "set"} (${input.description.length} chars)`,
+        reason: [
+          scope.via,
+          `description ${input.description.length} chars`,
+          before?.logoUrl !== saved.logoUrl
+            ? `logo ${saved.logoUrl ? "set" : "removed"}`
+            : null,
+          before?.bannerUrl !== saved.bannerUrl
+            ? `banner ${saved.bannerUrl ? "set" : "removed"}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("; "),
       });
 
       return saved;


### PR DESCRIPTION
Adds the upload infrastructure this app had none of — no storage package, an empty `next.config.js`, no upload route, no storage env var. A CCA head can now set a logo and banner alongside the description from `/cca/[id]/details`.

Follows #54, which added the dashboard and `CcaProfile`.

## ⚠️ Needs `prisma db push` before it works

`CcaProfile` gains `logoUrl` and `bannerUrl` — both nullable and additive. **I did not run this**, because `db push` applies the *entire* schema delta and the RBAC migrations are still outstanding, so the delta may not be only these two columns. Confirm it before running, and **if it asks for `--accept-data-loss`, stop.**

## The store

Created as `cca-images`, **public**, region **`sin1`** — chosen over the `iad1` default because every user of this app is in Singapore, so a cache miss shouldn't cross the Pacific. Public because these images are shown to every resident: the browser fetches from the CDN directly, where a private store would put a serverless function in the path for every image and cost Blob Data Transfer *plus* Fast Data Transfer.

`BLOB_READ_WRITE_TOKEN` was auto-added to the project across all three environments.

**Sizing:** 89 CCAs × (logo + banner) ≈ **62 MB** against 5 GB included. Uploads are Advanced Operations and only happen on save; views are Simple Operations only on a cache miss. Comfortably inside the allowance.

## The URL is persisted through tRPC, not `onUploadCompleted`

That callback is a webhook Vercel calls back into the deployment, and **it cannot reach localhost**. Anything depending on it works in production and silently does nothing on every developer's machine. So the browser uploads, gets a URL, and calls `cca.updateProfile` — already guarded by `assertHeadsCca`, already audited, and identical everywhere.

**That moves trust to the client, so the URL is validated before storage:** https only, host *exactly* the store's (not a suffix match — `evil-<store>.public.blob.vercel-storage.com.attacker.test` must not pass), and the path under this CCA's own `cca/{ccaID}/` prefix. Without it, `updateProfile` is an arbitrary-URL write: a head could point their CCA at an external image, or at another CCA's blob.

## `/api/cca/upload` is the app's first public write route

It's also the first place `assertHeadsCca` is called outside a tRPC procedure — it can't be a tRPC endpoint because `handleUpload` needs the raw `Request`. `onBeforeGenerateToken` is the **entire** authorisation boundary; Vercel's docs state plainly that without a check there, the route is open to the public. The file header says all of this so nobody assumes the tRPC guards cover it.

## Two size defences, one of which is trusted

The browser downscales to WebP (512 px logo, 1600×400 banner) before uploading. That's what keeps honest uploads small — across 89 CCAs it's the difference between ~60 MB and ~1 GB. But it runs on the client, so it's advice. `maximumSizeInBytes` on the minted token is the cap that actually holds against a crafted upload, alongside `allowedContentTypes` (enforced against the real bytes, so a `.pdf` renamed `.png` doesn't pass).

EXIF orientation is applied on resize, so portrait phone photos don't upload sideways.

## Smaller decisions

**`remotePatterns` pins the host exactly**, not `**.public.blob.vercel-storage.com`. That wildcard would let *any* Vercel Blob store on the internet render through this app's image optimizer — bandwidth theft, and a way to launder arbitrary content under our domain.

**`BLOB_READ_WRITE_TOKEN` is optional in `env.js`**, unlike `RESEND_API_KEY`. A contributor who hasn't pulled it can still build; only the upload route breaks, which is where the breakage belongs.

**Replaced blobs are deleted on save**, so a CCA re-uploading ten times doesn't leave nine paying tenants. Non-fatal and logged — an orphan costs fractions of a cent, a delete failure that rolled back the save would lose the edit. Abandoning the form after picking a file still orphans a blob; accepted, reconcilable later by diffing `list()` against `CcaProfile`.

## Verification

`tsc --noEmit`, `eslint` and `next build` pass; `/api/cca/upload` builds as a dynamic route.

No test framework. **Manual QA outstanding**, and these are the ones that matter:

- `POST /api/cca/upload` while logged out → `UNAUTHENTICATED`
- `POST /api/cca/upload` with a pathname for a CCA you don't head → `NOT_A_HEAD_OF_THIS_CCA`
- `updateProfile` with `logoUrl: "https://evil.example/x.png"` from the console → rejected
- `updateProfile` with another CCA's valid blob URL → rejected on the prefix check
- Replace a logo → new one renders, old blob gone from the store
- Upload with resizing bypassed via devtools → rejected by `maximumSizeInBytes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
