### PR TITLE
Bulk-select members for removal on the CCA member list

### DIFF
--- a/src/app/_components/RosterPanel.tsx
+++ b/src/app/_components/RosterPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { api } from "~/trpc/react";
 import {
@@ -12,21 +12,19 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
 import type { RosterEntry } from "~/server/api/services/ccaRoster";
-import RosterTable from "./RosterTable";
+import RosterTable, {
+  rosterEntryKey,
+  type RosterSelection,
+} from "./RosterTable";
 import RosterDriftNote from "./RosterDriftNote";
 
-/** How a roster entry maps to a removeMember target. */
+/** How a roster entry maps to a removeMembers target. */
 function removalTarget(entry: RosterEntry) {
   return entry.kind === "resolved"
     ? ({ kind: "user", userObjectId: entry.userId } as const)
     : ({ kind: "key", key: entry.key } as const);
-}
-
-function entryLabel(entry: RosterEntry): string {
-  return entry.kind === "resolved"
-    ? (entry.displayName ?? entry.email)
-    : `this unmatched record (${entry.key})`;
 }
 
 /**
@@ -46,11 +44,11 @@ export default function RosterPanel({
    */
   hideHeader = false,
   /**
-   * Enables the per-member remove control. Set ONLY by a head's own member-list
-   * section (/cca/[ccaID]/members); the /admin/ccas viewer stays read-only, and
-   * admins manage membership from /admin/manage-ccas. The server guard
-   * (assertHeadsCca on cca.removeMember) is the real boundary — this flag only
-   * decides whether the button is drawn.
+   * Enables member selection + bulk removal. Set ONLY by a head's own
+   * member-list section (/cca/[ccaID]/members); the /admin/ccas viewer stays
+   * read-only, and admins manage membership from /admin/manage-ccas. The server
+   * guard (assertHeadsCca on cca.removeMembers) is the real boundary — this flag
+   * only decides whether the checkboxes are drawn.
    */
   manageMembers = false,
 }: {
@@ -59,7 +57,9 @@ export default function RosterPanel({
   manageMembers?: boolean;
 }) {
   const utils = api.useUtils();
-  const [pending, setPending] = useState<RosterEntry | null>(null);
+  // Selected members, by rosterEntryKey. Confirmation opens a dialog separately.
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirming, setConfirming] = useState(false);
 
   const { data, isPending, error } = api.cca.getRoster.useQuery(
     { ccaID },
@@ -70,12 +70,31 @@ export default function RosterPanel({
     },
   );
 
-  const remove = api.cca.removeMember.useMutation({
+  const remove = api.cca.removeMembers.useMutation({
     onSuccess: async () => {
-      setPending(null);
+      setConfirming(false);
+      setSelected(new Set());
       await utils.cca.getRoster.invalidate({ ccaID });
     },
   });
+
+  // Memoised so the `?? []` fallback doesn't mint a new array every render and
+  // churn the selection memo below. react-query's `data` is reference-stable
+  // between renders until the query actually changes.
+  const members = useMemo(() => data?.members ?? [], [data]);
+
+  // Keep the selection honest: a member removed (or renamed away) on a refetch
+  // must drop out of the set, so the count and the bulk action never reference
+  // a row that is no longer on screen.
+  const liveSelected = useMemo(() => {
+    if (selected.size === 0) return selected;
+    const live = new Set<string>();
+    for (const m of members) {
+      const k = rosterEntryKey(m);
+      if (selected.has(k)) live.add(k);
+    }
+    return live;
+  }, [members, selected]);
 
   if (isPending) {
     return (
@@ -112,7 +131,46 @@ export default function RosterPanel({
     );
   }
 
-  const { cca, heads, members, drift, via } = data;
+  const { cca, heads, drift, via } = data;
+
+  const toggle = (entry: RosterEntry) => {
+    const k = rosterEntryKey(entry);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(k)) next.delete(k);
+      else next.add(k);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelected((prev) => {
+      // If everything on screen is already selected, clear; otherwise select
+      // every member currently listed.
+      const allKeys = members.map(rosterEntryKey);
+      const allSelected =
+        allKeys.length > 0 && allKeys.every((k) => prev.has(k));
+      return allSelected ? new Set() : new Set(allKeys);
+    });
+  };
+
+  const selectedCount = liveSelected.size;
+  const headerState: boolean | "indeterminate" =
+    members.length > 0 && selectedCount === members.length
+      ? true
+      : selectedCount > 0
+        ? "indeterminate"
+        : false;
+
+  const selection: RosterSelection | undefined = manageMembers
+    ? {
+        selectedKeys: liveSelected,
+        onToggle: toggle,
+        onToggleAll: toggleAll,
+        headerState,
+        disabled: remove.isPending,
+      }
+    : undefined;
 
   return (
     <div className="space-y-6">
@@ -141,43 +199,69 @@ export default function RosterPanel({
 
       <RosterDriftNote drift={drift} />
 
-      {/* Heads are NEVER removable here — headship is managed through
+      {/* Heads are NEVER selectable here — headship is managed through
           grant/revoke/transfer, which keep the CcaHead row and the cca_head
-          string in step (CH-1). So the members table gets onRemove and the
-          heads table never does. */}
+          string in step (CH-1). Only the members table gets `selection`. */}
       <RosterTable
         title="Heads"
         entries={heads}
         emptyCopy="Nobody is currently listed as a head of this CCA."
       />
+
+      {/* The bulk action bar. Reserves no space when nothing is selected, so it
+          reads as a response to the selection rather than permanent chrome. */}
+      {manageMembers && selectedCount > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+          <p className="text-sm text-emerald-900">
+            {selectedCount} selected
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={remove.isPending}
+              onClick={() => setSelected(new Set())}
+            >
+              Clear
+            </Button>
+            <Button
+              size="sm"
+              disabled={remove.isPending}
+              onClick={() => setConfirming(true)}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              Remove selected
+            </Button>
+          </div>
+        </div>
+      )}
+
       <RosterTable
         title="Members"
         entries={members}
         emptyCopy="No members are listed for this CCA yet."
-        onRemove={manageMembers ? (e) => setPending(e) : undefined}
-        removingBusy={remove.isPending}
+        selection={selection}
       />
 
       <AlertDialog
-        open={pending !== null}
+        open={confirming}
         onOpenChange={(open) => {
           if (!open && !remove.isPending) {
-            setPending(null);
+            setConfirming(false);
             remove.reset();
           }
         }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove this member?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Remove {selectedCount}{" "}
+              {selectedCount === 1 ? "member" : "members"}?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              {pending && (
-                <>
-                  {entryLabel(pending)} will be removed from this CCA. There is
-                  no way to add members back yet, so they&rsquo;d need to rejoin
-                  through the sign-up system.
-                </>
-              )}
+              {selectedCount === 1 ? "This member" : "These members"} will be
+              removed from this CCA. There&rsquo;s no way to add members back
+              yet, so they&rsquo;d need to rejoin through the sign-up system.
             </AlertDialogDescription>
           </AlertDialogHeader>
           {remove.error && (
@@ -196,15 +280,20 @@ export default function RosterPanel({
                 error. A plain button keeps it open until onSuccess closes it. */}
             <button
               type="button"
-              disabled={remove.isPending || pending === null}
+              disabled={remove.isPending || selectedCount === 0}
               onClick={() => {
-                if (pending) {
-                  remove.mutate({ ccaID, target: removalTarget(pending) });
+                const targets = members
+                  .filter((m) => liveSelected.has(rosterEntryKey(m)))
+                  .map(removalTarget);
+                if (targets.length > 0) {
+                  remove.mutate({ ccaID, targets });
                 }
               }}
               className="inline-flex h-10 items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:pointer-events-none disabled:opacity-50"
             >
-              {remove.isPending ? "Removing…" : "Remove member"}
+              {remove.isPending
+                ? "Removing…"
+                : `Remove ${selectedCount} ${selectedCount === 1 ? "member" : "members"}`}
             </button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/_components/RosterTable.tsx
+++ b/src/app/_components/RosterTable.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Trash2 } from "lucide-react";
-
 import {
   Table,
   TableBody,
@@ -10,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
-import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
 import type { RosterEntry } from "~/server/api/services/ccaRoster";
 
 /**
@@ -27,6 +25,25 @@ import type { RosterEntry } from "~/server/api/services/ccaRoster";
  * NOT filtered out: 07-cca-future.md §3 names the client-side .filter() as the
  * anti-pattern that hides the problem it is hiding from.
  */
+
+/**
+ * Stable identity for a roster entry, namespaced so a resolved User.id can
+ * never collide with an unresolved membership key. Exported so the selection
+ * state in RosterPanel and the checkboxes here agree on exactly one key per row.
+ */
+export function rosterEntryKey(entry: RosterEntry): string {
+  return entry.kind === "resolved" ? `u:${entry.userId}` : `k:${entry.key}`;
+}
+
+/** Everything RosterPanel threads in to make the members table selectable. */
+export type RosterSelection = {
+  selectedKeys: Set<string>;
+  onToggle: (entry: RosterEntry) => void;
+  onToggleAll: () => void;
+  /** true = all selected, false = none, "indeterminate" = some. */
+  headerState: boolean | "indeterminate";
+  disabled: boolean;
+};
 
 /** Head vs member, labelled on BOTH states — see the note in CcaBadges. */
 function RoleLabel({ isHead }: { isHead: boolean }) {
@@ -59,47 +76,48 @@ function unresolvedCopy(entry: Extract<RosterEntry, { kind: "unresolved" }>) {
       };
 }
 
-/** A remove control, shown only when the table is given an `onRemove`. */
-function RemoveCell({
+function SelectCell({
   entry,
-  onRemove,
-  busy,
+  selection,
 }: {
   entry: RosterEntry;
-  onRemove: (entry: RosterEntry) => void;
-  busy: boolean;
+  selection: RosterSelection;
 }) {
+  const checked = selection.selectedKeys.has(rosterEntryKey(entry));
   return (
-    <TableCell className="text-right">
-      <Button
-        variant="ghost"
-        size="sm"
-        disabled={busy}
-        aria-label="Remove member"
-        onClick={() => onRemove(entry)}
-        className="text-gray-400 hover:text-red-600"
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
+    <TableCell className="w-0 pr-0">
+      <Checkbox
+        checked={checked}
+        disabled={selection.disabled}
+        onCheckedChange={() => selection.onToggle(entry)}
+        aria-label={
+          entry.kind === "resolved"
+            ? `Select ${entry.displayName ?? entry.email}`
+            : `Select ${entry.key}`
+        }
+      />
     </TableCell>
   );
 }
 
 function EntryRow({
   entry,
-  onRemove,
-  busy,
+  selection,
 }: {
   entry: RosterEntry;
-  onRemove?: (entry: RosterEntry) => void;
-  busy: boolean;
+  selection?: RosterSelection;
 }) {
   const duplicate = entry.userCcaRowCount > 1;
+  const selected =
+    selection?.selectedKeys.has(rosterEntryKey(entry)) ?? false;
 
   if (entry.kind === "unresolved") {
     const { label, detail } = unresolvedCopy(entry);
     return (
-      <TableRow className="border-amber-200 bg-amber-50">
+      <TableRow
+        className={selected ? "bg-amber-100" : "border-amber-200 bg-amber-50"}
+      >
+        {selection && <SelectCell entry={entry} selection={selection} />}
         <TableCell className="font-medium text-amber-900">
           <span title={detail}>{label}</span>
           {duplicate && (
@@ -112,13 +130,13 @@ function EntryRow({
         <TableCell className="text-right">
           <RoleLabel isHead={entry.isHead} />
         </TableCell>
-        {onRemove && <RemoveCell entry={entry} onRemove={onRemove} busy={busy} />}
       </TableRow>
     );
   }
 
   return (
-    <TableRow>
+    <TableRow className={selected ? "bg-emerald-50" : undefined}>
+      {selection && <SelectCell entry={entry} selection={selection} />}
       <TableCell className="font-medium text-gray-900">
         {entry.displayName ?? (
           <span className="text-gray-500">No name on file</span>
@@ -136,7 +154,6 @@ function EntryRow({
       <TableCell className="text-right">
         <RoleLabel isHead={entry.isHead} />
       </TableCell>
-      {onRemove && <RemoveCell entry={entry} onRemove={onRemove} busy={busy} />}
     </TableRow>
   );
 }
@@ -146,20 +163,18 @@ export default function RosterTable({
   entries,
   emptyCopy,
   /**
-   * When provided, each row gets a remove control. Passed ONLY to the members
-   * table on a head's own dashboard — the heads table and the read-only
-   * /admin/ccas viewer leave it undefined, so the extra column and the write
-   * affordance never appear there. Removal is still authorised server-side by
-   * assertHeadsCca regardless; this only decides whether to draw the button.
+   * When provided, each row gets a selection checkbox and the header gets a
+   * select-all. Passed ONLY to the members table on a head's own dashboard —
+   * the heads table and the read-only /admin/ccas viewer leave it undefined, so
+   * the column never appears there. Removal is still authorised server-side by
+   * assertHeadsCca; this only decides whether to draw the checkboxes.
    */
-  onRemove,
-  removingBusy = false,
+  selection,
 }: {
   title: string;
   entries: RosterEntry[];
   emptyCopy: string;
-  onRemove?: (entry: RosterEntry) => void;
-  removingBusy?: boolean;
+  selection?: RosterSelection;
 }) {
   return (
     <section>
@@ -179,23 +194,27 @@ export default function RosterTable({
           <Table>
             <TableHeader>
               <TableRow>
+                {selection && (
+                  <TableHead className="w-0 pr-0">
+                    <Checkbox
+                      checked={selection.headerState}
+                      disabled={selection.disabled}
+                      onCheckedChange={() => selection.onToggleAll()}
+                      aria-label="Select all members"
+                    />
+                  </TableHead>
+                )}
                 <TableHead>Name</TableHead>
                 <TableHead>Email</TableHead>
                 <TableHead className="text-right">Role</TableHead>
-                {onRemove && (
-                  <TableHead className="text-right">
-                    <span className="sr-only">Remove</span>
-                  </TableHead>
-                )}
               </TableRow>
             </TableHeader>
             <TableBody>
               {entries.map((e) => (
                 <EntryRow
-                  key={e.kind === "resolved" ? e.userId : e.key}
+                  key={rosterEntryKey(e)}
                   entry={e}
-                  onRemove={onRemove}
-                  busy={removingBusy}
+                  selection={selection}
                 />
               ))}
             </TableBody>

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -6,6 +6,8 @@ import { getUserRoles } from "~/server/api/services/access";
 import { computeCapabilities } from "~/server/api/services/roles";
 import { assertHeadsCca } from "~/server/api/services/ccaScope";
 import { resolveRoster } from "~/server/api/services/ccaRoster";
+import { randomUUID } from "node:crypto";
+
 import { del } from "@vercel/blob";
 import { writeAudit } from "~/server/api/routers/admin";
 import {
@@ -305,7 +307,11 @@ export const ccaRouter = createTRPCRouter({
     }),
 
   /**
-   * Remove a member from a CCA a head is responsible for.
+   * Remove one or more members from a CCA a head is responsible for.
+   *
+   * BATCH, not single: `targets` is 1..N, so removing one member and removing
+   * fifty go through the same path — the roster has "a lot of members" and
+   * pruning them one round-trip at a time is the thing this avoids.
    *
    * The head-facing sibling of `ccaAdmin.removeMember`. Both wrap the SAME
    * `removeCcaMember` service, so the three-target delete (canonical UserCCA,
@@ -326,26 +332,58 @@ export const ccaRouter = createTRPCRouter({
    * the heads list and never appears as a removable member row. Headship is
    * managed only through grant/revoke/transfer, which maintain CH-1.
    */
-  removeMember: identifiedProcedure
-    .input(z.object({ ccaID: z.number().int().positive(), target: removeMemberTargetSchema }))
+  removeMembers: identifiedProcedure
+    .input(
+      z.object({
+        ccaID: z.number().int().positive(),
+        // Capped so one request cannot ask for an unbounded number of
+        // collection scans (UserCCA has no ccaID index yet). 200 comfortably
+        // exceeds any real CCA's roster; the UI can chunk if that ever changes.
+        targets: z.array(removeMemberTargetSchema).min(1).max(200),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const userID = ctx.session.user.userID;
       const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      // ONE authorisation check for the whole batch — the scope is the CCA, not
+      // the individual member.
       const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
 
-      const result = await removeCcaMember(ctx.db, input.ccaID, input.target);
+      // One batchId ties every row of this removal together in the audit log,
+      // exactly as transferCcaHead groups its two halves — so a bulk prune is
+      // one reviewable event, while each member is still an individually
+      // attributable row.
+      const batchId = randomUUID();
 
-      await writeAudit(ctx.db, {
-        actorUserID: userID,
-        actorRoles: roles,
-        targetCcaID: input.ccaID,
-        targetUserID: result.targetKey,
-        action: "ccaMember.remove",
-        reason: `${scope.via}: ${result.label} — ${result.removedRows} membership row(s)${
-          result.touchedEmbedded ? " + embedded array" : ""
-        }`,
-      });
+      let removedMembers = 0;
+      let removedRows = 0;
+      let failed = 0;
 
-      return { ccaID: input.ccaID, removedRows: result.removedRows };
+      // Per-target and independent, NOT one transaction: each removeCcaMember
+      // is idempotent, and one bad target (e.g. a User doc deleted mid-flight)
+      // must not roll back the members already removed. Failures are counted
+      // and surfaced, never silent.
+      for (const target of input.targets) {
+        try {
+          const result = await removeCcaMember(ctx.db, input.ccaID, target);
+          removedMembers += 1;
+          removedRows += result.removedRows;
+          await writeAudit(ctx.db, {
+            actorUserID: userID,
+            actorRoles: roles,
+            targetCcaID: input.ccaID,
+            targetUserID: result.targetKey,
+            action: "ccaMember.remove",
+            batchId,
+            reason: `${scope.via} (bulk): ${result.label} — ${result.removedRows} membership row(s)${
+              result.touchedEmbedded ? " + embedded array" : ""
+            }`,
+          });
+        } catch {
+          failed += 1;
+        }
+      }
+
+      return { ccaID: input.ccaID, removedMembers, removedRows, failed };
     }),
 });


### PR DESCRIPTION
A CCA head can now tick multiple members and remove them in one action, instead of a confirm per member. The member list can get long, so it's a checkbox column with a select-all header, a **"N selected"** action bar, and a single confirmation.

Builds on #56 (single-member removal), which is now on `main`.

## `removeMember` → `removeMembers`

The single procedure becomes a batch one — a single removal is just an array of one, so there's one procedure, not two. It runs **one** `assertHeadsCca` for the whole batch (the scope is the CCA, not each member), then loops the shared `removeCcaMember` service per target.

- **Audited per member, grouped by one `batchId`** — the `transferCcaHead` pattern. A bulk prune reads as one reviewable event while each member stays an individually attributable row.
- **Capped at 200 targets** — `UserCCA` has no `ccaID` index yet, so each removal is a collection scan; the cap bounds one request's work. Comfortably above any real roster.
- **Per-target and independent, not one transaction.** `removeCcaMember` is idempotent, and one bad target (e.g. a `User` doc deleted mid-flight) must not roll back the members already removed. Failures are counted and returned, never silent.

## UI

`RosterTable` gains an optional `selection` (checkboxes + a select-all header that shows an indeterminate state when some are picked), passed **only** to the members table on a head's own dashboard.

- **Heads are never selectable** — headship is grant/revoke/transfer territory (CH-1), so only the members table gets `selection`.
- **The read-only `/admin/ccas` viewer omits it**, so checkboxes never appear there.
- **The selection is reconciled against the live roster on every refetch** — a row that vanishes drops out of the set rather than leaving a phantom in the count.

The bulk bar only appears once something is selected, so it reads as a response to the selection rather than permanent chrome.

## Verification

`tsc --noEmit`, `eslint` and `next build` pass. Grep gate holds: every `input.ccaID` in `cca.ts` sits in a procedure that names `assertHeadsCca`.

No test framework. **Manual QA outstanding**, the ones that matter:

- Select several members, Remove → all gone; `RoleAuditLog` has one `ccaMember.remove` row per member, all sharing one `batchId`
- Select-all → removes everyone on the list; header checkbox shows indeterminate when only some are ticked
- Include a member with a duplicate/legacy row in the batch → fully gone, doesn't reappear
- `api.cca.removeMembers.mutate()` from the console for a CCA you don't head → `NOT_A_HEAD_OF_THIS_CCA`
- Confirm the heads table has no checkboxes, and `/admin/ccas` shows none either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
