### PR TITLE
Let CCA heads remove members from their own roster

### DIFF
--- a/src/app/_components/RosterPanel.tsx
+++ b/src/app/_components/RosterPanel.tsx
@@ -1,8 +1,33 @@
 "use client";
 
+import { useState } from "react";
+
 import { api } from "~/trpc/react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import type { RosterEntry } from "~/server/api/services/ccaRoster";
 import RosterTable from "./RosterTable";
 import RosterDriftNote from "./RosterDriftNote";
+
+/** How a roster entry maps to a removeMember target. */
+function removalTarget(entry: RosterEntry) {
+  return entry.kind === "resolved"
+    ? ({ kind: "user", userObjectId: entry.userId } as const)
+    : ({ kind: "key", key: entry.key } as const);
+}
+
+function entryLabel(entry: RosterEntry): string {
+  return entry.kind === "resolved"
+    ? (entry.displayName ?? entry.email)
+    : `this unmatched record (${entry.key})`;
+}
 
 /**
  * The roster for one CCA. Rendered by /cca/[ccaID] and by /admin/ccas.
@@ -20,10 +45,22 @@ export default function RosterPanel({
    * such heading and still needs it — hence a prop rather than deleting it.
    */
   hideHeader = false,
+  /**
+   * Enables the per-member remove control. Set ONLY by a head's own member-list
+   * section (/cca/[ccaID]/members); the /admin/ccas viewer stays read-only, and
+   * admins manage membership from /admin/manage-ccas. The server guard
+   * (assertHeadsCca on cca.removeMember) is the real boundary — this flag only
+   * decides whether the button is drawn.
+   */
+  manageMembers = false,
 }: {
   ccaID: number;
   hideHeader?: boolean;
+  manageMembers?: boolean;
 }) {
+  const utils = api.useUtils();
+  const [pending, setPending] = useState<RosterEntry | null>(null);
+
   const { data, isPending, error } = api.cca.getRoster.useQuery(
     { ccaID },
     {
@@ -32,6 +69,13 @@ export default function RosterPanel({
       retry: false,
     },
   );
+
+  const remove = api.cca.removeMember.useMutation({
+    onSuccess: async () => {
+      setPending(null);
+      await utils.cca.getRoster.invalidate({ ccaID });
+    },
+  });
 
   if (isPending) {
     return (
@@ -97,6 +141,10 @@ export default function RosterPanel({
 
       <RosterDriftNote drift={drift} />
 
+      {/* Heads are NEVER removable here — headship is managed through
+          grant/revoke/transfer, which keep the CcaHead row and the cca_head
+          string in step (CH-1). So the members table gets onRemove and the
+          heads table never does. */}
       <RosterTable
         title="Heads"
         entries={heads}
@@ -106,7 +154,61 @@ export default function RosterPanel({
         title="Members"
         entries={members}
         emptyCopy="No members are listed for this CCA yet."
+        onRemove={manageMembers ? (e) => setPending(e) : undefined}
+        removingBusy={remove.isPending}
       />
+
+      <AlertDialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open && !remove.isPending) {
+            setPending(null);
+            remove.reset();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this member?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pending && (
+                <>
+                  {entryLabel(pending)} will be removed from this CCA. There is
+                  no way to add members back yet, so they&rsquo;d need to rejoin
+                  through the sign-up system.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {remove.error && (
+            <p className="text-sm text-red-600">
+              {remove.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+                ? "You're no longer a head of this CCA."
+                : "That didn't work. Try again."}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={remove.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            {/* Not AlertDialogAction: that closes the dialog on click, which
+                would dismiss it before the mutation resolves and hide any
+                error. A plain button keeps it open until onSuccess closes it. */}
+            <button
+              type="button"
+              disabled={remove.isPending || pending === null}
+              onClick={() => {
+                if (pending) {
+                  remove.mutate({ ccaID, target: removalTarget(pending) });
+                }
+              }}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:pointer-events-none disabled:opacity-50"
+            >
+              {remove.isPending ? "Removing…" : "Remove member"}
+            </button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/_components/RosterTable.tsx
+++ b/src/app/_components/RosterTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Trash2 } from "lucide-react";
+
 import {
   Table,
   TableBody,
@@ -8,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
+import { Button } from "~/components/ui/button";
 import type { RosterEntry } from "~/server/api/services/ccaRoster";
 
 /**
@@ -56,7 +59,41 @@ function unresolvedCopy(entry: Extract<RosterEntry, { kind: "unresolved" }>) {
       };
 }
 
-function EntryRow({ entry }: { entry: RosterEntry }) {
+/** A remove control, shown only when the table is given an `onRemove`. */
+function RemoveCell({
+  entry,
+  onRemove,
+  busy,
+}: {
+  entry: RosterEntry;
+  onRemove: (entry: RosterEntry) => void;
+  busy: boolean;
+}) {
+  return (
+    <TableCell className="text-right">
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={busy}
+        aria-label="Remove member"
+        onClick={() => onRemove(entry)}
+        className="text-gray-400 hover:text-red-600"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </TableCell>
+  );
+}
+
+function EntryRow({
+  entry,
+  onRemove,
+  busy,
+}: {
+  entry: RosterEntry;
+  onRemove?: (entry: RosterEntry) => void;
+  busy: boolean;
+}) {
   const duplicate = entry.userCcaRowCount > 1;
 
   if (entry.kind === "unresolved") {
@@ -75,6 +112,7 @@ function EntryRow({ entry }: { entry: RosterEntry }) {
         <TableCell className="text-right">
           <RoleLabel isHead={entry.isHead} />
         </TableCell>
+        {onRemove && <RemoveCell entry={entry} onRemove={onRemove} busy={busy} />}
       </TableRow>
     );
   }
@@ -98,6 +136,7 @@ function EntryRow({ entry }: { entry: RosterEntry }) {
       <TableCell className="text-right">
         <RoleLabel isHead={entry.isHead} />
       </TableCell>
+      {onRemove && <RemoveCell entry={entry} onRemove={onRemove} busy={busy} />}
     </TableRow>
   );
 }
@@ -106,10 +145,21 @@ export default function RosterTable({
   title,
   entries,
   emptyCopy,
+  /**
+   * When provided, each row gets a remove control. Passed ONLY to the members
+   * table on a head's own dashboard — the heads table and the read-only
+   * /admin/ccas viewer leave it undefined, so the extra column and the write
+   * affordance never appear there. Removal is still authorised server-side by
+   * assertHeadsCca regardless; this only decides whether to draw the button.
+   */
+  onRemove,
+  removingBusy = false,
 }: {
   title: string;
   entries: RosterEntry[];
   emptyCopy: string;
+  onRemove?: (entry: RosterEntry) => void;
+  removingBusy?: boolean;
 }) {
   return (
     <section>
@@ -132,11 +182,21 @@ export default function RosterTable({
                 <TableHead>Name</TableHead>
                 <TableHead>Email</TableHead>
                 <TableHead className="text-right">Role</TableHead>
+                {onRemove && (
+                  <TableHead className="text-right">
+                    <span className="sr-only">Remove</span>
+                  </TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
               {entries.map((e) => (
-                <EntryRow key={e.kind === "resolved" ? e.userId : e.key} entry={e} />
+                <EntryRow
+                  key={e.kind === "resolved" ? e.userId : e.key}
+                  entry={e}
+                  onRemove={onRemove}
+                  busy={removingBusy}
+                />
               ))}
             </TableBody>
           </Table>

--- a/src/app/cca/[ccaID]/members/page.tsx
+++ b/src/app/cca/[ccaID]/members/page.tsx
@@ -4,10 +4,14 @@ import RosterPanel from "~/app/_components/RosterPanel";
 import { parseCcaID } from "../../_lib/ccaParam";
 
 /**
- * The member list. A thin wrapper over the SAME RosterPanel that /admin/ccas
- * renders — one component, one query, so the head's view and the manager's view
- * cannot drift apart. Only the heading is suppressed, since the dashboard shell
- * already shows the CCA's name.
+ * The member list. The SAME RosterPanel that /admin/ccas renders, but with
+ * `manageMembers` on: a head can remove members from their own roster here.
+ * The heading is suppressed because the dashboard shell already shows the name.
+ *
+ * The read-only /admin/ccas viewer omits `manageMembers`, so removal is a
+ * head-surface affordance only — admins prune from /admin/manage-ccas. Either
+ * way cca.removeMember re-checks with assertHeadsCca, so the flag is UI, not
+ * the boundary.
  */
 export default function CcaMembersPage({
   params,
@@ -17,5 +21,5 @@ export default function CcaMembersPage({
   const ccaID = parseCcaID(params.ccaID);
   if (ccaID === null) notFound();
 
-  return <RosterPanel ccaID={ccaID} hideHeader />;
+  return <RosterPanel ccaID={ccaID} hideHeader manageMembers />;
 }

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -8,6 +8,10 @@ import { assertHeadsCca } from "~/server/api/services/ccaScope";
 import { resolveRoster } from "~/server/api/services/ccaRoster";
 import { del } from "@vercel/blob";
 import { writeAudit } from "~/server/api/routers/admin";
+import {
+  removeCcaMember,
+  removeMemberTargetSchema,
+} from "~/server/api/services/ccaMembers";
 import { ccaProfileInput } from "~/lib/schemas/cca";
 
 /**
@@ -298,5 +302,50 @@ export const ccaRouter = createTRPCRouter({
       });
 
       return saved;
+    }),
+
+  /**
+   * Remove a member from a CCA a head is responsible for.
+   *
+   * The head-facing sibling of `ccaAdmin.removeMember`. Both wrap the SAME
+   * `removeCcaMember` service, so the three-target delete (canonical UserCCA,
+   * legacy-key UserCCA, embedded array) cannot diverge between them.
+   *
+   * There is intentionally NO addMember here: joining a CCA will run through the
+   * application-management system, not a head typing a userID. Removal is the
+   * only membership write a head gets in this phase.
+   *
+   * NO KILL SWITCH, unlike the admin surface. `cca.management.enabled` gates the
+   * admin CRUD tab (create/rename/heads/members) as one unit; a head pruning
+   * their own roster is a distinct, self-scoped, audited action and is the
+   * feature, not part of that surface. The safety here is the client
+   * confirmation plus the per-CCA guard, not a global flag.
+   *
+   * Only MEMBERS are removable — heads never reach this path. The roster splits
+   * on `isHead`, so a co-head (even one who also holds membership rows) sits in
+   * the heads list and never appears as a removable member row. Headship is
+   * managed only through grant/revoke/transfer, which maintain CH-1.
+   */
+  removeMember: identifiedProcedure
+    .input(z.object({ ccaID: z.number().int().positive(), target: removeMemberTargetSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const result = await removeCcaMember(ctx.db, input.ccaID, input.target);
+
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        targetUserID: result.targetKey,
+        action: "ccaMember.remove",
+        reason: `${scope.via}: ${result.label} — ${result.removedRows} membership row(s)${
+          result.touchedEmbedded ? " + embedded array" : ""
+        }`,
+      });
+
+      return { ccaID: input.ccaID, removedRows: result.removedRows };
     }),
 });

--- a/src/server/api/routers/ccaAdmin.ts
+++ b/src/server/api/routers/ccaAdmin.ts
@@ -9,7 +9,12 @@ import {
   isCcaManagementEnabled,
 } from "~/server/api/services/ccaScope";
 import { writeAudit } from "~/server/api/routers/admin";
-import { canonicalUserID, isCanonicalResidentID } from "~/lib/identity";
+import {
+  membershipKeysFor,
+  removeCcaMember,
+  removeMemberTargetSchema,
+} from "~/server/api/services/ccaMembers";
+import { isCanonicalResidentID } from "~/lib/identity";
 
 /**
  * CCA MANAGEMENT — admin only, and additionally behind the
@@ -59,25 +64,6 @@ function requireManageCcas(roles: readonly string[]): void {
       message: "CAPABILITY_REQUIRED:manageCcas",
     });
   }
-}
-
-/**
- * Every membership key that resolves to one person.
- *
- * REMOVAL MUST USE ALL OF THEM. UserCCA.userID is mixed-format: a person can
- * hold a legacy A-format row AND a canonical row for the same CCA. Deleting
- * only the canonical one "removes" them while their legacy row keeps them on
- * the roster — a bug that looks like the delete silently failed.
- */
-function membershipKeysFor(u: {
-  email: string;
-  userID: string | null;
-}): string[] {
-  const keys = new Set<string>();
-  const cid = canonicalUserID(u.email);
-  if (cid) keys.add(cid);
-  if (u.userID && u.userID.length > 0) keys.add(u.userID);
-  return [...keys];
 }
 
 export const ccaAdminRouter = createTRPCRouter({
@@ -336,75 +322,26 @@ export const ccaAdminRouter = createTRPCRouter({
    * from the roster), and the key set is recomputed here.
    */
   removeMember: adminProcedure
-    .input(
-      z.object({
-        ccaID: ccaIDSchema,
-        target: z.discriminatedUnion("kind", [
-          // A resolved roster entry: the User.id the roster deduped on.
-          z.object({ kind: z.literal("user"), userObjectId: z.string().min(1) }),
-          // An UNRESOLVED roster entry — a membership key matching no User row.
-          // Removable so the amber rows can actually be cleaned up.
-          z.object({ kind: z.literal("key"), key: z.string().trim().min(1) }),
-        ]),
-      }),
-    )
+    .input(z.object({ ccaID: ccaIDSchema, target: removeMemberTargetSchema }))
     .mutation(async ({ ctx, input }) => {
       await assertCcaManagementEnabled(ctx.db);
       const actorUserID = ctx.session.user.userID;
       const roles = await getUserRoles(ctx.db, actorUserID); // I-5
       requireManageCcas(roles);
 
-      let keys: string[];
-      let userObjectId: string | null = null;
-      let label: string;
-
-      if (input.target.kind === "user") {
-        const u = await ctx.db.user.findUnique({
-          where: { id: input.target.userObjectId },
-          select: { id: true, email: true, userID: true },
-        });
-        if (!u) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_USER" });
-        }
-        keys = membershipKeysFor(u);
-        userObjectId = u.id;
-        label = u.email;
-      } else {
-        keys = [input.target.key];
-        label = input.target.key;
-        // An unresolved key matches no User row by definition, so there is no
-        // embedded array to clean — (3) does not apply on this branch.
-      }
-
-      const removed = await ctx.db.userCCA.deleteMany({
-        where: { ccaID: input.ccaID, userID: { in: keys } },
-      });
-
-      // (3) the embedded array. Not declared in `model User`, so Prisma cannot
-      // express this — it has to be a raw command.
-      if (userObjectId) {
-        await ctx.db.$runCommandRaw({
-          update: "User",
-          updates: [
-            {
-              q: { _id: { $oid: userObjectId } },
-              u: { $pull: { userCCA: input.ccaID } },
-            },
-          ],
-        });
-      }
+      const result = await removeCcaMember(ctx.db, input.ccaID, input.target);
 
       await writeAudit(ctx.db, {
         actorUserID,
         actorRoles: roles,
         targetCcaID: input.ccaID,
-        targetUserID: keys[0],
+        targetUserID: result.targetKey,
         action: "ccaMember.remove",
-        reason: `${label} — ${removed.count} membership row(s)${
-          userObjectId ? " + embedded array" : ""
+        reason: `admin: ${result.label} — ${result.removedRows} membership row(s)${
+          result.touchedEmbedded ? " + embedded array" : ""
         }`,
       });
 
-      return { ccaID: input.ccaID, removedRows: removed.count };
+      return { ccaID: input.ccaID, removedRows: result.removedRows };
     }),
 });

--- a/src/server/api/services/ccaMembers.ts
+++ b/src/server/api/services/ccaMembers.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+import { canonicalUserID } from "~/lib/identity";
+
+/**
+ * The single writer that REMOVES a CCA membership.
+ *
+ * Extracted here because two call sites need identical behaviour and must never
+ * drift apart: `ccaAdmin.removeMember` (admin, behind the management kill
+ * switch) and `cca.removeMember` (a CCA head managing their own roster). A
+ * second copy of the three-target delete is exactly how one of them ends up
+ * cleaning two of the three places and silently leaving members on the roster.
+ *
+ * Authorisation is the CALLER'S job — this function trusts that its caller has
+ * already run assertHeadsCca (heads) or requireManageCcas (admin). It performs
+ * no permission check of its own, deliberately, so the guard lives with the
+ * procedure boundary rather than being duplicated here.
+ */
+
+/**
+ * How a member is named for removal. Never a client-supplied membership KEY for
+ * a resolved user — the caller hands us the User.id the roster deduped on, and
+ * we recompute the key set from the User document. The raw `key` branch exists
+ * only for UNRESOLVED roster rows (amber records matching no account), which
+ * have no User document to recompute from and would otherwise be uncleanable.
+ */
+export const removeMemberTargetSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("user"), userObjectId: z.string().min(1) }),
+  z.object({ kind: z.literal("key"), key: z.string().trim().min(1) }),
+]);
+
+export type RemoveMemberTarget = z.infer<typeof removeMemberTargetSchema>;
+
+/**
+ * Every membership key that resolves to one person.
+ *
+ * REMOVAL MUST USE ALL OF THEM. UserCCA.userID is mixed-format: a person can
+ * hold a legacy A-format row AND a canonical row for the same CCA. Deleting
+ * only the canonical one "removes" them while their legacy row keeps them on
+ * the roster — a bug that looks like the delete silently failed.
+ */
+export function membershipKeysFor(u: {
+  email: string;
+  userID: string | null;
+}): string[] {
+  const keys = new Set<string>();
+  const cid = canonicalUserID(u.email);
+  if (cid) keys.add(cid);
+  if (u.userID && u.userID.length > 0) keys.add(u.userID);
+  return [...keys];
+}
+
+export type RemoveMemberResult = {
+  removedRows: number;
+  /** Human label for the audit reason: an email, or the raw key. */
+  label: string;
+  /** The key stored on the audit row's targetUserID. */
+  targetKey: string;
+  /** Whether the embedded User.userCCA array was also cleaned. */
+  touchedEmbedded: boolean;
+};
+
+/**
+ * MEMBERSHIP LIVES IN THREE PLACES AND THIS CLEANS ALL OF THEM:
+ *   1. UserCCA rows under the CANONICAL key
+ *   2. UserCCA rows under the LEGACY A-format key (same person, other key)
+ *   3. the undeclared User.userCCA Int[] — a roster SOURCE, so a member left
+ *      in the array simply reappears after a "successful" removal
+ *
+ * Adding a member writes only (1). The asymmetry is deliberate: do not grow the
+ * legacy embedded array, but do clean it.
+ */
+export async function removeCcaMember(
+  db: PrismaClient,
+  ccaID: number,
+  target: RemoveMemberTarget,
+): Promise<RemoveMemberResult> {
+  let keys: string[];
+  let userObjectId: string | null = null;
+  let label: string;
+
+  if (target.kind === "user") {
+    const u = await db.user.findUnique({
+      where: { id: target.userObjectId },
+      // Never a bare findMany/findUnique on User: passwordHash must not be read
+      // (a Google-adapter row lacking it throws on deserialization — I-2).
+      select: { id: true, email: true, userID: true },
+    });
+    if (!u) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_USER" });
+    }
+    keys = membershipKeysFor(u);
+    userObjectId = u.id;
+    label = u.email;
+  } else {
+    // An unresolved key matches no User row by definition, so there is no
+    // embedded array to clean — (3) does not apply on this branch.
+    keys = [target.key];
+    label = target.key;
+  }
+
+  const removed = await db.userCCA.deleteMany({
+    where: { ccaID, userID: { in: keys } },
+  });
+
+  // (3) the embedded array. Not declared in `model User`, so Prisma cannot
+  // express this — it has to be a raw command.
+  if (userObjectId) {
+    await db.$runCommandRaw({
+      update: "User",
+      updates: [
+        {
+          q: { _id: { $oid: userObjectId } },
+          u: { $pull: { userCCA: ccaID } },
+        },
+      ],
+    });
+  }
+
+  return {
+    removedRows: removed.count,
+    label,
+    targetKey: keys[0] ?? "",
+    touchedEmbedded: userObjectId !== null,
+  };
+}


### PR DESCRIPTION
A CCA head can now remove a member from the **member-list** section of their dashboard (`/cca/[id]/members`). Each member row gets a remove control with a confirmation.

**No add**, by design — joining a CCA will run through the application-management system later. Removal is the only membership write a head gets in this phase.

## One implementation of the three-target delete

Membership lives in three places: `UserCCA` under the canonical key, `UserCCA` under the legacy A-format key, and the undeclared `User.userCCA` array (a roster source — a member left there just reappears). A second copy of that delete is exactly how one caller ends up cleaning two of the three and silently leaving members on the roster.

So the delete moved into `services/ccaMembers.ts` (`removeCcaMember`), and **both** the new head path and the existing `ccaAdmin.removeMember` now call it.

## The new procedure

`cca.removeMember`, guarded by `assertHeadsCca` like every other per-CCA action — a head prunes their own roster, and admin/jcrc pass on `manageCcaHeads`. Audited as `ccaMember.remove` with the scope's `via`.

**No kill switch**, unlike the admin CRUD surface. `cca.management.enabled` gates the admin create/rename/heads/members tab as one unit; a head pruning their own roster is a distinct, self-scoped, audited, per-CCA action. The safety is the confirmation dialog plus the guard, not a global flag.

## Only members, never heads

The roster splits on `isHead`, so a co-head — even one who also holds membership rows — sits in the heads list and never appears as a removable member row. Headship is managed only through grant/revoke/transfer, which keep `CcaHead` and the `cca_head` string in step (CH-1). The heads table gets no remove control; the members table does.

## Where the button appears

Threaded through `RosterTable` as an optional `onRemove`, set **only** by the head's own member list. The read-only `/admin/ccas` viewer omits it (admins prune from `/admin/manage-ccas`), so removal never shows there. The flag is UI — `cca.removeMember` re-checks server-side regardless.

## Verification

`tsc --noEmit`, `eslint` and `next build` pass. Grep gate holds: every `input.ccaID` in `cca.ts` sits in a procedure that names `assertHeadsCca`.

No test framework. **Manual QA outstanding**, the ones that matter:

- Remove a member, reload → gone; `RoleAuditLog` has `ccaMember.remove` with `targetCcaID`
- Remove a member who has a duplicate/legacy membership row → fully gone, doesn't reappear (the three-target delete)
- `api.cca.removeMember.mutate()` from the console for a CCA you don't head → `NOT_A_HEAD_OF_THIS_CCA`
- Confirm the heads table shows no remove control, and `/admin/ccas` shows none either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
