### PR TITLE
Show head names in the admin heads manager, not bare NUSNET ids

### DIFF
--- a/src/app/admin/ccas/_components/CcaHeadsManager.tsx
+++ b/src/app/admin/ccas/_components/CcaHeadsManager.tsx
@@ -14,11 +14,13 @@ import HeadCandidateInput from "~/app/_components/HeadCandidateInput";
  */
 export default function CcaHeadsManager({ ccaID }: { ccaID: number }) {
   const utils = api.useUtils();
-  const heads = api.admin.listCcaHeads.useQuery({ ccaID }, { retry: false });
+  // listHeads (not admin.listCcaHeads) so each head shows a NAME, not a bare
+  // NUSNET id — while still returning the canonical userID that Remove needs.
+  const heads = api.cca.listHeads.useQuery({ ccaID }, { retry: false });
 
   const refresh = async () => {
     await Promise.all([
-      utils.admin.listCcaHeads.invalidate({ ccaID }),
+      utils.cca.listHeads.invalidate({ ccaID }),
       utils.cca.getRoster.invalidate({ ccaID }),
     ]);
   };
@@ -26,7 +28,7 @@ export default function CcaHeadsManager({ ccaID }: { ccaID: number }) {
   const grant = api.admin.grantCcaHead.useMutation({ onSuccess: refresh });
   const revoke = api.admin.revokeCcaHead.useMutation({ onSuccess: refresh });
 
-  const rows = heads.data ?? [];
+  const rows = heads.data?.heads ?? [];
   const error = grant.error?.message ?? revoke.error?.message ?? null;
 
   return (
@@ -56,14 +58,22 @@ export default function CcaHeadsManager({ ccaID }: { ccaID: number }) {
               key={h.userID}
               className="flex items-center justify-between gap-3 px-3 py-2"
             >
-              <span className="font-mono text-sm text-gray-900">
-                {h.userID}
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium text-gray-900">
+                  {h.displayName ?? h.email ?? h.userID}
+                </span>
+                {/* Always show the NUSNET id underneath — it's the thing being
+                    written to CcaHead, and worth confirming even when a name
+                    resolved. When nothing resolved, this is the only label. */}
+                <span className="block truncate font-mono text-xs text-gray-400">
+                  {h.email ? `${h.email} · ${h.userID}` : h.userID}
+                </span>
               </span>
               <Button
                 variant="ghost"
                 size="sm"
                 disabled={revoke.isPending}
-                className="text-gray-400 hover:text-red-600"
+                className="shrink-0 text-gray-400 hover:text-red-600"
                 onClick={() => revoke.mutate({ ccaID, userID: h.userID })}
               >
                 Remove

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -404,6 +404,70 @@ export const ccaRouter = createTRPCRouter({
    * Never guesses. A matric matching more than one account is AMBIGUOUS and
    * refused — matric is self-asserted and UserMatric.matric is not unique.
    */
+  /**
+   * The CCA's heads WITH resolved names, for the admin heads manager.
+   *
+   * admin.listCcaHeads returns raw CcaHead rows — just the canonical userID — so
+   * a manager sees "E1714044", not a person. This resolves each head's name the
+   * same way the roster does (there is no reverse canonical→User query, so guess
+   * the email and also match the stored key), while still returning the
+   * authoritative CcaHead.userID that Remove needs.
+   *
+   * Guarded by assertHeadsCca, so it works for a manager (manageCcaHeads) on any
+   * CCA and for a head on their own — the same gate as the rest of this router.
+   */
+  listHeads: identifiedProcedure
+    .input(z.object({ ccaID: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const heads = await ctx.db.ccaHead.findMany({
+        where: { ccaID: input.ccaID },
+        select: { userID: true, grantedAt: true },
+        orderBy: { userID: "asc" },
+      });
+      if (heads.length === 0) return { heads: [] };
+
+      const keys = heads.map((h) => h.userID);
+      const guessedEmails = keys.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+
+      const [byEmail, byStored] = await Promise.all([
+        ctx.db.user.findMany({
+          where: { email: { in: guessedEmails, mode: "insensitive" } },
+          // Never a bare read: passwordHash must not leave the server (I-2).
+          select: { email: true, displayName: true, userID: true },
+        }),
+        ctx.db.user.findMany({
+          where: { userID: { in: keys } },
+          select: { email: true, displayName: true, userID: true },
+        }),
+      ]);
+
+      // key → display, canonicalising the email-matched rows and dropping nulls
+      // so a non-NUS row can't land under a "" key (the listUsers guard).
+      const byKey = new Map<string, { displayName: string | null; email: string | null }>();
+      for (const u of byEmail) {
+        const cid = canonicalUserID(u.email);
+        if (cid) byKey.set(cid, { displayName: u.displayName, email: u.email });
+      }
+      for (const u of byStored) {
+        if (u.userID && !byKey.has(u.userID)) {
+          byKey.set(u.userID, { displayName: u.displayName, email: u.email });
+        }
+      }
+
+      return {
+        heads: heads.map((h) => ({
+          userID: h.userID,
+          displayName: byKey.get(h.userID)?.displayName ?? null,
+          email: byKey.get(h.userID)?.email ?? null,
+          grantedAt: h.grantedAt,
+        })),
+      };
+    }),
+
   resolveHeadCandidate: identifiedProcedure
     .input(
       z.object({


### PR DESCRIPTION
The `/admin/ccas` heads list showed `E1714044` instead of a name, because it read from `admin.listCcaHeads` — which returns raw `CcaHead` rows (just the canonical userID).

Adds `cca.listHeads`, which resolves each head's name the same way the roster does — there's no reverse canonical→User query, so it guesses the `@u.nus.edu` email and also matches the stored key — while still returning the authoritative `CcaHead.userID` that Remove needs. Guarded by `assertHeadsCca` like the rest of the router (so it works for managers on any CCA).

Each row now shows the **display name**, with the email and NUSNET id underneath. The id stays visible on purpose: it's the value written to `CcaHead`, worth confirming, and it's the only label when no account resolves (an amber-adjacent case the roster already handles this way).

`tsc`, `eslint`, `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bea7uWfU78MYyBA32fYiWh
