### PR TITLE
CCA head assignment: admin assign/unassign + head-initiated handover

### DIFF
--- a/src/app/_components/HeadCandidateInput.tsx
+++ b/src/app/_components/HeadCandidateInput.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import type { HeadCandidateResult } from "~/lib/schemas/cca";
+
+export type ResolvedHead = {
+  userID: string;
+  displayName: string | null;
+  email: string | null;
+};
+
+/**
+ * Type an email / NUSNET id / matric, look it up, and preview the person before
+ * committing them as a head. Shared by the admin add-head control and the head
+ * handover dialog — both need the same "resolve, eyeball, confirm" step, and
+ * matric especially must never be applied without a human seeing who it hit.
+ *
+ * The parent decides what `onConfirm` does: grant immediately (admin) or push a
+ * chip onto the new-head list (handover). `confirmLabel` names that action.
+ */
+export default function HeadCandidateInput({
+  ccaID,
+  onConfirm,
+  confirmLabel,
+  alreadyAdded = [],
+  disabled = false,
+}: {
+  ccaID: number;
+  onConfirm: (head: ResolvedHead) => void;
+  confirmLabel: string;
+  /** userIDs already chosen/current, so a duplicate is caught before the grant. */
+  alreadyAdded?: string[];
+  disabled?: boolean;
+}) {
+  const utils = api.useUtils();
+  const [identifier, setIdentifier] = useState("");
+  const [looking, setLooking] = useState(false);
+  const [result, setResult] = useState<HeadCandidateResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const lookup = async () => {
+    const id = identifier.trim();
+    if (!id) return;
+    setLooking(true);
+    setError(null);
+    setResult(null);
+    try {
+      const r = await utils.cca.resolveHeadCandidate.fetch({
+        ccaID,
+        identifier: id,
+      });
+      setResult(r);
+    } catch {
+      setError("That lookup didn't work. Try again.");
+    } finally {
+      setLooking(false);
+    }
+  };
+
+  const reset = () => {
+    setIdentifier("");
+    setResult(null);
+    setError(null);
+  };
+
+  const found = result?.status === "FOUND" ? result : null;
+  const duplicate = found ? alreadyAdded.includes(found.userID) : false;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="flex-1 space-y-1.5">
+          <label
+            htmlFor={`head-lookup-${ccaID}`}
+            className="block text-sm font-medium text-gray-700"
+          >
+            Add a head
+          </label>
+          <Input
+            id={`head-lookup-${ccaID}`}
+            value={identifier}
+            disabled={disabled || looking}
+            placeholder="NUSNET id, email, or matric"
+            onChange={(e) => {
+              setIdentifier(e.target.value);
+              setResult(null);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void lookup();
+              }
+            }}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled || looking || !identifier.trim()}
+          onClick={() => void lookup()}
+        >
+          {looking ? "Looking up…" : "Look up"}
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {result && result.status !== "FOUND" && (
+        <p className="text-sm text-amber-700">
+          {result.status === "NOT_FOUND" &&
+            "No account matches that. Check the id, email, or matric."}
+          {result.status === "AMBIGUOUS" &&
+            "That matric matches more than one account, so it can't be used. Try their NUSNET id or email."}
+          {result.status === "NOT_SIGNED_IN" &&
+            "That person has an id but hasn't signed in to the app yet, so they can't be made a head until they do."}
+        </p>
+      )}
+
+      {found && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-gray-900">
+              {found.displayName ?? found.email ?? found.userID}
+            </p>
+            <p className="truncate text-xs text-gray-500">
+              {found.email ?? found.userID}
+            </p>
+          </div>
+          {duplicate ? (
+            <span className="text-xs text-gray-400">Already added</span>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              disabled={disabled}
+              onClick={() => {
+                onConfirm({
+                  userID: found.userID,
+                  displayName: found.displayName,
+                  email: found.email,
+                });
+                reset();
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/ccas/_components/CcaHeadsManager.tsx
+++ b/src/app/admin/ccas/_components/CcaHeadsManager.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import HeadCandidateInput from "~/app/_components/HeadCandidateInput";
+
+/**
+ * Assign and unassign a CCA's heads, for admin/JCRC in the CCAs tab.
+ *
+ * Uses the shipped admin.grantCcaHead / revokeCcaHead (roleManagerProcedure,
+ * manageCcaHeads) — NOT the ccaAdmin management surface, so it is NOT behind the
+ * cca.management.enabled kill switch. Lists heads from admin.listCcaHeads, which
+ * returns clean canonical userIDs.
+ */
+export default function CcaHeadsManager({ ccaID }: { ccaID: number }) {
+  const utils = api.useUtils();
+  const heads = api.admin.listCcaHeads.useQuery({ ccaID }, { retry: false });
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.admin.listCcaHeads.invalidate({ ccaID }),
+      utils.cca.getRoster.invalidate({ ccaID }),
+    ]);
+  };
+
+  const grant = api.admin.grantCcaHead.useMutation({ onSuccess: refresh });
+  const revoke = api.admin.revokeCcaHead.useMutation({ onSuccess: refresh });
+
+  const rows = heads.data ?? [];
+  const error = grant.error?.message ?? revoke.error?.message ?? null;
+
+  return (
+    <section className="space-y-3 rounded-lg border border-gray-200 bg-white p-5">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+        Heads
+        <span className="ml-2 font-normal normal-case tracking-normal text-gray-400">
+          {rows.length}
+        </span>
+      </h2>
+
+      {rows.length > 3 && (
+        <p className="text-xs text-amber-700">
+          This CCA has {rows.length} heads. Allowed, but worth a double-check.
+        </p>
+      )}
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          Nobody heads this CCA, so nobody can see its roster from their own CCA
+          page. Add a head below.
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200">
+          {rows.map((h) => (
+            <li
+              key={h.userID}
+              className="flex items-center justify-between gap-3 px-3 py-2"
+            >
+              <span className="font-mono text-sm text-gray-900">
+                {h.userID}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={revoke.isPending}
+                className="text-gray-400 hover:text-red-600"
+                onClick={() => revoke.mutate({ ccaID, userID: h.userID })}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <HeadCandidateInput
+        ccaID={ccaID}
+        confirmLabel="Add as head"
+        alreadyAdded={rows.map((h) => h.userID)}
+        disabled={grant.isPending}
+        onConfirm={(head) => grant.mutate({ ccaID, userID: head.userID })}
+      />
+
+      {error && (
+        <p className="text-sm text-red-600">
+          {error === "CANNOT_MODIFY_AN_ADMIN"
+            ? "You can't change an admin's roles."
+            : "That didn't work. Try again."}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/admin/ccas/page.tsx
+++ b/src/app/admin/ccas/page.tsx
@@ -6,17 +6,15 @@ import CcaPicker, {
   type CcaOption,
 } from "~/app/admin/_components/bulk/CcaPicker";
 import RosterPanel from "~/app/_components/RosterPanel";
+import CcaHeadsManager from "./_components/CcaHeadsManager";
 
 /**
- * Browse any CCA's roster. READ-ONLY.
+ * Browse any CCA's roster, and assign/unassign its heads.
  *
- * Reuses CcaPicker (built for the bulk head wizard) and RosterPanel (built for
- * /cca/[ccaID]) verbatim, and calls the SAME cca.getRoster procedure — the
- * object-scope guard simply passes on the manageCcaHeads capability here rather
- * than on a headship row.
- *
- * No new query, no new table, no new guard. If this page ever needs its own,
- * that is a signal something upstream was designed wrong.
+ * The roster reuses RosterPanel + cca.getRoster (the object-scope guard passes
+ * on manageCcaHeads here). Head management uses the shipped admin.grantCcaHead /
+ * revokeCcaHead, which are NOT behind the cca.management.enabled kill switch —
+ * that switch gates the separate /admin/manage-ccas CRUD surface.
  */
 export default function AdminCcasPage() {
   const [selected, setSelected] = useState<CcaOption | null>(null);
@@ -36,7 +34,10 @@ export default function AdminCcasPage() {
       />
 
       {selected ? (
-        <RosterPanel ccaID={selected.ccaID} />
+        <>
+          <CcaHeadsManager ccaID={selected.ccaID} />
+          <RosterPanel ccaID={selected.ccaID} />
+        </>
       ) : (
         <p className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-sm text-gray-500">
           Choose a CCA above to see who&rsquo;s in it.

--- a/src/app/cca/_components/CcaHandoverDialog.tsx
+++ b/src/app/cca/_components/CcaHandoverDialog.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { X } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+import HeadCandidateInput, {
+  type ResolvedHead,
+} from "~/app/_components/HeadCandidateInput";
+import type { RosterEntry } from "~/server/api/services/ccaRoster";
+
+/**
+ * Hand a CCA over: name the new head(s), preview, and OVERWRITE the head set to
+ * exactly that selection.
+ *
+ * A head who doesn't include themselves stops being a head — the whole point of
+ * handing over. The dialog makes that consequence loud, since it can't be undone
+ * from here (only an admin/JCRC can re-grant).
+ */
+
+/** Canonical userID candidates a head roster entry could match. */
+function headKeys(entry: RosterEntry): string[] {
+  return entry.kind === "resolved" ? entry.membershipKeys : [entry.key];
+}
+
+function headLabel(entry: RosterEntry): string {
+  return entry.kind === "resolved"
+    ? (entry.displayName ?? entry.email ?? entry.membershipKeys[0] ?? "a head")
+    : entry.key;
+}
+
+export default function CcaHandoverDialog({
+  ccaID,
+  currentHeads,
+  open,
+  onOpenChange,
+}: {
+  ccaID: number;
+  currentHeads: RosterEntry[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: session } = useSession();
+  const myUserID = session?.user?.userID ?? null;
+  const utils = api.useUtils();
+
+  const [selected, setSelected] = useState<ResolvedHead[]>([]);
+
+  const handover = api.cca.handoverHeads.useMutation({
+    onSuccess: async (res) => {
+      await Promise.all([
+        utils.cca.getRoster.invalidate({ ccaID }),
+        utils.cca.listMine.invalidate(),
+      ]);
+      // If the initiator handed themselves out, the layout's next live-role read
+      // closes /cca. Send them home rather than leaving a page that's about to
+      // 403 under them.
+      if (res.selfRemoved) window.location.href = "/";
+      else onOpenChange(false);
+    },
+  });
+
+  const selectedIDs = selected.map((s) => s.userID);
+  const iAmKept = myUserID !== null && selectedIDs.includes(myUserID);
+
+  // Which current heads this handover would remove — matched by any of their
+  // canonical keys against the new selection.
+  const removed = currentHeads.filter(
+    (h) => !headKeys(h).some((k) => selectedIDs.includes(k)),
+  );
+
+  const addSelf = () => {
+    if (myUserID && !selectedIDs.includes(myUserID)) {
+      setSelected((prev) => [
+        ...prev,
+        { userID: myUserID, displayName: "You", email: null },
+      ]);
+    }
+  };
+
+  const reset = () => {
+    setSelected([]);
+    handover.reset();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o && handover.isPending) return;
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Hand over this CCA</DialogTitle>
+          <DialogDescription>
+            Choose who should head this CCA from now on. This replaces the
+            current heads entirely — anyone not on the new list stops being a
+            head.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <HeadCandidateInput
+            ccaID={ccaID}
+            confirmLabel="Add"
+            alreadyAdded={selectedIDs}
+            disabled={handover.isPending}
+            onConfirm={(head) => setSelected((prev) => [...prev, head])}
+          />
+
+          {myUserID && !iAmKept && (
+            <button
+              type="button"
+              className="text-xs font-medium text-emerald-700 underline underline-offset-2"
+              onClick={addSelf}
+            >
+              Keep me as a head too
+            </button>
+          )}
+
+          {/* New heads */}
+          <div>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              New heads ({selected.length})
+            </p>
+            {selected.length === 0 ? (
+              <p className="rounded-md border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-400">
+                Nobody added yet. Look someone up above.
+              </p>
+            ) : (
+              <ul className="flex flex-wrap gap-2">
+                {selected.map((s) => (
+                  <li
+                    key={s.userID}
+                    className="flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 py-1 pl-3 pr-1.5 text-sm text-emerald-900"
+                  >
+                    <span className="max-w-[12rem] truncate">
+                      {s.displayName ?? s.email ?? s.userID}
+                      {s.userID === myUserID && " (you)"}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label="Remove from list"
+                      disabled={handover.isPending}
+                      onClick={() =>
+                        setSelected((prev) =>
+                          prev.filter((p) => p.userID !== s.userID),
+                        )
+                      }
+                      className="rounded-full p-0.5 text-emerald-500 hover:bg-emerald-100 hover:text-emerald-800"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Removed preview */}
+          {selected.length > 0 && removed.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+              <p className="text-xs font-medium text-amber-900">
+                No longer heads after this
+              </p>
+              <p className="mt-0.5 text-sm text-amber-800">
+                {removed.map(headLabel).join(", ")}
+              </p>
+            </div>
+          )}
+
+          {myUserID && selected.length > 0 && !iAmKept && (
+            <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              You&rsquo;re not on the new list, so you&rsquo;ll stop being a head
+              and lose access to this page. Only an admin or the JCRC can add you
+              back.
+            </p>
+          )}
+
+          {handover.error && (
+            <p className="text-sm text-red-600">
+              {handover.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+                ? "You're no longer a head of this CCA."
+                : handover.error.message === "SUCCESSOR_HAS_NOT_SIGNED_IN"
+                  ? "One of the people you picked hasn't signed in yet."
+                  : "That didn't work. Try again."}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            disabled={handover.isPending}
+            onClick={() => {
+              reset();
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={handover.isPending || selected.length === 0}
+            onClick={() =>
+              handover.mutate({ ccaID, newHeadUserIDs: selectedIDs })
+            }
+          >
+            {handover.isPending ? "Handing over…" : "Hand over"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/cca/_components/CcaOverview.tsx
+++ b/src/app/cca/_components/CcaOverview.tsx
@@ -3,9 +3,13 @@
 import Link from "next/link";
 import Image from "next/image";
 
+import { useState } from "react";
+
 import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
 import RosterDriftNote from "~/app/_components/RosterDriftNote";
 import StatTile from "./StatTile";
+import CcaHandoverDialog from "./CcaHandoverDialog";
 
 /**
  * The dashboard landing section: how many heads, how many members, who the
@@ -24,6 +28,7 @@ export default function CcaOverview({ ccaID }: { ccaID: number }) {
   const roster = api.cca.getRoster.useQuery({ ccaID }, { retry: false });
   const mine = api.cca.listMine.useQuery(undefined, { retry: false });
   const profile = api.cca.getProfile.useQuery({ ccaID }, { retry: false });
+  const [handoverOpen, setHandoverOpen] = useState(false);
 
   if (roster.error) {
     if (roster.error.message === "NOT_A_HEAD_OF_THIS_CCA") {
@@ -124,9 +129,20 @@ export default function CcaOverview({ ccaID }: { ccaID: number }) {
 
       {/* Co-heads. Already resolved by the roster query — no extra call. */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
-          Heads
-        </h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Heads
+          </h2>
+          {data && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setHandoverOpen(true)}
+            >
+              Hand over
+            </Button>
+          )}
+        </div>
         {loading ? (
           <div className="h-20 animate-pulse rounded-lg bg-gray-200" />
         ) : data && data.heads.length > 0 ? (
@@ -199,6 +215,15 @@ export default function CcaOverview({ ccaID }: { ccaID: number }) {
           .
         </p>
       </section>
+
+      {data && (
+        <CcaHandoverDialog
+          ccaID={ccaID}
+          currentHeads={data.heads}
+          open={handoverOpen}
+          onOpenChange={setHandoverOpen}
+        />
+      )}
     </div>
   );
 }

--- a/src/lib/schemas/cca.ts
+++ b/src/lib/schemas/cca.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isCanonicalResidentID } from "~/lib/identity";
+
 /**
  * Shared CCA-profile validation. Deliberately NOT under `src/server/`: the
  * client mirrors this validation with a real `safeParse`, so it needs the
@@ -9,6 +11,51 @@ import { z } from "zod";
  */
 
 export const CCA_DESCRIPTION_MAX = 1000;
+
+/* -------------------------------------------------------------------------- */
+/* Head assignment / handover                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A canonical userID as produced by canonicalUserID(email).
+ *
+ * DO NOT constrain this to /^E\d{7}$/. Non-E-format @u.nus.edu localparts are
+ * REAL in this database — `g.s_samuel@u.nus.edu` canonicalises to "G.S_SAMUEL".
+ * Reintroducing the regex re-opens lockout mode L-27. (Mirrors the local schema
+ * in ccaAdmin.ts; kept here because both the admin and head head-assignment
+ * flows need it.)
+ */
+export const canonicalUserIDSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .refine(isCanonicalResidentID, "not a canonical @u.nus.edu userID");
+
+/** Upper bound on heads set in one handover — a soft sanity cap, not policy. */
+export const MAX_HEADS_PER_HANDOVER = 20;
+
+export const handoverHeadsInput = z.object({
+  ccaID: z.number().int().positive(),
+  // >= 1 is the real rule: overwriting to zero heads is the unrecoverable
+  // headless state, refused here and again server-side (NO_HEADS_LEFT).
+  newHeadUserIDs: z
+    .array(canonicalUserIDSchema)
+    .min(1)
+    .max(MAX_HEADS_PER_HANDOVER),
+});
+
+export type HandoverHeadsInput = z.input<typeof handoverHeadsInput>;
+
+/**
+ * The shape `resolveHeadCandidate` returns. A discriminated union the UI renders
+ * without interpreting error strings — FOUND carries the human the head must
+ * eyeball before confirming.
+ */
+export type HeadCandidateResult =
+  | { status: "FOUND"; userID: string; displayName: string | null; email: string | null }
+  | { status: "NOT_FOUND" }
+  | { status: "AMBIGUOUS" } // a matric matched more than one account
+  | { status: "NOT_SIGNED_IN"; userID: string }; // resolves, but never logged in
 
 /* -------------------------------------------------------------------------- */
 /* Image uploads                                                               */

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -726,6 +726,68 @@ async function writeCcaHeadString(
 }
 
 /**
+ * OVERWRITE a CCA's head set to exactly `newHeadUserIDs`.
+ *
+ * The primitive behind head-initiated handover (`cca.handoverHeads`). It reuses
+ * `writeCcaHeadString` above — the SOLE writer of the `cca_head` string — so
+ * CH-1 (`holds "cca_head"` iff `has >= 1 CcaHead row`) cannot drift, exactly as
+ * grantCcaHead / revokeCcaHead / transferCcaHead maintain it.
+ *
+ * BOUNDED AUTHORITY. It touches only the `cca_head` string and `CcaHead` rows
+ * for this one ccaID; every other stored role is carried through verbatim by
+ * writeCcaHeadString. So a caller can neither escalate nor strip
+ * admin/jcrc/resident from anyone — which is why the head path that calls this
+ * needs no admin-target guard (assertMayManageCcaHeadOf): the escalation that
+ * guard prevents is not expressible here.
+ *
+ * GRANT-BEFORE-REVOKE, like transferCcaHead: a crash mid-way must leave a CCA
+ * with EXTRA heads, never ZERO. The caller is responsible for refusing an empty
+ * `newHeadUserIDs` (a headless CCA is the unrecoverable state).
+ *
+ * Callers audit the returned diff under one batchId; this function writes no
+ * audit row of its own.
+ */
+export async function setCcaHeads(
+  db: PrismaClient,
+  ccaID: number,
+  newHeadUserIDs: readonly string[],
+  actorUserID: string,
+): Promise<{ granted: string[]; revoked: string[]; batchId: string }> {
+  const desiredSet = new Set(newHeadUserIDs);
+  const batchId = randomUUID();
+
+  const current = await db.ccaHead.findMany({
+    where: { ccaID },
+    select: { userID: true },
+  });
+  const currentSet = new Set(current.map((r) => r.userID));
+
+  const toGrant = [...desiredSet].filter((u) => !currentSet.has(u));
+  const toRevoke = [...currentSet].filter((u) => !desiredSet.has(u));
+
+  await db.$transaction(async (tx) => {
+    // Grants first — see the ordering note above.
+    for (const userID of toGrant) {
+      await tx.ccaHead.upsert({
+        where: { userID_ccaID: { userID, ccaID } },
+        create: { userID, ccaID, grantedBy: actorUserID },
+        update: { grantedBy: actorUserID },
+      });
+      await writeCcaHeadString(tx, userID, true, actorUserID);
+    }
+    for (const userID of toRevoke) {
+      await tx.ccaHead.deleteMany({ where: { userID, ccaID } });
+      // CH-1: the string goes only when the LAST scope goes. A head of two CCAs
+      // handed out of one keeps the role.
+      const remaining = await tx.ccaHead.count({ where: { userID } });
+      await writeCcaHeadString(tx, userID, remaining > 0, actorUserID);
+    }
+  });
+
+  return { granted: toGrant, revoked: toRevoke, batchId };
+}
+
+/**
  * G3 for the CCA path. The generic guards are not reachable from here, so the
  * target guard is re-stated: a jcrc must not be able to reach an admin's role
  * document through the CCA endpoints either.

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -3,18 +3,24 @@ import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, identifiedProcedure } from "~/server/api/trpc";
 import { getUserRoles } from "~/server/api/services/access";
-import { computeCapabilities } from "~/server/api/services/roles";
+import { computeCapabilities, isEFormatUserID } from "~/server/api/services/roles";
 import { assertHeadsCca } from "~/server/api/services/ccaScope";
 import { resolveRoster } from "~/server/api/services/ccaRoster";
 import { randomUUID } from "node:crypto";
 
 import { del } from "@vercel/blob";
-import { writeAudit } from "~/server/api/routers/admin";
+import { setCcaHeads, writeAudit } from "~/server/api/routers/admin";
 import {
   removeCcaMember,
   removeMemberTargetSchema,
 } from "~/server/api/services/ccaMembers";
-import { ccaProfileInput } from "~/lib/schemas/cca";
+import {
+  ccaProfileInput,
+  handoverHeadsInput,
+  type HeadCandidateResult,
+} from "~/lib/schemas/cca";
+import { MATRIC_RE } from "~/lib/schemas/profile";
+import { canonicalUserID } from "~/lib/identity";
 
 /**
  * CCA-head-facing procedures, scoped per-CCA rather than per-role.
@@ -385,5 +391,168 @@ export const ccaRouter = createTRPCRouter({
       }
 
       return { ccaID: input.ccaID, removedMembers, removedRows, failed };
+    }),
+
+  /**
+   * Resolve a typed identifier (email / NUSNET id / matric) to an account, for
+   * the handover and admin add-head previews.
+   *
+   * Guarded by assertHeadsCca so it is NOT an open directory oracle: only a head
+   * of this CCA (or a manager) can resolve identities through it. The name/email
+   * it returns is what the human eyeballs before committing a headship change.
+   *
+   * Never guesses. A matric matching more than one account is AMBIGUOUS and
+   * refused — matric is self-asserted and UserMatric.matric is not unique.
+   */
+  resolveHeadCandidate: identifiedProcedure
+    .input(
+      z.object({
+        ccaID: z.number().int().positive(),
+        identifier: z.string().trim().min(1).max(120),
+      }),
+    )
+    .query(async ({ ctx, input }): Promise<HeadCandidateResult> => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const raw = input.identifier.trim();
+
+      // Resolve to a canonical userID by tier. Matric is the only tier that can
+      // be AMBIGUOUS, because it is looked up in a non-unique collection.
+      let candidateID: string | null = null;
+      if (raw.includes("@")) {
+        candidateID = canonicalUserID(raw); // email → canonical, or null
+      } else if (isEFormatUserID(raw.toUpperCase())) {
+        candidateID = raw.toUpperCase(); // NUSNET id is already canonical
+      } else if (MATRIC_RE.test(raw.toUpperCase())) {
+        const rows = await ctx.db.userMatric.findMany({
+          where: { matric: raw.toUpperCase() },
+          select: { userID: true },
+        });
+        if (rows.length > 1) return { status: "AMBIGUOUS" };
+        candidateID = rows[0]?.userID ?? null;
+      }
+
+      if (candidateID === null) return { status: "NOT_FOUND" };
+
+      // Must have signed in: a UserRole row is written at account creation and
+      // topped up every session, so "has a row" is a reliable proxy for "has
+      // logged in at least once" (mirrors transferCcaHead's H3 successor gate).
+      const hasSignedIn = await ctx.db.userRole.findUnique({
+        where: { userID: candidateID },
+        select: { userID: true },
+      });
+      if (!hasSignedIn) return { status: "NOT_SIGNED_IN", userID: candidateID };
+
+      // Best-effort display. There is no reverse canonical→User query, so guess
+      // the email like admin.listUsers does, and fall back to the stored key.
+      const user = await ctx.db.user.findFirst({
+        where: {
+          OR: [
+            {
+              email: {
+                equals: `${candidateID.toLowerCase()}@u.nus.edu`,
+                mode: "insensitive",
+              },
+            },
+            { userID: candidateID },
+          ],
+        },
+        // Never a bare read: passwordHash must not leave the server, and a
+        // Google-adapter row lacking it throws on deserialization (I-2).
+        select: { displayName: true, email: true },
+      });
+
+      return {
+        status: "FOUND",
+        userID: candidateID,
+        displayName: user?.displayName ?? null,
+        email: user?.email ?? null,
+      };
+    }),
+
+  /**
+   * HAND OVER — overwrite this CCA's head set to exactly `newHeadUserIDs`.
+   *
+   * The first head-INITIATED change to headship (07-cca-future.md §6.6 deferred
+   * this until an object-scoped guard existed; assertHeadsCca is that guard). A
+   * head who omits themselves stops being a head — that is the point of handing
+   * over; to stay, they include themselves.
+   *
+   * setCcaHeads is the write primitive and shares writeCcaHeadString with
+   * grant/revoke/transfer, so CH-1 holds and no other role is touched — which is
+   * why this head-facing path needs no admin-target guard (see setCcaHeads).
+   */
+  handoverHeads: identifiedProcedure
+    .input(handoverHeadsInput)
+    .mutation(async ({ ctx, input }) => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const desired = [...new Set(input.newHeadUserIDs)];
+      // Belt-and-braces: the schema already enforces >= 1, but overwriting to
+      // zero heads is the one unrecoverable state, so refuse it explicitly too.
+      if (desired.length === 0) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "NO_HEADS_LEFT" });
+      }
+
+      // Every incoming head must have signed in — re-checked server-side, never
+      // trusting the client's preview. A userID with no UserRole row cannot be
+      // made a head (else a CCA is handed to someone who may never appear).
+      const rows = await ctx.db.userRole.findMany({
+        where: { userID: { in: desired } },
+        select: { userID: true },
+      });
+      const signedIn = new Set(rows.map((r) => r.userID));
+      const missing = desired.filter((u) => !signedIn.has(u));
+      if (missing.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SUCCESSOR_HAS_NOT_SIGNED_IN",
+        });
+      }
+
+      const { granted, revoked, batchId } = await setCcaHeads(
+        ctx.db,
+        input.ccaID,
+        desired,
+        userID,
+      );
+
+      // One audit row per change, all under the batchId — a handover reads as a
+      // single event while each grant/revoke stays individually attributable.
+      for (const target of granted) {
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetUserID: target,
+          targetCcaID: input.ccaID,
+          action: "ccaHead.grant",
+          batchId,
+          reason: `${scope.via} (handover)`,
+        });
+      }
+      for (const target of revoked) {
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetUserID: target,
+          targetCcaID: input.ccaID,
+          action: "ccaHead.revoke",
+          batchId,
+          reason: `${scope.via} (handover)`,
+        });
+      }
+
+      return {
+        ccaID: input.ccaID,
+        granted: granted.length,
+        revoked: revoked.length,
+        // The initiator lost their headship unless they kept themselves — the
+        // UI uses this to warn that /cca is about to close for them.
+        selfRemoved: revoked.includes(userID),
+      };
     }),
 });


### PR DESCRIPTION
Two gaps in head management, closed together.

## Admin — assign/unassign heads in the CCAs tab

The grant/revoke backend already existed, but its only UI was in `/admin/manage-ccas`, behind the `cca.management.enabled` kill switch (default off) — so in practice nobody could touch heads. `/admin/ccas` (gated on `viewAnyCcaRoster`, no kill switch) now has a heads manager: lists current heads from `admin.listCcaHeads`, adds via `admin.grantCcaHead`, removes via `admin.revokeCcaHead`. All shipped, audited procedures — no new write path.

## Head — a **Hand over** button

On the head dashboard. The head names the new head(s), previews who resolves, and on confirm the head set is **overwritten** to exactly that selection. A head who omits themselves stops being a head — the point of handing over — and if they hand themselves out, they're sent home since `/cca` closes for them on the next live-role read. The dialog makes both consequences loud.

This is the head-**initiated** headship change `07-cca-future.md §6.6` deferred until an object-scoped guard existed. `assertHeadsCca` is that guard.

## The write primitive keeps CH-1 intact

`setCcaHeads` (new, in `admin.ts` beside `writeCcaHeadString`) overwrites a CCA's heads in one `$transaction`, **grant-before-revoke** so a crash never leaves zero heads. It reuses `writeCcaHeadString` — the **sole** writer of the `cca_head` string — so CH-1 (`string` ⟺ `≥1 CcaHead row`) holds and **no other role is touched**.

That structural property is why the head path needs **no admin-target guard**: `setCcaHeads` can only move the `cca_head` bit for one ccaID, so a head can neither escalate nor strip `admin`/`jcrc`/`resident` from anyone. QA item 11 asserts this on the `UserRole` row.

## Guards

- **New heads must have signed in** (a `UserRole` row exists), re-checked server-side, never trusting the client preview — mirrors the §6.4 successor gate (H3).
- **Never zero heads** — overwriting to an empty set is refused (`NO_HEADS_LEFT`), client and server.
- **`resolveHeadCandidate`** (email / NUSNET id / matric → account) is guarded by `assertHeadsCca` so it's not an open directory oracle.
- **Matric** is supported (you asked for it): the preview shows the resolved person to eyeball, and a matric matching two accounts is `AMBIGUOUS` and refused, never guessed. It's self-asserted, so the human confirmation is the mitigation.
- Handover audits one `ccaHead.grant`/`ccaHead.revoke` per change under one `batchId`.

## Verification

`tsc --noEmit`, `eslint`, `next build` pass. No role branching under `src/app/cca/`; every `input.ccaID` procedure in `cca.ts` names `assertHeadsCca`; `setCcaHeads` writes `UserRole` only through `writeCcaHeadString`.

No test framework. **Manual QA outstanding**, the ones that matter:

- Head hands over to two others (not self) → they become the only heads; initiator + old heads revoked; `/cca` closes for the initiator on reload
- Hand over including self → self kept, others replaced
- New head who never signed in → `SUCCESSOR_HAS_NOT_SIGNED_IN`, not granted
- After handover: one `ccaHead.grant`/`revoke` per change, all one `batchId`; **an affected admin/jcrc keeps every non-`cca_head` role** (the invariant that lets the head path skip the admin guard)
- A head of two CCAs handed out of one → keeps `cca_head` (still heads the other)
- `handoverHeads` from console for a CCA you don't head → `NOT_A_HEAD_OF_THIS_CCA`
- Admin adds a head via matric → preview shows the person; a matric matching two accounts → `AMBIGUOUS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
