### PR TITLE
CCA membership applications + interview scheduling (behind cca.applications.enabled)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -692,6 +692,18 @@ model SupperGroup {
 }
 
 /// This collection uses a JSON Schema defined in the database, which requires additional setup for migrations. Visit https://pris.ly/d/mongodb-json-schema for more info.
+///
+/// ⚠️ `prisma db push` DROPS the production `email_unique_ci` index. That index
+/// is a case-insensitive (collation strength 2) UNIQUE index on `email` — the
+/// guard against duplicate accounts, created by scripts/remediation/
+/// dedupe-users.mjs (also merge-accounts.mjs / merge-by-canonical.mjs). Prisma
+/// cannot represent a collation index in this schema, so every `db push` sees
+/// it as "not in schema" and removes it WITHOUT needing --accept-data-loss.
+/// AFTER ANY `db push`, recreate it:
+///   db.$runCommandRaw({ createIndexes: "User", indexes: [{ key: { email: 1 },
+///     name: "email_unique_ci", unique: true,
+///     collation: { locale: "en", strength: 2 } }] })
+/// (re-run dedupe-users.mjs, or the one-liner above). Verify with listIndexes.
 model User {
   id             String          @id @default(auto()) @map("_id") @db.ObjectId
   email          String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -464,6 +464,96 @@ model CcaProfile {
   updatedBy   String?
 }
 
+/// A resident's application to JOIN a CCA. New, unvalidated collection — the
+/// SAME reasoning as CcaProfile/UserRole/UserMatric: application state cannot
+/// live on the $jsonSchema-guarded `UserCCA` (which declares only {ccaID,
+/// userID} and rejects any other field at write time, code 121, silently), so
+/// it gets its own collection here. Acceptance ultimately writes a `UserCCA`
+/// row — this is the workflow that governs WHEN.
+///
+/// I-2: every non-list scalar is nullable and `status` carries a default, so a
+/// row written by another process (a hand-fix, a partial restore) without them
+/// cannot break the reads that run on the resident dashboard.
+///
+/// `userID` is the CANONICAL applicant id (canonicalUserID(email) =
+/// session.user.userID), the same key UserCCA/CcaHead/UserMatric use — NEVER
+/// User.userID (legacy A-format matrics live there, invariant I-1).
+///
+/// `status` vocabulary (enforced in code, see src/lib/schemas/ccaApplication.ts):
+///   submitted | interview_scheduled | interviewed | accepted | rejected |
+///   withdrawn. Only accepted/rejected/withdrawn are TERMINAL — a non-terminal
+///   row is the "open application" a duplicate-apply check refuses.
+model CcaApplication {
+  id              String    @id @default(auto()) @map("_id") @db.ObjectId
+  /// Human/stable id from the Counter collection ("ccaApplicationID").
+  applicationID   Int       @unique(map: "applicationID")
+  ccaID           Int
+  userID          String
+  /// The applicant's self-supplied free text. Trim+max only (schema), never
+  /// sanitized — React escapes it on render (same reasoning as CcaProfile.description).
+  notes           String?
+  status          String?   @default("submitted")
+  /// The slotID the resident booked, null until they book. Points at
+  /// CcaInterviewSlot.slotID, not its ObjectId.
+  interviewSlotID Int?
+  decidedAt       DateTime?
+  decidedBy       String?
+  decisionReason  String?
+  withdrawnAt     DateTime?
+  createdAt       DateTime? @default(now())
+  updatedAt       DateTime?
+
+  /// The head's review queue for one CCA, filtered by status.
+  @@index([ccaID, status], map: "cca_status")
+  /// The resident's own "my applications" list.
+  @@index([userID], map: "applicant")
+  /// The duplicate-open-application check (one non-terminal row per person+CCA).
+  @@index([ccaID, userID], map: "cca_applicant")
+}
+
+/// An interview slot a CCA head opens from their availability; a resident then
+/// CLAIMS one. New, unvalidated collection. Modelled on `Bookings`: times are
+/// UNIX epoch SECONDS (Int), not DateTime, and overlap is a range query, not a
+/// DB constraint (Mongo cannot express an overlapping-range unique index).
+///
+/// A slot's lifecycle: created with bookedByUserID = null (open) → a resident's
+/// bookSlot sets bookedByUserID + bookedApplicationID under an advisory lock
+/// (withCcaLock) so two residents cannot claim the same slot. canceledAt marks
+/// a slot the head withdrew; a booked slot is reverted (application → submitted)
+/// before it is canceled, never hard-deleted out from under a resident.
+model CcaInterviewSlot {
+  id                  String    @id @default(auto()) @map("_id") @db.ObjectId
+  slotID              Int       @unique(map: "slotID")
+  ccaID               Int
+  startTime           Int?
+  endTime             Int?
+  location            String?
+  createdBy           String?
+  bookedByUserID      String?
+  bookedApplicationID Int?
+  bookedAt            DateTime?
+  canceledAt          DateTime?
+  createdAt           DateTime? @default(now())
+
+  @@index([ccaID, startTime, endTime], map: "cca_time")
+  @@index([bookedByUserID], map: "booked_by")
+}
+
+/// Append-only interview notes a head records against an application — multiple
+/// per application, multiple co-heads. New, unvalidated collection. Kept
+/// separate from CcaApplication (rather than a single `headNotes` string) so
+/// notes accumulate with authorship + timestamps and never overwrite.
+model CcaInterviewNote {
+  id            String    @id @default(auto()) @map("_id") @db.ObjectId
+  applicationID Int
+  ccaID         Int
+  authorUserID  String?
+  body          String?
+  createdAt     DateTime? @default(now())
+
+  @@index([applicationID], map: "application")
+}
+
 /// Matric number stored as an ATTRIBUTE (not identity), kept out of the
 /// validator-guarded User collection (same pattern as UserRole/FacilityAccess:
 /// the User $jsonSchema validator has no `matric` property, so writing it onto

--- a/scripts/remediation/set-cca-flag.mjs
+++ b/scripts/remediation/set-cca-flag.mjs
@@ -1,0 +1,139 @@
+/**
+ * Sets a CCA feature kill switch. These are NEW-WRITE-SURFACE switches, so
+ * unlike the rbac.* enforcement switches they are on|off and DEFAULT OFF (an
+ * absent row = off = the surface is inert). See ccaScope.isCcaManagementEnabled
+ * and ccaApplications.isApplicationsEnabled — both read `value === "on"`.
+ *
+ *   management    cca.management.enabled     /admin/manage-ccas (create/rename
+ *                                            CCAs, add/remove members)
+ *   applications  cca.applications.enabled   the resident applications +
+ *                                            interview workflow (/ccas)
+ *
+ *   node scripts/remediation/set-cca-flag.mjs                              # show both
+ *   node scripts/remediation/set-cca-flag.mjs management on                # dry run
+ *   node scripts/remediation/set-cca-flag.mjs management on --commit       # apply
+ *   node scripts/remediation/set-cca-flag.mjs applications on --commit
+ *
+ * A SystemFlag ROW, not an env var, for the same reason as set-enforcement.mjs:
+ * Vercel snapshots env vars per deployment, so only a DB row is a no-redeploy
+ * switch. Writes via $runCommandRaw and INSPECTS THE REPLY (I-8f) rather than
+ * trusting a throw, then reads the row back to verify.
+ */
+import { PrismaClient } from "@prisma/client";
+import { inspectWriteReply, isCommit, abort, nowExt } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+
+const SWITCHES = {
+  management: { key: "cca.management.enabled" },
+  applications: { key: "cca.applications.enabled" },
+};
+const MODES = ["on", "off"];
+
+const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const NAME = positional[0];
+const MODE = positional[1];
+const COMMIT = isCommit();
+
+async function readFlag(key) {
+  const r = await db.$runCommandRaw({
+    find: "SystemFlag",
+    filter: { key },
+    limit: 1,
+  });
+  return r?.cursor?.firstBatch?.[0] ?? null;
+}
+
+async function showAll() {
+  console.log(`\n=== set-cca-flag.mjs — current state ===`);
+  for (const [name, { key }] of Object.entries(SWITCHES)) {
+    const row = await readFlag(key);
+    const val = row ? JSON.stringify(row.value) : `(no row — default "off")`;
+    console.log(`  ${name.padEnd(13)} ${key.padEnd(26)} ${val}`);
+  }
+  console.log(
+    `\nusage: node scripts/remediation/set-cca-flag.mjs <${Object.keys(
+      SWITCHES,
+    ).join("|")}> <on|off> [--commit]`,
+  );
+}
+
+async function main() {
+  if (!NAME) return showAll();
+
+  const SWITCH = SWITCHES[NAME];
+  if (!SWITCH) {
+    return abort(
+      `unknown switch ${JSON.stringify(NAME)} — one of ${Object.keys(
+        SWITCHES,
+      ).join(" | ")}`,
+    );
+  }
+  const KEY = SWITCH.key;
+
+  const before = await readFlag(KEY);
+  console.log(`\n=== set-cca-flag.mjs (${NAME}) ===`);
+  console.log(
+    `current: ${before ? JSON.stringify(before.value) : `(no row — default "off")`}`,
+  );
+
+  if (!MODE) {
+    console.log(
+      `\nusage: node scripts/remediation/set-cca-flag.mjs ${NAME} <${MODES.join(
+        "|",
+      )}> [--commit]`,
+    );
+    return;
+  }
+  if (!MODES.includes(MODE)) {
+    return abort(`mode must be one of ${MODES.join(" | ")} — got ${JSON.stringify(MODE)}`);
+  }
+
+  console.log(
+    `\n  ${COMMIT ? "+" : "~"} ${KEY}: ${JSON.stringify(
+      before?.value ?? null,
+    )} -> ${JSON.stringify(MODE)}`,
+  );
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing changed. Re-run with --commit to apply.`);
+    return;
+  }
+
+  const reply = await db.$runCommandRaw({
+    update: "SystemFlag",
+    updates: [
+      {
+        q: { key: KEY },
+        u: {
+          $set: {
+            key: KEY,
+            value: MODE,
+            updatedAt: nowExt(),
+            updatedBy: `script:set-cca-flag:${NAME}`,
+          },
+        },
+        upsert: true,
+      },
+    ],
+  });
+  const r = inspectWriteReply(reply, KEY);
+  if (r.writeErrors.length) {
+    console.error(`  ! WRITE FAILED: ${JSON.stringify(r.writeErrors)}`);
+    return abort(`the flag was NOT changed.`);
+  }
+
+  const after = await readFlag(KEY);
+  console.log(`\n=== VERIFY ===`);
+  console.log(`${KEY} = ${JSON.stringify(after?.value ?? null)}`);
+  if (after?.value !== MODE) {
+    return abort(`read-back mismatch: expected ${MODE}, got ${JSON.stringify(after?.value ?? null)}`);
+  }
+}
+
+main()
+  .then(() => console.log("\nDone."))
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -8,6 +8,7 @@ import {
   Calendar,
   User,
   Users,
+  LayoutGrid,
   LogOut,
   UserCircle,
   ShieldCheck,
@@ -64,6 +65,10 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
     { name: "Home", href: "/", icon: Home },
     { name: "My Bookings", href: "/bookings", icon: Calendar },
     // { name: "Facilities", href: "/facilities", icon: Box },
+    // Resident-facing CCA browse + applications. Shown to everyone signed in;
+    // the page itself is inert until cca.applications.enabled is on, so this is
+    // a link to a "not open yet" state at worst, never a broken route.
+    { name: "CCAs", href: "/ccas", icon: LayoutGrid },
     ...(isCcaHead ? [{ name: "My CCAs", href: "/cca", icon: Users }] : []),
     ...(canReachAdmin
       ? [{ name: "Admin", href: "/admin", icon: ShieldCheck }]

--- a/src/app/cca/[ccaID]/applications/page.tsx
+++ b/src/app/cca/[ccaID]/applications/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+
+import { parseCcaID } from "../../_lib/ccaParam";
+import ApplicationsReview from "../../_components/ApplicationsReview";
+
+/** The head's application review queue. Data comes from procedures that each
+ *  call assertHeadsCca, so this page is chrome, not the boundary. */
+export default function CcaApplicationsPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  if (ccaID === null) notFound();
+  return <ApplicationsReview ccaID={ccaID} />;
+}

--- a/src/app/cca/[ccaID]/interviews/page.tsx
+++ b/src/app/cca/[ccaID]/interviews/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+
+import { parseCcaID } from "../../_lib/ccaParam";
+import InterviewSlots from "../../_components/InterviewSlots";
+
+/** Open and manage interview slots for a CCA the caller heads. Every procedure
+ *  behind this re-checks with assertHeadsCca. */
+export default function CcaInterviewsPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  if (ccaID === null) notFound();
+  return <InterviewSlots ccaID={ccaID} />;
+}

--- a/src/app/cca/_components/ApplicationsReview.tsx
+++ b/src/app/cca/_components/ApplicationsReview.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarClock, ChevronDown, MapPin } from "lucide-react";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  addNoteInput,
+  APPLICATION_STATUSES,
+  DECISION_REASON_MAX,
+  INTERVIEW_NOTE_MAX,
+  isTerminalStatus,
+  type ApplicationStatus,
+} from "~/lib/schemas/ccaApplication";
+import {
+  formatSlot,
+  statusBadgeClass,
+  statusLabel,
+} from "~/app/ccas/_lib/status";
+
+type Filter = "all" | ApplicationStatus;
+const FILTERS: Filter[] = ["all", ...APPLICATION_STATUSES];
+
+export default function ApplicationsReview({ ccaID }: { ccaID: number }) {
+  const [filter, setFilter] = useState<Filter>("all");
+  const list = api.ccaApplicationsHead.listApplications.useQuery(
+    { ccaID, ...(filter === "all" ? {} : { status: filter }) },
+    { retry: false },
+  );
+
+  if (list.isPending) {
+    return <div className="h-64 animate-pulse rounded-lg bg-gray-200" />;
+  }
+  if (list.error) {
+    if (list.error.message === "NOT_A_HEAD_OF_THIS_CCA") {
+      return (
+        <Denied text="You can only review applications for CCAs you head." />
+      );
+    }
+    if (list.error.message === "CCA_APPLICATIONS_DISABLED") {
+      return <Denied text="CCA applications aren't open right now." />;
+    }
+    return <Denied text="These couldn't be loaded. Reload the page." tone="error" />;
+  }
+
+  const apps = list.data.applications;
+
+  return (
+    <div className="space-y-4">
+      {/* Status filter */}
+      <div className="flex flex-wrap gap-1.5">
+        {FILTERS.map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              filter === f
+                ? "bg-emerald-600 text-white"
+                : "bg-white text-gray-600 ring-1 ring-inset ring-gray-200 hover:bg-gray-50"
+            }`}
+          >
+            {f === "all" ? "All" : statusLabel(f)}
+          </button>
+        ))}
+      </div>
+
+      {apps.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center text-sm text-gray-500">
+          {filter === "all"
+            ? "No applications yet."
+            : `No ${statusLabel(filter).toLowerCase()} applications.`}
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {apps.map((a) => (
+            <ApplicationRow key={a.applicationID} ccaID={ccaID} app={a} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Denied({
+  text,
+  tone = "muted",
+}: {
+  text: string;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <div
+      className={`rounded-lg border px-4 py-6 text-sm ${
+        tone === "error"
+          ? "border-red-200 bg-red-50 text-red-800"
+          : "border-gray-200 bg-white text-gray-600"
+      }`}
+    >
+      {text}
+    </div>
+  );
+}
+
+type AppRow =
+  RouterOutputs["ccaApplicationsHead"]["listApplications"]["applications"][number];
+
+function ApplicationRow({ ccaID, app }: { ccaID: number; app: AppRow }) {
+  const [open, setOpen] = useState(false);
+  const decided = isTerminalStatus(app.status);
+  const name = app.applicant.displayName ?? app.userID;
+
+  return (
+    <li className="rounded-lg border border-gray-200 bg-white">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 p-4 text-left"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-medium text-gray-900">{name}</span>
+            <span
+              className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+                app.status,
+              )}`}
+            >
+              {statusLabel(app.status)}
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-xs text-gray-500">
+            {[app.applicant.matric, app.applicant.email]
+              .filter(Boolean)
+              .join(" · ") || app.userID}
+          </p>
+          {app.slot && app.status === "interview_scheduled" && (
+            <p className="mt-1 inline-flex items-center gap-1.5 text-xs text-emerald-700">
+              <CalendarClock className="h-3.5 w-3.5" />
+              {formatSlot(app.slot.startTime, app.slot.endTime)}
+              {app.slot.location && (
+                <span className="inline-flex items-center gap-1 text-gray-500">
+                  <MapPin className="h-3 w-3" />
+                  {app.slot.location}
+                </span>
+              )}
+            </p>
+          )}
+        </div>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${
+            open ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      {open && (
+        <ApplicationDetail ccaID={ccaID} applicationID={app.applicationID} decided={decided} />
+      )}
+    </li>
+  );
+}
+
+/** Expanded detail: the applicant's notes, interview notes, and the decision
+ *  controls. Loads getApplication lazily so a long queue doesn't fetch every
+ *  application's full detail up front. */
+function ApplicationDetail({
+  ccaID,
+  applicationID,
+  decided,
+}: {
+  ccaID: number;
+  applicationID: number;
+  decided: boolean;
+}) {
+  const utils = api.useUtils();
+  const detail = api.ccaApplicationsHead.getApplication.useQuery(
+    { ccaID, applicationID },
+    { retry: false },
+  );
+  const [note, setNote] = useState("");
+  const [reason, setReason] = useState("");
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.ccaApplicationsHead.getApplication.invalidate({ ccaID, applicationID }),
+      utils.ccaApplicationsHead.listApplications.invalidate({ ccaID }),
+    ]);
+  };
+
+  const addNote = api.ccaApplicationsHead.addNote.useMutation({
+    onSuccess: async () => {
+      setNote("");
+      await refresh();
+    },
+  });
+  const decide = api.ccaApplicationsHead.decide.useMutation({
+    onSuccess: refresh,
+  });
+  const markInterviewed = api.ccaApplicationsHead.markInterviewed.useMutation({
+    onSuccess: refresh,
+  });
+
+  if (detail.isPending) {
+    return (
+      <div className="border-t border-gray-100 p-4">
+        <div className="h-20 animate-pulse rounded bg-gray-100" />
+      </div>
+    );
+  }
+  if (detail.error) {
+    return (
+      <div className="border-t border-gray-100 p-4 text-sm text-red-600">
+        Couldn&rsquo;t load this application.
+      </div>
+    );
+  }
+
+  const d = detail.data;
+  const canInterview =
+    d.status === "submitted" || d.status === "interview_scheduled";
+
+  return (
+    <div className="space-y-4 border-t border-gray-100 p-4">
+      {/* Applicant's own notes */}
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+          Applicant&rsquo;s notes
+        </p>
+        <p className="mt-1 whitespace-pre-line text-sm text-gray-700">
+          {d.notes?.trim() ? d.notes : "— none —"}
+        </p>
+      </div>
+
+      {/* Interview notes */}
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+          Interview notes
+        </p>
+        <NoteList notes={d.interviewNotes} />
+      </div>
+
+      {/* Add a note */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const parsed = addNoteInput.safeParse({ ccaID, applicationID, body: note });
+          if (!parsed.success) return;
+          addNote.mutate(parsed.data);
+        }}
+        className="space-y-2"
+      >
+        <textarea
+          value={note}
+          maxLength={INTERVIEW_NOTE_MAX}
+          rows={2}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Add an interview note…"
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        />
+        <Button
+          type="submit"
+          variant="outline"
+          disabled={addNote.isPending || note.trim().length === 0}
+        >
+          {addNote.isPending ? "Adding…" : "Add note"}
+        </Button>
+      </form>
+
+      {/* Decision */}
+      {decided ? (
+        <div className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-600">
+          Decision: <span className="font-medium">{statusLabel(d.status)}</span>
+          {d.decisionReason ? ` — ${d.decisionReason}` : ""}
+        </div>
+      ) : (
+        <div className="space-y-2 border-t border-gray-100 pt-4">
+          {canInterview && (
+            <button
+              onClick={() => markInterviewed.mutate({ ccaID, applicationID })}
+              disabled={markInterviewed.isPending}
+              className="text-xs font-medium text-gray-500 hover:text-gray-800 disabled:opacity-50"
+            >
+              {markInterviewed.isPending ? "…" : "Mark as interviewed"}
+            </button>
+          )}
+          <input
+            type="text"
+            value={reason}
+            maxLength={DECISION_REASON_MAX}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason (optional, shared with applicant on rejection)"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          />
+          {decide.error && (
+            <p className="text-sm text-red-600">
+              {decide.error.message === "ALREADY_DECIDED"
+                ? "This application was already decided. Refresh."
+                : "That didn't go through. Try again."}
+            </p>
+          )}
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={decide.isPending}
+              onClick={() =>
+                decide.mutate({
+                  ccaID,
+                  applicationID,
+                  decision: "accepted",
+                  reason: reason.trim() || undefined,
+                })
+              }
+            >
+              {decide.isPending ? "…" : "Accept"}
+            </Button>
+            <button
+              disabled={decide.isPending}
+              onClick={() =>
+                decide.mutate({
+                  ccaID,
+                  applicationID,
+                  decision: "rejected",
+                  reason: reason.trim() || undefined,
+                })
+              }
+              className="rounded-md px-3 py-2 text-sm font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NoteList({
+  notes,
+}: {
+  notes: {
+    id: string;
+    body: string | null;
+    createdAt: Date | null;
+    authorName: string | null;
+  }[];
+}) {
+  if (!notes || notes.length === 0) {
+    return <p className="mt-1 text-sm text-gray-400">No interview notes yet.</p>;
+  }
+  return (
+    <ul className="mt-1 space-y-2">
+      {notes.map((n) => (
+        <li key={n.id} className="rounded-md bg-gray-50 px-3 py-2 text-sm">
+          <p className="whitespace-pre-line text-gray-700">{n.body}</p>
+          <p className="mt-1 text-xs text-gray-400">
+            {n.authorName ?? "Head"}
+            {n.createdAt
+              ? ` · ${new Date(n.createdAt).toLocaleString()}`
+              : ""}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/cca/_components/CcaDashboardShell.tsx
+++ b/src/app/cca/_components/CcaDashboardShell.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, Users, Pencil } from "lucide-react";
+import {
+  LayoutDashboard,
+  Users,
+  Pencil,
+  ClipboardList,
+  CalendarClock,
+} from "lucide-react";
 
 import { api } from "~/trpc/react";
 import CcaSwitcher from "./CcaSwitcher";
@@ -16,6 +22,8 @@ import CcaSwitcher from "./CcaSwitcher";
  */
 const SECTIONS = [
   { slug: "", label: "Overview", icon: LayoutDashboard },
+  { slug: "applications", label: "Applications", icon: ClipboardList },
+  { slug: "interviews", label: "Interview slots", icon: CalendarClock },
   { slug: "members", label: "View member list", icon: Users },
   { slug: "details", label: "CCA details", icon: Pencil },
 ] as const;

--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { MapPin, Trash2 } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  INTERVIEW_LOCATION_MAX,
+  slotDraftSchema,
+} from "~/lib/schemas/ccaApplication";
+import { formatSlot } from "~/app/ccas/_lib/status";
+
+/**
+ * A CCA head opens interview slots from their availability and sees who booked
+ * each. Times are entered as local wall-clock (a date + start/end time) and
+ * converted to epoch seconds the same way BookingModal does — the app is
+ * single-hall, so there is no timezone to carry.
+ */
+export default function InterviewSlots({ ccaID }: { ccaID: number }) {
+  const utils = api.useUtils();
+  const list = api.ccaApplicationsHead.listSlots.useQuery(
+    { ccaID },
+    { retry: false },
+  );
+
+  const [date, setDate] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [location, setLocation] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const refresh = () => utils.ccaApplicationsHead.listSlots.invalidate({ ccaID });
+
+  const open = api.ccaApplicationsHead.openSlots.useMutation({
+    onSuccess: async () => {
+      setStart("");
+      setEnd("");
+      setLocation("");
+      setFormError(null);
+      await refresh();
+    },
+  });
+  const cancel = api.ccaApplicationsHead.cancelSlot.useMutation({
+    onSuccess: refresh,
+  });
+
+  /** Local date + "HH:MM" → epoch seconds, mirroring BookingModal. */
+  const toEpoch = (d: string, t: string): number | null => {
+    if (!d || !t) return null;
+    const [h, m] = t.split(":").map(Number);
+    const dt = new Date(d);
+    if (Number.isNaN(dt.getTime()) || h === undefined || m === undefined) {
+      return null;
+    }
+    dt.setHours(h, m, 0, 0);
+    return Math.floor(dt.getTime() / 1000);
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const startTime = toEpoch(date, start);
+    const endTime = toEpoch(date, end);
+    if (startTime === null || endTime === null) {
+      setFormError("Pick a date, a start time and an end time.");
+      return;
+    }
+    const parsed = slotDraftSchema.safeParse({
+      startTime,
+      endTime,
+      location: location.trim() || undefined,
+    });
+    if (!parsed.success) {
+      setFormError(
+        parsed.error.issues[0]?.message === "END_BEFORE_START"
+          ? "The end time has to be after the start time."
+          : "That slot isn't valid.",
+      );
+      return;
+    }
+    if (endTime <= Math.floor(Date.now() / 1000)) {
+      setFormError("That slot is in the past.");
+      return;
+    }
+    setFormError(null);
+    open.mutate({ ccaID, slots: [parsed.data] });
+  };
+
+  const serverError = open.error
+    ? open.error.message === "SLOT_OVERLAP"
+      ? "That overlaps a slot you've already opened."
+      : open.error.message === "SLOT_IN_PAST"
+        ? "That slot is in the past."
+        : open.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+          ? "You're no longer a head of this CCA."
+          : "That didn't open. Try again."
+    : null;
+
+  return (
+    <div className="space-y-5">
+      {/* Open a slot */}
+      <form
+        onSubmit={submit}
+        className="space-y-3 rounded-lg border border-gray-200 bg-white p-5"
+      >
+        <p className="text-sm font-medium text-gray-900">Open an interview slot</p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-gray-700">Date</span>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-gray-700">Location</span>
+            <input
+              type="text"
+              value={location}
+              maxLength={INTERVIEW_LOCATION_MAX}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. JCRC Room (optional)"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-gray-700">Start</span>
+            <input
+              type="time"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-gray-700">End</span>
+            <input
+              type="time"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+          </label>
+        </div>
+        {(formError ?? serverError) && (
+          <p className="text-sm text-red-600">{formError ?? serverError}</p>
+        )}
+        <Button type="submit" disabled={open.isPending}>
+          {open.isPending ? "Opening…" : "Open slot"}
+        </Button>
+      </form>
+
+      {/* Existing slots */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-gray-900">Open slots</p>
+        {list.isPending ? (
+          <div className="h-24 animate-pulse rounded-lg bg-gray-200" />
+        ) : list.error ? (
+          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-800">
+            {list.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+              ? "You can only manage slots for CCAs you head."
+              : "These couldn't be loaded."}
+          </p>
+        ) : list.data.slots.length === 0 ? (
+          <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500">
+            No slots open yet. Add one above.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {list.data.slots.map((s) => (
+              <li
+                key={s.slotID}
+                className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-800">
+                    {formatSlot(s.startTime, s.endTime)}
+                  </p>
+                  <p className="mt-0.5 flex flex-wrap items-center gap-x-3 text-xs text-gray-500">
+                    {s.location && (
+                      <span className="inline-flex items-center gap-1">
+                        <MapPin className="h-3 w-3" />
+                        {s.location}
+                      </span>
+                    )}
+                    {s.bookedBy ? (
+                      <span className="text-emerald-700">
+                        Booked by {s.bookedBy.displayName ?? s.bookedBy.email ?? "an applicant"}
+                      </span>
+                    ) : (
+                      <span>Open</span>
+                    )}
+                  </p>
+                </div>
+                <button
+                  onClick={() => {
+                    if (
+                      s.bookedByUserID &&
+                      !window.confirm(
+                        "This slot is booked. Cancelling it will send that applicant back to schedule again. Continue?",
+                      )
+                    ) {
+                      return;
+                    }
+                    cancel.mutate({ ccaID, slotID: s.slotID });
+                  }}
+                  disabled={cancel.isPending}
+                  aria-label="Cancel slot"
+                  className="shrink-0 rounded-md p-2 text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ccas/[ccaID]/page.tsx
+++ b/src/app/ccas/[ccaID]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+
+import { parseCcaID } from "~/app/cca/_lib/ccaParam";
+import CcaApplyPanel from "../_components/CcaApplyPanel";
+
+export const dynamic = "force-dynamic";
+
+/** One CCA's page: details + apply + interview scheduling. The param is parsed
+ *  with the SAME helper the head dashboard uses so "what is a valid ccaID"
+ *  cannot drift; all real authorization is in the procedures. */
+export default function CcaDetailPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  if (ccaID === null) notFound();
+  return <CcaApplyPanel ccaID={ccaID} />;
+}

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowLeft, CalendarClock, MapPin } from "lucide-react";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  applyInput,
+  APPLICATION_NOTES_MAX,
+  isTerminalStatus,
+} from "~/lib/schemas/ccaApplication";
+import { formatSlot, statusBadgeClass, statusLabel } from "../_lib/status";
+
+/** Friendly copy for the machine-readable error tokens the procedures throw. */
+function applyErrorCopy(message: string | undefined): string | null {
+  switch (message) {
+    case undefined:
+      return null;
+    case "ALREADY_MEMBER":
+      return "You're already a member of this CCA.";
+    case "APPLICATION_OPEN":
+      return "You already have an application in progress here.";
+    case "HEAD_CANNOT_APPLY":
+      return "You head this CCA — you can't apply to it.";
+    case "MATRIC_REQUIRED":
+      return "Add your matriculation number in your profile before applying.";
+    case "NO_SUCH_CCA":
+      return "This CCA no longer exists.";
+    case "CCA_APPLICATIONS_DISABLED":
+      return "Applications aren't open right now.";
+    default:
+      return "That didn't go through. Try again.";
+  }
+}
+
+export default function CcaApplyPanel({ ccaID }: { ccaID: number }) {
+  const utils = api.useUtils();
+  const cca = api.ccaApplications.getCca.useQuery({ ccaID }, { retry: false });
+
+  const [notes, setNotes] = useState("");
+  const [showApply, setShowApply] = useState(false);
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.ccaApplications.getCca.invalidate({ ccaID }),
+      utils.ccaApplications.browse.invalidate(),
+      utils.ccaApplications.availableSlots.invalidate({ ccaID }),
+    ]);
+  };
+
+  const apply = api.ccaApplications.apply.useMutation({
+    onSuccess: async () => {
+      setShowApply(false);
+      setNotes("");
+      await refresh();
+    },
+  });
+  const withdraw = api.ccaApplications.withdraw.useMutation({
+    onSuccess: refresh,
+  });
+  const cancelSlot = api.ccaApplications.cancelSlot.useMutation({
+    onSuccess: refresh,
+  });
+
+  if (cca.isPending) {
+    return <div className="h-64 animate-pulse rounded-lg bg-gray-200" />;
+  }
+  if (cca.error) {
+    const disabled = cca.error.message === "CCA_APPLICATIONS_DISABLED";
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center">
+        <p className="text-sm font-medium text-gray-900">
+          {disabled
+            ? "CCA applications aren't open right now"
+            : "This CCA couldn't be loaded"}
+        </p>
+        <Link
+          href="/ccas"
+          className="mt-3 inline-block text-sm font-medium text-emerald-700"
+        >
+          ← Back to all CCAs
+        </Link>
+      </div>
+    );
+  }
+
+  const d = cca.data;
+  const app = d.application;
+  const openApp = app && !isTerminalStatus(app.status);
+
+  return (
+    <div className="space-y-5">
+      <Link
+        href="/ccas"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-800"
+      >
+        <ArrowLeft className="h-4 w-4" /> All CCAs
+      </Link>
+
+      {/* Header card */}
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        {d.bannerUrl && (
+          <div className="relative h-32 w-full sm:h-40">
+            <Image src={d.bannerUrl} alt="" fill className="object-cover" />
+          </div>
+        )}
+        <div className="flex items-start gap-4 p-5">
+          {d.logoUrl ? (
+            <Image
+              src={d.logoUrl}
+              alt=""
+              width={56}
+              height={56}
+              className="h-14 w-14 shrink-0 rounded-lg object-cover"
+            />
+          ) : (
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-lg font-semibold text-emerald-700">
+              {d.ccaName.slice(0, 2).toUpperCase()}
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <h1 className="text-xl font-semibold text-gray-900">{d.ccaName}</h1>
+            {d.category && (
+              <p className="text-sm text-gray-500">{d.category}</p>
+            )}
+          </div>
+          {d.isMember && (
+            <span className="inline-flex items-center rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+              Member
+            </span>
+          )}
+        </div>
+        {d.description && (
+          <p className="whitespace-pre-line border-t border-gray-100 px-5 py-4 text-sm text-gray-600">
+            {d.description}
+          </p>
+        )}
+      </div>
+
+      {/* Application state */}
+      {d.isMember ? (
+        <Card>
+          <p className="text-sm text-gray-700">
+            You&rsquo;re a member of {d.ccaName}. 🎉
+          </p>
+        </Card>
+      ) : openApp ? (
+        <ApplicationInProgress
+          ccaID={ccaID}
+          app={app}
+          openSlotCount={d.openSlotCount}
+          onWithdraw={() =>
+            withdraw.mutate({ applicationID: app.applicationID })
+          }
+          withdrawing={withdraw.isPending}
+          onCancelSlot={() =>
+            cancelSlot.mutate({ applicationID: app.applicationID })
+          }
+          cancelingSlot={cancelSlot.isPending}
+          onChanged={refresh}
+        />
+      ) : (
+        <Card>
+          {app && (
+            <div className="mb-3 flex items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+                  app.status,
+                )}`}
+              >
+                {statusLabel(app.status)}
+              </span>
+              {app.status === "rejected" && (
+                <span className="text-sm text-gray-500">
+                  You can apply again below.
+                </span>
+              )}
+            </div>
+          )}
+
+          {app?.status === "rejected" && app.decisionReason && (
+            <p className="mb-3 text-sm text-gray-600">
+              <span className="font-medium text-gray-700">Note from the CCA:</span>{" "}
+              {app.decisionReason}
+            </p>
+          )}
+
+          {!showApply ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="text-sm text-gray-600">
+                {d.canApply
+                  ? "Interested? Apply to become a member."
+                  : "You can't apply right now."}
+              </p>
+              {d.canApply && (
+                <Button onClick={() => setShowApply(true)}>Apply to join</Button>
+              )}
+            </div>
+          ) : (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                const parsed = applyInput.safeParse({ ccaID, notes });
+                if (!parsed.success) return;
+                apply.mutate(parsed.data);
+              }}
+              className="space-y-3"
+            >
+              <label
+                htmlFor="apply-notes"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Anything you&rsquo;d like the CCA to know?{" "}
+                <span className="font-normal text-gray-400">(optional)</span>
+              </label>
+              <textarea
+                id="apply-notes"
+                value={notes}
+                maxLength={APPLICATION_NOTES_MAX}
+                rows={5}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Why you're interested, relevant experience, availability…"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+              />
+              <p className="text-right text-xs text-gray-400">
+                {notes.length}/{APPLICATION_NOTES_MAX}
+              </p>
+              {apply.error && (
+                <p className="text-sm text-red-600">
+                  {applyErrorCopy(apply.error.message)}
+                </p>
+              )}
+              <div className="flex items-center gap-3">
+                <Button type="submit" disabled={apply.isPending}>
+                  {apply.isPending ? "Submitting…" : "Submit application"}
+                </Button>
+                <button
+                  type="button"
+                  onClick={() => setShowApply(false)}
+                  className="text-sm font-medium text-gray-500 hover:text-gray-800"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-5">
+      {children}
+    </div>
+  );
+}
+
+type AppShape = RouterOutputs["ccaApplications"]["getCca"]["application"];
+
+/** The panel shown while an application is live (submitted / scheduled). */
+function ApplicationInProgress({
+  ccaID,
+  app,
+  openSlotCount,
+  onWithdraw,
+  withdrawing,
+  onCancelSlot,
+  cancelingSlot,
+  onChanged,
+}: {
+  ccaID: number;
+  app: NonNullable<AppShape>;
+  openSlotCount: number;
+  onWithdraw: () => void;
+  withdrawing: boolean;
+  onCancelSlot: () => void;
+  cancelingSlot: boolean;
+  onChanged: () => Promise<void>;
+}) {
+  const scheduled = app.status === "interview_scheduled";
+  const [picking, setPicking] = useState(false);
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+              app.status,
+            )}`}
+          >
+            {statusLabel(app.status)}
+          </span>
+          <p className="mt-2 text-sm text-gray-600">
+            {app.status === "submitted" &&
+              (openSlotCount > 0
+                ? "Your application is in. Book an interview slot below."
+                : "Your application is in. The CCA will open interview slots soon.")}
+            {scheduled && "Your interview is booked."}
+            {app.status === "interviewed" &&
+              "Your interview's done — the CCA will be in touch with a decision."}
+          </p>
+        </div>
+        {!scheduled && (
+          <button
+            onClick={onWithdraw}
+            disabled={withdrawing}
+            className="shrink-0 text-sm font-medium text-gray-400 hover:text-red-600 disabled:opacity-50"
+          >
+            {withdrawing ? "Withdrawing…" : "Withdraw"}
+          </button>
+        )}
+      </div>
+
+      {(app.status === "submitted" || scheduled) && (
+        <div className="mt-4 border-t border-gray-100 pt-4">
+          {!picking ? (
+            <div className="flex flex-wrap items-center gap-3">
+              {scheduled ? (
+                <>
+                  <Button variant="outline" onClick={() => setPicking(true)}>
+                    Reschedule interview
+                  </Button>
+                  <button
+                    onClick={onCancelSlot}
+                    disabled={cancelingSlot}
+                    className="text-sm font-medium text-gray-500 hover:text-red-600 disabled:opacity-50"
+                  >
+                    {cancelingSlot ? "Cancelling…" : "Cancel interview"}
+                  </button>
+                </>
+              ) : openSlotCount > 0 ? (
+                <Button
+                  onClick={() => setPicking(true)}
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <CalendarClock className="h-4 w-4" /> Book an interview
+                </Button>
+              ) : (
+                <p className="text-sm text-gray-500">
+                  No interview slots are open yet.
+                </p>
+              )}
+            </div>
+          ) : (
+            <SlotPicker
+              ccaID={ccaID}
+              applicationID={app.applicationID}
+              currentSlotID={app.interviewSlotID}
+              onDone={async () => {
+                setPicking(false);
+                await onChanged();
+              }}
+              onCancel={() => setPicking(false)}
+            />
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+/** The slot list + confirm. Hand-rolled buttons, not a calendar widget — the
+ *  @fullcalendar/interaction plugin isn't installed, and a short list of open
+ *  slots reads more clearly as a list anyway. */
+function SlotPicker({
+  ccaID,
+  applicationID,
+  currentSlotID,
+  onDone,
+  onCancel,
+}: {
+  ccaID: number;
+  applicationID: number;
+  currentSlotID: number | null;
+  onDone: () => Promise<void>;
+  onCancel: () => void;
+}) {
+  const slots = api.ccaApplications.availableSlots.useQuery(
+    { ccaID },
+    { retry: false },
+  );
+  const [selected, setSelected] = useState<number | null>(null);
+  const book = api.ccaApplications.bookSlot.useMutation({
+    onSuccess: onDone,
+  });
+
+  if (slots.isPending) {
+    return <div className="h-24 animate-pulse rounded-md bg-gray-100" />;
+  }
+  if (slots.error) {
+    return (
+      <p className="text-sm text-red-600">
+        Couldn&rsquo;t load slots. Close and try again.
+      </p>
+    );
+  }
+
+  const open = slots.data.slots;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-gray-700">Pick a time</p>
+      {open.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No open slots right now. Check back later.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {open.map((s) => {
+            const isCurrent = s.slotID === currentSlotID;
+            const isSel = s.slotID === selected;
+            return (
+              <li key={s.slotID}>
+                <button
+                  type="button"
+                  onClick={() => setSelected(s.slotID)}
+                  aria-pressed={isSel}
+                  className={`flex w-full items-center justify-between rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                    isSel
+                      ? "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500"
+                      : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  <span className="font-medium text-gray-800">
+                    {formatSlot(s.startTime, s.endTime)}
+                  </span>
+                  <span className="flex items-center gap-3 text-gray-500">
+                    {s.location && (
+                      <span className="inline-flex items-center gap-1">
+                        <MapPin className="h-3.5 w-3.5" />
+                        {s.location}
+                      </span>
+                    )}
+                    {isCurrent && (
+                      <span className="text-xs text-emerald-700">Current</span>
+                    )}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {book.error && (
+        <p className="text-sm text-red-600">
+          {book.error.message === "SLOT_TAKEN"
+            ? "Someone just took that slot. Pick another."
+            : book.error.message === "SLOT_IN_PAST"
+              ? "That slot has passed. Pick another."
+              : "That didn't book. Try again."}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          disabled={selected === null || book.isPending}
+          onClick={() => {
+            if (selected !== null) book.mutate({ applicationID, slotID: selected });
+          }}
+        >
+          {book.isPending ? "Booking…" : "Confirm slot"}
+        </Button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm font-medium text-gray-500 hover:text-gray-800"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -51,7 +51,7 @@ export default function CcaApplyPanel({ ccaID }: { ccaID: number }) {
     ]);
   };
 
-  const apply = api.ccaApplications.apply.useMutation({
+  const apply = api.ccaApplications.submitApplication.useMutation({
     onSuccess: async () => {
       setShowApply(false);
       setNotes("");

--- a/src/app/ccas/_components/CcaBrowseGrid.tsx
+++ b/src/app/ccas/_components/CcaBrowseGrid.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Search } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { statusBadgeClass, statusLabel } from "../_lib/status";
+
+/**
+ * The /ccas grid. Each card shows the caller's own standing against that CCA —
+ * member, application in flight, or open to apply — so the whole page answers
+ * "what can I do here" at a glance.
+ *
+ * useState for the client-side filter only; all data is the single browse query
+ * (which enforces cca.applications.enabled server-side).
+ */
+export default function CcaBrowseGrid() {
+  const browse = api.ccaApplications.browse.useQuery(undefined, {
+    retry: false,
+  });
+  const [q, setQ] = useState("");
+
+  if (browse.isPending) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-40 animate-pulse rounded-lg bg-gray-200" />
+        ))}
+      </div>
+    );
+  }
+
+  if (browse.error) {
+    if (browse.error.message === "CCA_APPLICATIONS_DISABLED") {
+      return (
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center">
+          <p className="text-sm font-medium text-gray-900">
+            CCA applications aren&rsquo;t open right now
+          </p>
+          <p className="mx-auto mt-1 max-w-sm text-sm text-gray-500">
+            Check back later — this is where you&rsquo;ll browse CCAs and apply
+            to join once applications open.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-6 text-sm text-red-800">
+        These couldn&rsquo;t be loaded. Reload the page.
+      </div>
+    );
+  }
+
+  const needle = q.trim().toLowerCase();
+  const ccas = browse.data.ccas.filter(
+    (c) =>
+      needle === "" ||
+      c.ccaName.toLowerCase().includes(needle) ||
+      (c.category ?? "").toLowerCase().includes(needle),
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="relative max-w-sm">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          type="search"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search CCAs…"
+          aria-label="Search CCAs"
+          className="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+        />
+      </div>
+
+      {ccas.length === 0 ? (
+        <p className="py-10 text-center text-sm text-gray-500">
+          No CCAs match &ldquo;{q}&rdquo;.
+        </p>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {ccas.map((c) => (
+            <li key={c.ccaID}>
+              <Link
+                href={`/ccas/${c.ccaID}`}
+                className="flex h-full flex-col rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              >
+                <div className="flex items-start gap-3">
+                  {c.logoUrl ? (
+                    <Image
+                      src={c.logoUrl}
+                      alt=""
+                      width={44}
+                      height={44}
+                      className="h-11 w-11 shrink-0 rounded-md object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-emerald-100 text-sm font-semibold text-emerald-700">
+                      {c.ccaName.slice(0, 2).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-gray-900">
+                      {c.ccaName}
+                    </p>
+                    {c.category && (
+                      <p className="truncate text-xs text-gray-500">
+                        {c.category}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {c.description && (
+                  <p className="mt-3 line-clamp-2 text-sm text-gray-600">
+                    {c.description}
+                  </p>
+                )}
+
+                <div className="mt-auto pt-3">
+                  {c.isMember ? (
+                    <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+                      Member
+                    </span>
+                  ) : c.applicationStatus ? (
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+                        c.applicationStatus,
+                      )}`}
+                    >
+                      {statusLabel(c.applicationStatus)}
+                    </span>
+                  ) : (
+                    <span className="text-xs font-medium text-emerald-700">
+                      Apply →
+                    </span>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/ccas/_components/MyApplicationsList.tsx
+++ b/src/app/ccas/_components/MyApplicationsList.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarClock, MapPin } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { formatSlot, statusBadgeClass, statusLabel } from "../_lib/status";
+
+export default function MyApplicationsList() {
+  const q = api.ccaApplications.myApplications.useQuery(undefined, {
+    retry: false,
+  });
+
+  if (q.isPending) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-gray-200" />
+        ))}
+      </div>
+    );
+  }
+
+  if (q.error) {
+    if (q.error.message === "CCA_APPLICATIONS_DISABLED") {
+      return (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500">
+          CCA applications aren&rsquo;t open right now.
+        </p>
+      );
+    }
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-6 text-sm text-red-800">
+        These couldn&rsquo;t be loaded. Reload the page.
+      </p>
+    );
+  }
+
+  if (q.data.applications.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center">
+        <p className="text-sm font-medium text-gray-900">No applications yet</p>
+        <Link
+          href="/ccas"
+          className="mt-2 inline-block text-sm font-medium text-emerald-700"
+        >
+          Browse CCAs →
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {q.data.applications.map((a) => (
+        <li key={a.applicationID}>
+          <Link
+            href={`/ccas/${a.ccaID}`}
+            className="block rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-medium text-gray-900">
+                {a.ccaName ?? `CCA #${a.ccaID}`}
+              </p>
+              <span
+                className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+                  a.status,
+                )}`}
+              >
+                {statusLabel(a.status)}
+              </span>
+            </div>
+
+            {a.slot && a.status === "interview_scheduled" && (
+              <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
+                <span className="inline-flex items-center gap-1.5">
+                  <CalendarClock className="h-4 w-4 text-gray-400" />
+                  {formatSlot(a.slot.startTime, a.slot.endTime)}
+                </span>
+                {a.slot.location && (
+                  <span className="inline-flex items-center gap-1">
+                    <MapPin className="h-3.5 w-3.5 text-gray-400" />
+                    {a.slot.location}
+                  </span>
+                )}
+              </p>
+            )}
+
+            {a.status === "rejected" && a.decisionReason && (
+              <p className="mt-2 text-sm text-gray-600">{a.decisionReason}</p>
+            )}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/ccas/_lib/status.ts
+++ b/src/app/ccas/_lib/status.ts
@@ -1,0 +1,63 @@
+import type { ApplicationStatus } from "~/lib/schemas/ccaApplication";
+
+/**
+ * Human copy + badge styling for an application status. Shared by every surface
+ * that shows one (resident browse, apply panel, my-applications, head review),
+ * so the wording and colour of "interview_scheduled" cannot drift between them.
+ *
+ * Plain module (no "use client"): it exports data + pure helpers, imported by
+ * both client components and server-safe code.
+ */
+export const STATUS_LABEL: Record<ApplicationStatus, string> = {
+  submitted: "Submitted",
+  interview_scheduled: "Interview booked",
+  interviewed: "Interviewed",
+  accepted: "Accepted",
+  rejected: "Not accepted",
+  withdrawn: "Withdrawn",
+};
+
+const STATUS_CLASS: Record<ApplicationStatus, string> = {
+  submitted: "bg-sky-50 text-sky-700 ring-sky-600/20",
+  interview_scheduled: "bg-emerald-50 text-emerald-700 ring-emerald-600/20",
+  interviewed: "bg-amber-50 text-amber-700 ring-amber-600/20",
+  accepted: "bg-green-50 text-green-700 ring-green-600/20",
+  rejected: "bg-rose-50 text-rose-700 ring-rose-600/20",
+  withdrawn: "bg-gray-100 text-gray-600 ring-gray-500/20",
+};
+
+export function statusLabel(status: string | null | undefined): string {
+  return STATUS_LABEL[(status ?? "") as ApplicationStatus] ?? "Unknown";
+}
+
+/** Tailwind classes for a `ring-1` pill of the given status. */
+export function statusBadgeClass(status: string | null | undefined): string {
+  return (
+    STATUS_CLASS[(status ?? "") as ApplicationStatus] ??
+    "bg-gray-100 text-gray-600 ring-gray-500/20"
+  );
+}
+
+/** Format an epoch-seconds slot as a human date + time range. */
+export function formatSlot(
+  startTime: number | null,
+  endTime: number | null,
+): string {
+  if (startTime === null) return "—";
+  const start = new Date(startTime * 1000);
+  const date = start.toLocaleDateString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+  const startT = start.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (endTime === null) return `${date}, ${startT}`;
+  const endT = new Date(endTime * 1000).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${date}, ${startT}–${endT}`;
+}

--- a/src/app/ccas/applications/page.tsx
+++ b/src/app/ccas/applications/page.tsx
@@ -1,0 +1,20 @@
+import MyApplicationsList from "../_components/MyApplicationsList";
+
+export const dynamic = "force-dynamic";
+
+/** The resident's own applications across all CCAs. */
+export default function MyApplicationsPage() {
+  return (
+    <div>
+      <header className="mb-5">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          My applications
+        </h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          Track where each of your CCA applications stands.
+        </p>
+      </header>
+      <MyApplicationsList />
+    </div>
+  );
+}

--- a/src/app/ccas/layout.tsx
+++ b/src/app/ccas/layout.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import Header from "~/app/_components/header";
+
+/** Session-dependent; never cached (a shared CCA list would leak one user's
+ *  membership badges to the next viewer). */
+export const dynamic = "force-dynamic";
+
+/**
+ * The resident-facing CCA surface: browse every CCA and apply to join.
+ *
+ * Unlike /cca (the head dashboard) this has NO headship gate — every signed-in,
+ * eligible resident may browse. Authorization for the actions lives in the
+ * procedures (assertApplicationsEnabled + ownership), so this layout only
+ * establishes "signed in", the same defence-in-depth role /cca/layout plays.
+ */
+export default async function CcasLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  return (
+    <div className="mb-14 min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+      {/* Must match the nav link's `name` in header.tsx. */}
+      <Header currentPage="CCAs" />
+      <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/ccas/page.tsx
+++ b/src/app/ccas/page.tsx
@@ -1,0 +1,19 @@
+import CcaBrowseGrid from "./_components/CcaBrowseGrid";
+
+export const dynamic = "force-dynamic";
+
+/** Browse every CCA and apply to join one. The layout established "signed in";
+ *  the grid's data comes from a procedure that enforces the kill switch. */
+export default function CcasBrowsePage() {
+  return (
+    <div>
+      <header className="mb-5">
+        <h1 className="text-2xl font-semibold text-gray-900">Explore CCAs</h1>
+        <p className="mt-0.5 text-sm text-gray-500">
+          Find a co-curricular activity and apply to become a member.
+        </p>
+      </header>
+      <CcaBrowseGrid />
+    </div>
+  );
+}

--- a/src/lib/schemas/ccaApplication.ts
+++ b/src/lib/schemas/ccaApplication.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+
+/**
+ * Shared validation for the CCA membership-application + interview workflow.
+ *
+ * Deliberately NOT under `src/server/`: the resident and head forms mirror this
+ * validation with a real `safeParse`, so they need the runtime VALUE, and a
+ * `"use client"` component value-importing from the server tree risks pulling
+ * Prisma into the browser bundle. Same reasoning, same location, as `cca.ts`
+ * and `profile.ts` beside it.
+ *
+ * SECURITY — every input object below must NEVER gain a `userID`, `status`,
+ * `decidedBy`, `decisionReason` (on a resident input), `ccaName`, `category` or
+ * `roles` key. The applicant is always `ctx.session.user.userID`, the status is
+ * a server-driven state machine, and the decision is a head-only field. zod
+ * strips unknown keys, so the only way a resident writes something they should
+ * not is if someone ADDS the key here. `ccaID`/`applicationID`/`slotID` are
+ * present but are TARGETS, not payload — authorised per request (assertHeadsCca
+ * for heads, ownership for residents).
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Status vocabulary — enforced in code (CcaApplication.status is a String)    */
+/* -------------------------------------------------------------------------- */
+
+export const APPLICATION_STATUSES = [
+  "submitted",
+  "interview_scheduled",
+  "interviewed",
+  "accepted",
+  "rejected",
+  "withdrawn",
+] as const;
+export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number];
+
+/**
+ * TERMINAL states end an application. Only these free the (ccaID, userID) pair
+ * for a fresh application, and only `accepted` writes membership. A row in any
+ * NON-terminal state is the "open application" a duplicate-apply check refuses.
+ */
+export const TERMINAL_STATUSES = [
+  "accepted",
+  "rejected",
+  "withdrawn",
+] as const satisfies readonly ApplicationStatus[];
+
+export function isTerminalStatus(status: string | null | undefined): boolean {
+  return (TERMINAL_STATUSES as readonly string[]).includes(status ?? "");
+}
+
+/* -------------------------------------------------------------------------- */
+/* Field bounds                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const APPLICATION_NOTES_MAX = 1500;
+export const INTERVIEW_LOCATION_MAX = 200;
+export const INTERVIEW_NOTE_MAX = 2000;
+export const DECISION_REASON_MAX = 1000;
+/** Soft cap on how many slots a head opens in one request — a sanity bound. */
+export const MAX_SLOTS_PER_OPEN = 50;
+
+/** Reused everywhere a CCA is the target. ccaID 0 is RESERVED (cascade.ts). */
+const ccaID = z.number().int().positive();
+const applicationID = z.number().int().positive();
+const slotID = z.number().int().positive();
+/** UNIX epoch SECONDS, matching Bookings.startTime/endTime. */
+const epochSeconds = z.number().int().positive();
+
+/* -------------------------------------------------------------------------- */
+/* Resident inputs                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Apply to join a CCA. `notes` is the applicant's own free text — trim + max
+ * ONLY, never sanitized (React escapes it on render; same reasoning as
+ * CcaProfile.description). "" is allowed: notes are optional.
+ */
+export const applyInput = z.object({
+  ccaID,
+  notes: z.string().trim().max(APPLICATION_NOTES_MAX).default(""),
+});
+export type ApplyInput = z.input<typeof applyInput>;
+
+/** Book an open interview slot against one's own application. */
+export const bookSlotInput = z.object({ applicationID, slotID });
+export type BookSlotInput = z.input<typeof bookSlotInput>;
+
+/** Withdraw an application, or cancel one's booked slot back to `submitted`. */
+export const applicationTargetInput = z.object({ applicationID });
+export type ApplicationTargetInput = z.input<typeof applicationTargetInput>;
+
+/** Browse one CCA / list its open slots. */
+export const ccaTargetInput = z.object({ ccaID });
+export type CcaTargetInput = z.input<typeof ccaTargetInput>;
+
+/* -------------------------------------------------------------------------- */
+/* Head inputs                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** One slot a head is opening. The clock check (not in the past) is server-side. */
+export const slotDraftSchema = z
+  .object({
+    startTime: epochSeconds,
+    endTime: epochSeconds,
+    location: z.string().trim().max(INTERVIEW_LOCATION_MAX).optional(),
+  })
+  .refine((s) => s.endTime > s.startTime, {
+    message: "END_BEFORE_START",
+    path: ["endTime"],
+  });
+export type SlotDraft = z.input<typeof slotDraftSchema>;
+
+export const openSlotsInput = z.object({
+  ccaID,
+  slots: z.array(slotDraftSchema).min(1).max(MAX_SLOTS_PER_OPEN),
+});
+export type OpenSlotsInput = z.input<typeof openSlotsInput>;
+
+/** Cancel a slot a head opened (open, or booked → reverts the application). */
+export const cancelSlotInput = z.object({ ccaID, slotID });
+export type CancelSlotInput = z.input<typeof cancelSlotInput>;
+
+/** View / act on one application within a CCA the caller heads. */
+export const headApplicationInput = z.object({ ccaID, applicationID });
+export type HeadApplicationInput = z.input<typeof headApplicationInput>;
+
+/** The head's review queue, optionally filtered by status. */
+export const listApplicationsInput = z.object({
+  ccaID,
+  status: z.enum(APPLICATION_STATUSES).optional(),
+});
+export type ListApplicationsInput = z.input<typeof listApplicationsInput>;
+
+/** Add an interview note. `body` is required (an empty note is meaningless). */
+export const addNoteInput = z.object({
+  ccaID,
+  applicationID,
+  body: z.string().trim().min(1).max(INTERVIEW_NOTE_MAX),
+});
+export type AddNoteInput = z.input<typeof addNoteInput>;
+
+/**
+ * Accept or reject an application. `decision` is head-only and the ONLY reason
+ * this file guards its vocabulary so tightly — a resident input must never carry
+ * it. `reason` is optional prose recorded on the application + audit row.
+ */
+export const decisionInput = z.object({
+  ccaID,
+  applicationID,
+  decision: z.enum(["accepted", "rejected"]),
+  reason: z.string().trim().max(DECISION_REASON_MAX).optional(),
+});
+export type DecisionInput = z.input<typeof decisionInput>;

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -5,6 +5,8 @@ import { userRouter } from "./routers/user";
 import { adminRouter } from "./routers/admin";
 import { ccaRouter } from "./routers/cca";
 import { ccaAdminRouter } from "./routers/ccaAdmin";
+import { ccaApplicationsRouter } from "./routers/ccaApplications";
+import { ccaApplicationsHeadRouter } from "./routers/ccaApplicationsHead";
 
 /**
  * This is the primary router for your server.
@@ -20,6 +22,10 @@ export const appRouter = createTRPCRouter({
   cca: ccaRouter,
   /** Admin-only CCA management, behind the cca.management.enabled switch. */
   ccaAdmin: ccaAdminRouter,
+  /** Resident-facing CCA applications, behind the cca.applications.enabled switch. */
+  ccaApplications: ccaApplicationsRouter,
+  /** CCA-head review/interview/decide, object-scoped by assertHeadsCca. */
+  ccaApplicationsHead: ccaApplicationsHeadRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -286,7 +286,10 @@ export const ccaApplicationsRouter = createTRPCRouter({
    * caller heads this CCA — plus the create run INSIDE withCcaLock so two
    * concurrent applies cannot both pass the "no open application" check.
    */
-  apply: identifiedProcedure
+  // NB: named `submitApplication`, not `apply` — tRPC reserves `apply` as a
+  // router key (it collides with Function.prototype.apply) and the build fails
+  // with "Reserved words used in router({}) call: apply".
+  submitApplication: identifiedProcedure
     .use(requireMatric)
     .input(applyInput)
     .mutation(async ({ ctx, input }) => {

--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -1,0 +1,589 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  createTRPCRouter,
+  identifiedProcedure,
+  requireMatric,
+} from "~/server/api/trpc";
+import { writeAudit } from "~/server/api/routers/admin";
+import { membershipKeysFor } from "~/server/api/services/ccaMembers";
+import {
+  APPLICATION_COUNTER_KEY,
+  assertApplicationsEnabled,
+  nextCounter,
+  withCcaLock,
+} from "~/server/api/services/ccaApplications";
+import {
+  applyInput,
+  applicationTargetInput,
+  bookSlotInput,
+  ccaTargetInput,
+  isTerminalStatus,
+} from "~/lib/schemas/ccaApplication";
+
+/**
+ * Resident-facing side of the CCA membership-application workflow.
+ *
+ * Every procedure is `identifiedProcedure` (a non-null canonical userID is the
+ * applicant key) and asserts `cca.applications.enabled` first — the whole
+ * surface is inert until that switch is on. Unlike cca.ts these are NOT
+ * object-scoped by headship: a resident acts on THEIR OWN applications, so the
+ * guard is OWNERSHIP (app.userID === caller), and a mismatch returns NOT_FOUND
+ * rather than FORBIDDEN so an applicationID is not an existence oracle.
+ *
+ * The head-facing half (review, open slots, decide) lives in
+ * ccaApplicationsHead.ts, guarded by assertHeadsCca — the same split, and for
+ * the same reason, as cca.ts vs ccaAdmin.ts.
+ *
+ * Times are UNIX epoch SECONDS (Int), matching Bookings and CcaInterviewSlot.
+ */
+
+/** Load the caller's own application, or 404 — never leak another's existence. */
+async function ownApplicationOr404(
+  db: PrismaClient,
+  applicationID: number,
+  userID: string,
+) {
+  const app = await db.ccaApplication.findUnique({
+    where: { applicationID },
+    select: {
+      applicationID: true,
+      ccaID: true,
+      userID: true,
+      status: true,
+      interviewSlotID: true,
+    },
+  });
+  if (!app || app.userID !== userID) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_APPLICATION" });
+  }
+  return app;
+}
+
+/**
+ * Return a slot to the open pool, but ONLY if it is still this resident's — a
+ * conditional updateMany, so a slot the head already reassigned or canceled is
+ * never clobbered. Idempotent: a no-op if the slot moved on.
+ */
+async function releaseSlotIfMine(
+  db: PrismaClient,
+  slotID: number,
+  userID: string,
+): Promise<void> {
+  await db.ccaInterviewSlot.updateMany({
+    where: { slotID, bookedByUserID: userID },
+    data: { bookedByUserID: null, bookedApplicationID: null, bookedAt: null },
+  });
+}
+
+export const ccaApplicationsRouter = createTRPCRouter({
+  /**
+   * Browse every CCA with the caller's own status against each: are they a
+   * member, and do they have an application in flight. This is the /ccas grid.
+   */
+  browse: identifiedProcedure.query(async ({ ctx }) => {
+    await assertApplicationsEnabled(ctx.db);
+    const userID = ctx.session.user.userID;
+    const keys = membershipKeysFor({
+      email: ctx.session.user.email ?? "",
+      userID,
+    });
+
+    const [ccas, profiles, memberships, myApps] = await Promise.all([
+      ctx.db.cCA.findMany({
+        select: { ccaID: true, ccaName: true, category: true },
+      }),
+      ctx.db.ccaProfile.findMany({
+        select: { ccaID: true, description: true, logoUrl: true },
+      }),
+      ctx.db.userCCA.findMany({
+        where: { userID: { in: keys } },
+        select: { ccaID: true },
+      }),
+      // Applications are always written under the CANONICAL key, so one key
+      // suffices here (unlike membership, which is mixed-format).
+      ctx.db.ccaApplication.findMany({
+        where: { userID },
+        select: { ccaID: true, status: true },
+        orderBy: { applicationID: "desc" },
+      }),
+    ]);
+
+    const profileByID = new Map(profiles.map((p) => [p.ccaID, p]));
+    const memberOf = new Set(memberships.map((m) => m.ccaID));
+    // First (most recent) application per CCA is the one the badge reflects.
+    const appByCca = new Map<number, string | null>();
+    for (const a of myApps) {
+      if (!appByCca.has(a.ccaID)) appByCca.set(a.ccaID, a.status);
+    }
+
+    const rows = ccas.map((c) => {
+      const status = appByCca.get(c.ccaID) ?? null;
+      return {
+        ccaID: c.ccaID,
+        ccaName: c.ccaName,
+        category: c.category,
+        description: profileByID.get(c.ccaID)?.description ?? null,
+        logoUrl: profileByID.get(c.ccaID)?.logoUrl ?? null,
+        isMember: memberOf.has(c.ccaID),
+        // The status of the caller's most recent application, if any.
+        applicationStatus: status,
+      };
+    });
+
+    rows.sort(
+      (a, b) =>
+        (a.category ?? "￿").localeCompare(b.category ?? "￿") ||
+        a.ccaName.localeCompare(b.ccaName),
+    );
+    return { ccas: rows };
+  }),
+
+  /**
+   * One CCA's detail for the /ccas/[ccaID] page: profile, the caller's own
+   * membership + latest application, and whether they may apply right now.
+   */
+  getCca: identifiedProcedure
+    .input(ccaTargetInput)
+    .query(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const keys = membershipKeysFor({
+        email: ctx.session.user.email ?? "",
+        userID,
+      });
+      const now = Math.floor(Date.now() / 1000);
+
+      const cca = await ctx.db.cCA.findUnique({
+        where: { ccaID: input.ccaID },
+        select: { ccaID: true, ccaName: true, category: true },
+      });
+      if (!cca) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
+      }
+
+      const [profile, membership, apps, openSlotCount] = await Promise.all([
+        ctx.db.ccaProfile.findUnique({
+          where: { ccaID: input.ccaID },
+          select: { description: true, logoUrl: true, bannerUrl: true },
+        }),
+        ctx.db.userCCA.findFirst({
+          where: { ccaID: input.ccaID, userID: { in: keys } },
+          select: { id: true },
+        }),
+        ctx.db.ccaApplication.findMany({
+          where: { ccaID: input.ccaID, userID },
+          select: {
+            applicationID: true,
+            status: true,
+            notes: true,
+            interviewSlotID: true,
+            decisionReason: true,
+          },
+          orderBy: { applicationID: "desc" },
+        }),
+        ctx.db.ccaInterviewSlot.count({
+          where: {
+            ccaID: input.ccaID,
+            bookedByUserID: null,
+            canceledAt: null,
+            endTime: { gt: now },
+          },
+        }),
+      ]);
+
+      const latest = apps[0] ?? null;
+      const hasOpenApplication =
+        latest !== null && !isTerminalStatus(latest.status);
+      const isMember = membership !== null;
+
+      return {
+        ccaID: cca.ccaID,
+        ccaName: cca.ccaName,
+        category: cca.category,
+        description: profile?.description ?? null,
+        logoUrl: profile?.logoUrl ?? null,
+        bannerUrl: profile?.bannerUrl ?? null,
+        isMember,
+        application: latest,
+        // The client still shows an Apply button and the server re-checks — this
+        // just drives the default affordance.
+        canApply: !isMember && !hasOpenApplication,
+        openSlotCount,
+      };
+    }),
+
+  /**
+   * The caller's applications across all CCAs, with the CCA name and — for a
+   * scheduled interview — the booked slot's time. Drives /ccas/applications.
+   */
+  myApplications: identifiedProcedure.query(async ({ ctx }) => {
+    await assertApplicationsEnabled(ctx.db);
+    const userID = ctx.session.user.userID;
+
+    const apps = await ctx.db.ccaApplication.findMany({
+      where: { userID },
+      select: {
+        applicationID: true,
+        ccaID: true,
+        status: true,
+        notes: true,
+        interviewSlotID: true,
+        decisionReason: true,
+        createdAt: true,
+        decidedAt: true,
+      },
+      orderBy: { applicationID: "desc" },
+    });
+    if (apps.length === 0) return { applications: [] };
+
+    const ccaIDs = [...new Set(apps.map((a) => a.ccaID))];
+    const slotIDs = apps
+      .map((a) => a.interviewSlotID)
+      .filter((s): s is number => s !== null);
+
+    const [ccas, slots] = await Promise.all([
+      ctx.db.cCA.findMany({
+        where: { ccaID: { in: ccaIDs } },
+        select: { ccaID: true, ccaName: true },
+      }),
+      slotIDs.length > 0
+        ? ctx.db.ccaInterviewSlot.findMany({
+            where: { slotID: { in: slotIDs } },
+            select: {
+              slotID: true,
+              startTime: true,
+              endTime: true,
+              location: true,
+            },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const ccaName = new Map(ccas.map((c) => [c.ccaID, c.ccaName]));
+    const slotByID = new Map(slots.map((s) => [s.slotID, s]));
+
+    return {
+      applications: apps.map((a) => ({
+        ...a,
+        ccaName: ccaName.get(a.ccaID) ?? null,
+        slot:
+          a.interviewSlotID !== null
+            ? (slotByID.get(a.interviewSlotID) ?? null)
+            : null,
+      })),
+    };
+  }),
+
+  /**
+   * Apply to join a CCA. matric-gated (applying is an onboarding-complete
+   * action, like booking) via requireMatric, which is a no-op until
+   * rbac.matric.enforcement is turned on.
+   *
+   * The three refusals — already a member, an application already open, the
+   * caller heads this CCA — plus the create run INSIDE withCcaLock so two
+   * concurrent applies cannot both pass the "no open application" check.
+   */
+  apply: identifiedProcedure
+    .use(requireMatric)
+    .input(applyInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const email = ctx.session.user.email ?? "";
+
+      const cca = await ctx.db.cCA.findUnique({
+        where: { ccaID: input.ccaID },
+        select: { ccaID: true },
+      });
+      if (!cca) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
+      }
+
+      // Policy: a head does not apply to their own CCA (they are already inside
+      // it). Checked before the lock — it needs no serialization.
+      const heads = await ctx.db.ccaHead.findUnique({
+        where: { userID_ccaID: { userID, ccaID: input.ccaID } },
+        select: { id: true },
+      });
+      if (heads) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "HEAD_CANNOT_APPLY",
+        });
+      }
+
+      return withCcaLock(ctx.db, input.ccaID, async () => {
+        const keys = membershipKeysFor({ email, userID });
+        const member = await ctx.db.userCCA.findFirst({
+          where: { ccaID: input.ccaID, userID: { in: keys } },
+          select: { id: true },
+        });
+        if (member) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "ALREADY_MEMBER",
+          });
+        }
+
+        // Any NON-terminal application for this person+CCA blocks a new one.
+        // Filtered in code (not `notIn`) so a null/unknown status is handled
+        // explicitly rather than by Mongo's null semantics.
+        const existing = await ctx.db.ccaApplication.findMany({
+          where: { ccaID: input.ccaID, userID },
+          select: { status: true },
+        });
+        if (existing.some((a) => !isTerminalStatus(a.status))) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "APPLICATION_OPEN",
+          });
+        }
+
+        const applicationID = await nextCounter(
+          ctx.db,
+          APPLICATION_COUNTER_KEY,
+        );
+        const now = new Date();
+        await ctx.db.ccaApplication.create({
+          data: {
+            applicationID,
+            ccaID: input.ccaID,
+            userID,
+            notes: input.notes,
+            status: "submitted",
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: ctx.session.user.roles,
+          targetCcaID: input.ccaID,
+          action: "ccaApplication.submit",
+          reason: `application #${applicationID} (${input.notes.length} chars of notes)`,
+        });
+
+        return { applicationID, status: "submitted" as const };
+      });
+    }),
+
+  /**
+   * Open, future, unclaimed interview slots for a CCA — only visible to a
+   * resident who has a live (non-terminal) application there. Also reports the
+   * slot the caller currently holds, so the UI can offer a rebook.
+   */
+  availableSlots: identifiedProcedure
+    .input(ccaTargetInput)
+    .query(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const now = Math.floor(Date.now() / 1000);
+
+      const apps = await ctx.db.ccaApplication.findMany({
+        where: { ccaID: input.ccaID, userID },
+        select: { status: true, interviewSlotID: true },
+        orderBy: { applicationID: "desc" },
+      });
+      const live = apps.find((a) => !isTerminalStatus(a.status));
+      if (!live) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "NO_OPEN_APPLICATION",
+        });
+      }
+
+      const slots = await ctx.db.ccaInterviewSlot.findMany({
+        where: {
+          ccaID: input.ccaID,
+          bookedByUserID: null,
+          canceledAt: null,
+          endTime: { gt: now },
+        },
+        select: {
+          slotID: true,
+          startTime: true,
+          endTime: true,
+          location: true,
+        },
+        orderBy: { startTime: "asc" },
+      });
+
+      return { slots, mySlotID: live.interviewSlotID };
+    }),
+
+  /**
+   * Book an open slot against one's own live application. Rebooking is allowed
+   * and releases the previously held slot in the same locked section, so the two
+   * cannot both end up claimed.
+   */
+  bookSlot: identifiedProcedure
+    .input(bookSlotInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+
+      // Read once outside the lock to learn the ccaID to lock on; everything is
+      // re-read and re-checked inside.
+      const pre = await ownApplicationOr404(ctx.db, input.applicationID, userID);
+
+      return withCcaLock(ctx.db, pre.ccaID, async () => {
+        const app = await ownApplicationOr404(
+          ctx.db,
+          input.applicationID,
+          userID,
+        );
+        if (isTerminalStatus(app.status)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "APPLICATION_CLOSED",
+          });
+        }
+
+        const now = Math.floor(Date.now() / 1000);
+        const slot = await ctx.db.ccaInterviewSlot.findUnique({
+          where: { slotID: input.slotID },
+          select: {
+            slotID: true,
+            ccaID: true,
+            endTime: true,
+            canceledAt: true,
+            bookedByUserID: true,
+          },
+        });
+        if (!slot || slot.ccaID !== app.ccaID || slot.canceledAt !== null) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_SLOT" });
+        }
+        if (slot.endTime !== null && slot.endTime <= now) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
+        }
+        if (slot.bookedByUserID !== null) {
+          throw new TRPCError({ code: "CONFLICT", message: "SLOT_TAKEN" });
+        }
+
+        // Rebook: free the old slot first (only if still ours).
+        if (app.interviewSlotID !== null && app.interviewSlotID !== input.slotID) {
+          await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
+        }
+
+        await ctx.db.ccaInterviewSlot.update({
+          where: { slotID: input.slotID },
+          data: {
+            bookedByUserID: userID,
+            bookedApplicationID: app.applicationID,
+            bookedAt: new Date(),
+          },
+        });
+        await ctx.db.ccaApplication.update({
+          where: { applicationID: app.applicationID },
+          data: {
+            status: "interview_scheduled",
+            interviewSlotID: input.slotID,
+            updatedAt: new Date(),
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: ctx.session.user.roles,
+          targetCcaID: app.ccaID,
+          action: "ccaApplication.bookSlot",
+          reason: `application #${app.applicationID} → slot #${input.slotID}`,
+        });
+
+        return { applicationID: app.applicationID, slotID: input.slotID };
+      });
+    }),
+
+  /** Cancel one's booked interview, releasing the slot and reverting to submitted. */
+  cancelSlot: identifiedProcedure
+    .input(applicationTargetInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const pre = await ownApplicationOr404(ctx.db, input.applicationID, userID);
+
+      return withCcaLock(ctx.db, pre.ccaID, async () => {
+        const app = await ownApplicationOr404(
+          ctx.db,
+          input.applicationID,
+          userID,
+        );
+        if (app.status !== "interview_scheduled" || app.interviewSlotID === null) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "NO_SCHEDULED_INTERVIEW",
+          });
+        }
+
+        await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
+        await ctx.db.ccaApplication.update({
+          where: { applicationID: app.applicationID },
+          data: {
+            status: "submitted",
+            interviewSlotID: null,
+            updatedAt: new Date(),
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: ctx.session.user.roles,
+          targetCcaID: app.ccaID,
+          action: "ccaApplication.cancelSlot",
+          reason: `application #${app.applicationID} released slot #${app.interviewSlotID}`,
+        });
+
+        return { applicationID: app.applicationID };
+      });
+    }),
+
+  /** Withdraw an application entirely. Frees any booked slot; terminal. */
+  withdraw: identifiedProcedure
+    .input(applicationTargetInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const pre = await ownApplicationOr404(ctx.db, input.applicationID, userID);
+
+      return withCcaLock(ctx.db, pre.ccaID, async () => {
+        const app = await ownApplicationOr404(
+          ctx.db,
+          input.applicationID,
+          userID,
+        );
+        if (isTerminalStatus(app.status)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "ALREADY_CLOSED",
+          });
+        }
+
+        if (app.interviewSlotID !== null) {
+          await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
+        }
+        await ctx.db.ccaApplication.update({
+          where: { applicationID: app.applicationID },
+          data: {
+            status: "withdrawn",
+            interviewSlotID: null,
+            withdrawnAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: ctx.session.user.roles,
+          targetCcaID: app.ccaID,
+          action: "ccaApplication.withdraw",
+          reason: `application #${app.applicationID}`,
+        });
+
+        return { applicationID: app.applicationID };
+      });
+    }),
+});

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -242,6 +242,10 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       );
 
       return {
+        // ...app carries the APPLICANT's own `notes` string. The interview
+        // notes are a separate array under `interviewNotes` so the two never
+        // collide (an earlier version overwrote `notes` and lost the applicant
+        // text).
         ...app,
         applicant: people.get(app.userID) ?? {
           displayName: null,
@@ -249,7 +253,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           matric: null,
         },
         slot,
-        notes: notes.map((n) => ({
+        interviewNotes: notes.map((n) => ({
           id: n.id,
           body: n.body,
           createdAt: n.createdAt,

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -1,0 +1,680 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+import { randomUUID } from "node:crypto";
+
+import { createTRPCRouter, identifiedProcedure } from "~/server/api/trpc";
+import { getUserRoles } from "~/server/api/services/access";
+import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import { writeAudit } from "~/server/api/routers/admin";
+import { membershipKeysFor } from "~/server/api/services/ccaMembers";
+import {
+  assertApplicationsEnabled,
+  nextCounter,
+  SLOT_COUNTER_KEY,
+  withCcaLock,
+} from "~/server/api/services/ccaApplications";
+import {
+  addNoteInput,
+  cancelSlotInput,
+  ccaTargetInput,
+  decisionInput,
+  headApplicationInput,
+  isTerminalStatus,
+  listApplicationsInput,
+  openSlotsInput,
+} from "~/lib/schemas/ccaApplication";
+import { canonicalUserID } from "~/lib/identity";
+
+/**
+ * CCA-head-facing side of the applications workflow: review the queue, open and
+ * cancel interview slots, record interview notes, and accept/reject.
+ *
+ * THE ONE RULE, identical to cca.ts: every procedure takes `input.ccaID` from
+ * the client and MUST call assertHeadsCca before touching CCA-scoped data — the
+ * builder only narrows identity. `roles` for that call is ALWAYS a live
+ * getUserRoles() read (I-5), never session.user.roles. And every procedure
+ * asserts cca.applications.enabled first: the surface is inert until the switch
+ * is on.
+ *
+ * Acceptance ends in the exact `UserCCA.create({ ccaID, userID })` write that
+ * ccaAdmin.addMember performs (canonical key, deduped against both key formats),
+ * because "make this resident a member" is a single membership row and that is
+ * the only writer of one.
+ */
+
+/**
+ * Resolve canonical applicant ids to a human: displayName, email, matric. Same
+ * approach as cca.listHeads (there is no reverse canonical→User query, so guess
+ * the email AND match the stored key), plus the matric from UserMatric.
+ */
+async function resolveApplicants(
+  db: PrismaClient,
+  userIDs: readonly string[],
+): Promise<
+  Map<string, { displayName: string | null; email: string | null; matric: string | null }>
+> {
+  const keys = [...new Set(userIDs)];
+  const out = new Map<
+    string,
+    { displayName: string | null; email: string | null; matric: string | null }
+  >();
+  if (keys.length === 0) return out;
+
+  const guessedEmails = keys.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+  const [byEmail, byStored, matrics] = await Promise.all([
+    db.user.findMany({
+      where: { email: { in: guessedEmails, mode: "insensitive" } },
+      // Never a bare read: passwordHash must not leave the server (I-2).
+      select: { email: true, displayName: true, userID: true },
+    }),
+    db.user.findMany({
+      where: { userID: { in: keys } },
+      select: { email: true, displayName: true, userID: true },
+    }),
+    db.userMatric.findMany({
+      where: { userID: { in: keys } },
+      select: { userID: true, matric: true },
+    }),
+  ]);
+
+  const matricByKey = new Map(matrics.map((m) => [m.userID, m.matric]));
+  const set = (
+    key: string,
+    v: { displayName: string | null; email: string | null },
+  ) => {
+    if (!out.has(key)) {
+      out.set(key, { ...v, matric: matricByKey.get(key) ?? null });
+    }
+  };
+  for (const u of byEmail) {
+    const cid = canonicalUserID(u.email);
+    if (cid) set(cid, { displayName: u.displayName, email: u.email });
+  }
+  for (const u of byStored) {
+    if (u.userID) set(u.userID, { displayName: u.displayName, email: u.email });
+  }
+  // Ensure every requested key is present, even if unresolved (amber in the UI).
+  for (const k of keys) {
+    if (!out.has(k)) {
+      out.set(k, { displayName: null, email: null, matric: matricByKey.get(k) ?? null });
+    }
+  }
+  return out;
+}
+
+/** Half-open overlap: two intervals collide iff aStart < bEnd AND bStart < aEnd. */
+function overlaps(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+export const ccaApplicationsHeadRouter = createTRPCRouter({
+  /** The review queue for one CCA, optionally filtered by status. */
+  listApplications: identifiedProcedure
+    .input(listApplicationsInput)
+    .query(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const apps = await ctx.db.ccaApplication.findMany({
+        where: {
+          ccaID: input.ccaID,
+          ...(input.status ? { status: input.status } : {}),
+        },
+        select: {
+          applicationID: true,
+          userID: true,
+          status: true,
+          notes: true,
+          interviewSlotID: true,
+          createdAt: true,
+          decidedAt: true,
+          decisionReason: true,
+        },
+        orderBy: { applicationID: "desc" },
+      });
+
+      const [people, slots] = await Promise.all([
+        resolveApplicants(ctx.db, apps.map((a) => a.userID)),
+        (async () => {
+          const slotIDs = apps
+            .map((a) => a.interviewSlotID)
+            .filter((s): s is number => s !== null);
+          if (slotIDs.length === 0) return new Map<number, { startTime: number | null; endTime: number | null; location: string | null }>();
+          const rows = await ctx.db.ccaInterviewSlot.findMany({
+            where: { slotID: { in: slotIDs } },
+            select: { slotID: true, startTime: true, endTime: true, location: true },
+          });
+          return new Map(rows.map((r) => [r.slotID, r]));
+        })(),
+      ]);
+
+      return {
+        applications: apps.map((a) => ({
+          applicationID: a.applicationID,
+          userID: a.userID,
+          status: a.status,
+          notes: a.notes,
+          createdAt: a.createdAt,
+          decidedAt: a.decidedAt,
+          decisionReason: a.decisionReason,
+          applicant: people.get(a.userID) ?? {
+            displayName: null,
+            email: null,
+            matric: null,
+          },
+          slot:
+            a.interviewSlotID !== null
+              ? (slots.get(a.interviewSlotID) ?? null)
+              : null,
+        })),
+      };
+    }),
+
+  /** One application in full — for the head to read DURING the interview. */
+  getApplication: identifiedProcedure
+    .input(headApplicationInput)
+    .query(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const app = await ctx.db.ccaApplication.findUnique({
+        where: { applicationID: input.applicationID },
+        select: {
+          applicationID: true,
+          ccaID: true,
+          userID: true,
+          status: true,
+          notes: true,
+          interviewSlotID: true,
+          createdAt: true,
+          decidedAt: true,
+          decidedBy: true,
+          decisionReason: true,
+        },
+      });
+      // ccaID from the row must match the authorised scope — an applicationID
+      // from another CCA is NOT_FOUND to a head who does not head that CCA.
+      if (!app || app.ccaID !== input.ccaID) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "NO_SUCH_APPLICATION",
+        });
+      }
+
+      const [people, notes, slot] = await Promise.all([
+        resolveApplicants(ctx.db, [app.userID]),
+        ctx.db.ccaInterviewNote.findMany({
+          where: { applicationID: app.applicationID },
+          select: {
+            id: true,
+            authorUserID: true,
+            body: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: "asc" },
+        }),
+        app.interviewSlotID !== null
+          ? ctx.db.ccaInterviewSlot.findUnique({
+              where: { slotID: app.interviewSlotID },
+              select: {
+                slotID: true,
+                startTime: true,
+                endTime: true,
+                location: true,
+              },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      const authors = await resolveApplicants(
+        ctx.db,
+        notes.map((n) => n.authorUserID).filter((a): a is string => a !== null),
+      );
+
+      return {
+        ...app,
+        applicant: people.get(app.userID) ?? {
+          displayName: null,
+          email: null,
+          matric: null,
+        },
+        slot,
+        notes: notes.map((n) => ({
+          id: n.id,
+          body: n.body,
+          createdAt: n.createdAt,
+          authorUserID: n.authorUserID,
+          authorName:
+            (n.authorUserID && authors.get(n.authorUserID)?.displayName) ||
+            n.authorUserID ||
+            null,
+        })),
+      };
+    }),
+
+  /** All interview slots for a CCA, with who booked each — the head's calendar. */
+  listSlots: identifiedProcedure
+    .input(ccaTargetInput)
+    .query(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const slots = await ctx.db.ccaInterviewSlot.findMany({
+        where: { ccaID: input.ccaID, canceledAt: null },
+        select: {
+          slotID: true,
+          startTime: true,
+          endTime: true,
+          location: true,
+          bookedByUserID: true,
+          bookedApplicationID: true,
+        },
+        orderBy: { startTime: "asc" },
+      });
+
+      const booked = slots
+        .map((s) => s.bookedByUserID)
+        .filter((u): u is string => u !== null);
+      const people = await resolveApplicants(ctx.db, booked);
+
+      return {
+        slots: slots.map((s) => ({
+          ...s,
+          bookedBy:
+            s.bookedByUserID !== null
+              ? (people.get(s.bookedByUserID) ?? {
+                  displayName: null,
+                  email: null,
+                  matric: null,
+                })
+              : null,
+        })),
+      };
+    }),
+
+  /**
+   * Open one or more interview slots. Rejects a slot in the past, a zero/negative
+   * duration (the schema already blocks end<=start), or one overlapping an
+   * existing open slot OR another slot in the same batch.
+   */
+  openSlots: identifiedProcedure
+    .input(openSlotsInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+      const now = Math.floor(Date.now() / 1000);
+
+      if (input.slots.some((s) => s.endTime <= now)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
+      }
+
+      const existing = await ctx.db.ccaInterviewSlot.findMany({
+        where: { ccaID: input.ccaID, canceledAt: null },
+        select: { startTime: true, endTime: true },
+      });
+
+      // Against existing slots and against slots earlier in this same batch.
+      const accepted: { startTime: number; endTime: number }[] = [];
+      for (const s of input.slots) {
+        const clash =
+          existing.some(
+            (e) =>
+              e.startTime !== null &&
+              e.endTime !== null &&
+              overlaps(s.startTime, s.endTime, e.startTime, e.endTime),
+          ) ||
+          accepted.some((e) =>
+            overlaps(s.startTime, s.endTime, e.startTime, e.endTime),
+          );
+        if (clash) {
+          throw new TRPCError({ code: "CONFLICT", message: "SLOT_OVERLAP" });
+        }
+        accepted.push({ startTime: s.startTime, endTime: s.endTime });
+      }
+
+      const batchId = randomUUID();
+      const created: number[] = [];
+      for (const s of input.slots) {
+        const slotID = await nextCounter(ctx.db, SLOT_COUNTER_KEY);
+        await ctx.db.ccaInterviewSlot.create({
+          data: {
+            slotID,
+            ccaID: input.ccaID,
+            startTime: s.startTime,
+            endTime: s.endTime,
+            location: s.location ?? null,
+            createdBy: userID,
+            createdAt: new Date(),
+          },
+        });
+        created.push(slotID);
+      }
+
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        action: "ccaInterviewSlot.open",
+        batchId,
+        reason: `${scope.via}: opened ${created.length} slot(s)`,
+      });
+
+      return { ccaID: input.ccaID, opened: created.length, slotIDs: created };
+    }),
+
+  /**
+   * Cancel a slot. If it was booked, the applicant's application is reverted to
+   * `submitted` (so they can rebook) BEFORE the slot is marked canceled — a
+   * booked slot is never yanked out from under a resident silently.
+   */
+  cancelSlot: identifiedProcedure
+    .input(cancelSlotInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      return withCcaLock(ctx.db, input.ccaID, async () => {
+        const slot = await ctx.db.ccaInterviewSlot.findUnique({
+          where: { slotID: input.slotID },
+          select: {
+            slotID: true,
+            ccaID: true,
+            canceledAt: true,
+            bookedApplicationID: true,
+          },
+        });
+        if (!slot || slot.ccaID !== input.ccaID || slot.canceledAt !== null) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_SLOT" });
+        }
+
+        let revertedApplicationID: number | null = null;
+        if (slot.bookedApplicationID !== null) {
+          // Only revert if that application is still pointing at THIS slot and
+          // is not already decided.
+          const reverted = await ctx.db.ccaApplication.updateMany({
+            where: {
+              applicationID: slot.bookedApplicationID,
+              interviewSlotID: slot.slotID,
+              status: "interview_scheduled",
+            },
+            data: {
+              status: "submitted",
+              interviewSlotID: null,
+              updatedAt: new Date(),
+            },
+          });
+          if (reverted.count > 0) revertedApplicationID = slot.bookedApplicationID;
+        }
+
+        await ctx.db.ccaInterviewSlot.update({
+          where: { slotID: input.slotID },
+          data: {
+            canceledAt: new Date(),
+            bookedByUserID: null,
+            bookedApplicationID: null,
+            bookedAt: null,
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetCcaID: input.ccaID,
+          action: "ccaInterviewSlot.cancel",
+          reason: `${scope.via}: canceled slot #${input.slotID}${
+            revertedApplicationID !== null
+              ? ` (reverted application #${revertedApplicationID})`
+              : ""
+          }`,
+        });
+
+        return { slotID: input.slotID, revertedApplicationID };
+      });
+    }),
+
+  /** Append an interview note to an application. */
+  addNote: identifiedProcedure
+    .input(addNoteInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const app = await ctx.db.ccaApplication.findUnique({
+        where: { applicationID: input.applicationID },
+        select: { ccaID: true },
+      });
+      if (!app || app.ccaID !== input.ccaID) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "NO_SUCH_APPLICATION",
+        });
+      }
+
+      const note = await ctx.db.ccaInterviewNote.create({
+        data: {
+          applicationID: input.applicationID,
+          ccaID: input.ccaID,
+          authorUserID: userID,
+          body: input.body,
+          createdAt: new Date(),
+        },
+        select: { id: true, createdAt: true },
+      });
+
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: input.ccaID,
+        action: "ccaInterviewNote.add",
+        reason: `application #${input.applicationID} (${input.body.length} chars)`,
+      });
+
+      return { id: note.id, createdAt: note.createdAt };
+    }),
+
+  /** Mark a scheduled/submitted application as interviewed (optional stage). */
+  markInterviewed: identifiedProcedure
+    .input(headApplicationInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const updated = await ctx.db.ccaApplication.updateMany({
+        where: {
+          applicationID: input.applicationID,
+          ccaID: input.ccaID,
+          status: { in: ["submitted", "interview_scheduled"] },
+        },
+        data: { status: "interviewed", updatedAt: new Date() },
+      });
+      if (updated.count === 0) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "NOT_INTERVIEWABLE",
+        });
+      }
+      return { applicationID: input.applicationID, status: "interviewed" as const };
+    }),
+
+  /**
+   * THE ACCEPT/REJECT STEP. Under withCcaLock so two heads cannot both decide
+   * one application. Accept writes the UserCCA membership row (canonical key,
+   * deduped against both formats exactly as ccaAdmin.addMember), then records
+   * the decision; reject frees any FUTURE booked slot for other applicants.
+   */
+  decide: identifiedProcedure
+    .input(decisionInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      return withCcaLock(ctx.db, input.ccaID, async () => {
+        const app = await ctx.db.ccaApplication.findUnique({
+          where: { applicationID: input.applicationID },
+          select: {
+            applicationID: true,
+            ccaID: true,
+            userID: true,
+            status: true,
+            interviewSlotID: true,
+          },
+        });
+        if (!app || app.ccaID !== input.ccaID) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "NO_SUCH_APPLICATION",
+          });
+        }
+        if (isTerminalStatus(app.status)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "ALREADY_DECIDED",
+          });
+        }
+
+        const batchId = randomUUID();
+        const now = new Date();
+
+        if (input.decision === "accepted") {
+          // Resolve the applicant's key set the same way ccaAdmin.addMember
+          // does, so we don't add a canonical row next to an existing legacy
+          // one for the same person.
+          const target = await ctx.db.user.findFirst({
+            where: {
+              OR: [
+                {
+                  email: {
+                    equals: `${app.userID.toLowerCase()}@u.nus.edu`,
+                    mode: "insensitive",
+                  },
+                },
+                { userID: app.userID },
+              ],
+            },
+            select: { email: true, userID: true },
+          });
+          const keys = target ? membershipKeysFor(target) : [app.userID];
+
+          const already = await ctx.db.userCCA.findFirst({
+            where: { ccaID: app.ccaID, userID: { in: keys } },
+            select: { id: true },
+          });
+          if (!already) {
+            await ctx.db.userCCA.create({
+              data: { ccaID: app.ccaID, userID: app.userID },
+            });
+          }
+
+          await ctx.db.ccaApplication.update({
+            where: { applicationID: app.applicationID },
+            data: {
+              status: "accepted",
+              decidedBy: userID,
+              decidedAt: now,
+              decisionReason: input.reason ?? null,
+              updatedAt: now,
+            },
+          });
+
+          await writeAudit(ctx.db, {
+            actorUserID: userID,
+            actorRoles: roles,
+            targetCcaID: app.ccaID,
+            targetUserID: app.userID,
+            action: "ccaApplication.accept",
+            batchId,
+            reason: `${scope.via}: application #${app.applicationID}${
+              input.reason ? ` — ${input.reason}` : ""
+            }`,
+          });
+          // Paired membership row, so the roster change is attributable — the
+          // same action string ccaAdmin.addMember writes.
+          await writeAudit(ctx.db, {
+            actorUserID: userID,
+            actorRoles: roles,
+            targetCcaID: app.ccaID,
+            targetUserID: app.userID,
+            action: "ccaMember.add",
+            batchId,
+            reason: already
+              ? "already a member (accept was idempotent)"
+              : "via application acceptance",
+          });
+
+          return {
+            applicationID: app.applicationID,
+            status: "accepted" as const,
+            alreadyMember: already !== null,
+          };
+        }
+
+        // REJECT. Free a still-future booked slot so another applicant can take
+        // it; a past interview slot is left as the historical record.
+        if (app.interviewSlotID !== null) {
+          const nowSec = Math.floor(Date.now() / 1000);
+          await ctx.db.ccaInterviewSlot.updateMany({
+            where: {
+              slotID: app.interviewSlotID,
+              bookedApplicationID: app.applicationID,
+              endTime: { gt: nowSec },
+            },
+            data: {
+              bookedByUserID: null,
+              bookedApplicationID: null,
+              bookedAt: null,
+            },
+          });
+        }
+
+        await ctx.db.ccaApplication.update({
+          where: { applicationID: app.applicationID },
+          data: {
+            status: "rejected",
+            decidedBy: userID,
+            decidedAt: now,
+            decisionReason: input.reason ?? null,
+            updatedAt: now,
+          },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetCcaID: app.ccaID,
+          targetUserID: app.userID,
+          action: "ccaApplication.reject",
+          reason: `${scope.via}: application #${app.applicationID}${
+            input.reason ? ` — ${input.reason}` : ""
+          }`,
+        });
+
+        return {
+          applicationID: app.applicationID,
+          status: "rejected" as const,
+          alreadyMember: false,
+        };
+      });
+    }),
+});

--- a/src/server/api/services/ccaApplications.ts
+++ b/src/server/api/services/ccaApplications.ts
@@ -1,0 +1,172 @@
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Infrastructure for the CCA membership-application + interview workflow: the
+ * feature's kill switch, an atomic id allocator, and a per-CCA advisory lock.
+ *
+ * The lock and counter reuse the SAME `BookingLock` and `Counter` collections
+ * the booking system uses (booking.ts) — a different key namespace, not a new
+ * collection — so they inherit the unique indexes that make them safe. Requires
+ * `prisma db push` so those indexes exist.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* The applications kill switch                                                */
+/* -------------------------------------------------------------------------- */
+
+const APPLICATIONS_FLAG_KEY = "cca.applications.enabled";
+const FLAG_TTL_MS = 15_000;
+
+let flagCache: { at: number; on: boolean } | null = null;
+
+/**
+ * Gates the ENTIRE applications surface — resident apply/book and head
+ * review/decide alike.
+ *
+ * Same shape as `isCcaManagementEnabled` (ccaScope.ts), and for the same
+ * reason: this is a NEW WRITE SURFACE, so "behave as yesterday" means DISABLED,
+ * not "no gate". An unreachable flag returns false and an absent row returns
+ * false — the surface is inert until someone deliberately writes
+ * `cca.applications.enabled = "on"`. Fails CLOSED, and the closed result is
+ * deliberately NOT cached so a transient Atlas hiccup does not pin "disabled"
+ * for 15s.
+ */
+export async function isApplicationsEnabled(
+  db: PrismaClient,
+): Promise<boolean> {
+  if (flagCache && Date.now() - flagCache.at < FLAG_TTL_MS) {
+    return flagCache.on;
+  }
+  try {
+    const row = await db.systemFlag.findUnique({
+      where: { key: APPLICATIONS_FLAG_KEY },
+    });
+    const on = row?.value === "on";
+    flagCache = { at: Date.now(), on };
+    return on;
+  } catch {
+    return false;
+  }
+}
+
+/** Test/ops seam: drop the per-lambda cache so the next read hits the row. */
+export function resetApplicationsCache(): void {
+  flagCache = null;
+}
+
+/**
+ * Assert the switch is on. Called at the top of EVERY applications mutation and
+ * every read that would otherwise leak the existence of the feature — the
+ * page-level check is cosmetic, this one is the boundary.
+ */
+export async function assertApplicationsEnabled(
+  db: PrismaClient,
+): Promise<void> {
+  if (!(await isApplicationsEnabled(db))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "CCA_APPLICATIONS_DISABLED",
+    });
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Atomic id allocation                                                        */
+/* -------------------------------------------------------------------------- */
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "P2002"
+  );
+}
+
+/**
+ * Allocate the next id for a `Counter` key atomically. Generic sibling of
+ * `nextBookingId` (booking.ts). Our collections start empty, so there is no
+ * historical max to seed from — the counter is created at 0 and the first id is
+ * 1. The unique index on `Counter.key` makes the create-then-increment safe:
+ * a create that loses the first-ever race falls through to the increment.
+ */
+export async function nextCounter(
+  db: PrismaClient,
+  key: string,
+): Promise<number> {
+  const existing = await db.counter.findUnique({ where: { key } });
+  if (!existing) {
+    try {
+      await db.counter.create({ data: { key, seq: 0 } });
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+    }
+  }
+  const updated = await db.counter.update({
+    where: { key },
+    data: { seq: { increment: 1 } },
+  });
+  return updated.seq;
+}
+
+export const APPLICATION_COUNTER_KEY = "ccaApplicationID";
+export const SLOT_COUNTER_KEY = "ccaInterviewSlotID";
+
+/* -------------------------------------------------------------------------- */
+/* Per-CCA advisory lock                                                       */
+/* -------------------------------------------------------------------------- */
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_ATTEMPTS = 50;
+const LOCK_RETRY_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` while holding a per-CCA advisory lock, so the check-then-write pairs
+ * in this workflow cannot interleave for the same CCA:
+ *   - two residents claiming the same open slot
+ *   - a resident applying twice concurrently (the "one open application" check)
+ *   - two heads deciding the same application at once
+ *
+ * Same mechanism as `withFacilityLock` (booking.ts) — a `BookingLock` document
+ * whose unique key is the mutex — under a distinct `ccaApp:` namespace. A lock
+ * abandoned by a crashed request is reclaimed after LOCK_STALE_MS.
+ */
+export async function withCcaLock<T>(
+  db: PrismaClient,
+  ccaID: number,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `ccaApp:${ccaID}`;
+  let acquired = false;
+
+  for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
+    try {
+      await db.bookingLock.create({ data: { key } });
+      acquired = true;
+      break;
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+      await db.bookingLock.deleteMany({
+        where: { key, createdAt: { lt: new Date(Date.now() - LOCK_STALE_MS) } },
+      });
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+
+  if (!acquired) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "CCA_BUSY",
+    });
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await db.bookingLock.deleteMany({ where: { key } });
+  }
+}

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -122,6 +122,21 @@ export const AUDIT_ACTIONS = [
   // may hold no management capability at all. Authorised per-ccaID by
   // assertHeadsCca, so the audit row's targetCcaID is the scope that was proven.
   "ccaProfile.update",
+  // CCA membership APPLICATIONS (cca.applications.enabled switch). The submit /
+  // withdraw / bookSlot / cancelSlot actions are RESIDENT-authored (actor is the
+  // applicant themselves, holding no management capability); the interview-slot,
+  // note, accept and reject actions are HEAD-authored and authorised per-ccaID by
+  // assertHeadsCca. `ccaApplication.accept` is paired with a `ccaMember.add` row
+  // for the UserCCA write it performs, so the roster change stays attributable.
+  "ccaApplication.submit",
+  "ccaApplication.withdraw",
+  "ccaApplication.bookSlot",
+  "ccaApplication.cancelSlot",
+  "ccaApplication.accept",
+  "ccaApplication.reject",
+  "ccaInterviewSlot.open",
+  "ccaInterviewSlot.cancel",
+  "ccaInterviewNote.add",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 


### PR DESCRIPTION
## What

Adds the **CCA membership-application + interview-scheduling** feature: a resident browses every CCA, applies to one (their profile + free-text notes), books an interview into slots the CCA head opens, gets interviewed with notes on file, and — on acceptance — becomes a member.

Ships **behind `cca.applications.enabled`** (a `SystemFlag`, default **off**, fail-closed): all code is inert until the row is written. Nothing changes for anyone until it's flipped on.

## State machine

`submitted → interview_scheduled → interviewed → accepted` (writes membership) / `rejected` / `withdrawn`. Only terminal states free the `(ccaID, userID)` pair for a fresh application; `accepted` is the only state that writes a `UserCCA` row.

## Server

- **3 new unvalidated collections** — `CcaApplication`, `CcaInterviewSlot`, `CcaInterviewNote`. New collections (not fields on `UserCCA`/`CCA`) because those carry DB `$jsonSchema` validators that silently reject unknown fields; all scalars nullable per I-2.
- **`services/ccaApplications.ts`** — the kill switch, an atomic `Counter` id allocator, and a per-CCA advisory lock (reuses `BookingLock`/`Counter` like `booking.ts`).
- **`routers/ccaApplications.ts`** (resident, `identifiedProcedure`, ownership-guarded) — `browse / getCca / myApplications / submitApplication / availableSlots / bookSlot / cancelSlot / withdraw`.
- **`routers/ccaApplicationsHead.ts`** (head) — `listApplications / getApplication / listSlots / openSlots / cancelSlot / addNote / markInterviewed / decide`. **Every procedure calls `assertHeadsCca`** with a live `getUserRoles` read (I-5); `decide(accept)` writes the `UserCCA` row exactly like `ccaAdmin.addMember` (canonical key, deduped). New `AUDIT_ACTIONS` added; membership change audited as `ccaApplication.accept` + `ccaMember.add`.

## Client

- Resident **`/ccas`**: browse grid (per-CCA status badge), CCA detail + apply form, interview **slot picker** (hand-rolled list — `@fullcalendar/interaction` isn't installed), and **My applications**.
- Head dashboard gains **Applications** (review queue → detail → interview notes → accept/reject) and **Interview slots** (open/cancel) tabs.
- Forms are `useState` + `safeParse` against the shared zod schema; errors switch on the `UPPER_SNAKE` tokens the procedures throw.

## Edge cases covered

Duplicate/concurrent apply (per-CCA lock), already-a-member, head-applies-to-own-CCA, slot contention between two residents (`SLOT_TAKEN`), past slots, rebooking (atomic release+claim), head cancelling a booked slot (reverts applicant to `submitted`, never yanked silently), overlapping slots, concurrent head decisions (`ALREADY_DECIDED`), accept-when-already-member dedup, head-loses-headship-mid-review.

## Verification

- `tsc --noEmit` clean · `next build` passes (5 new dynamic routes) · `verify-identity-parity.mjs` green.

## ⚠️ Before enabling

1. **Run `prisma db push`** against the target DB so the 3 new collections + indexes exist.
2. **Write the flag row** `cca.applications.enabled = "on"` when ready.

## Decisions (flip if you disagree)

Applying requires onboarding (`matricProcedure`, no-op until matric enforcement is on) · a head can't apply to their own CCA · one interview slot per application (rebook replaces) · notifications are DB-status-only for v1 (Resend email is a documented follow-up) · re-apply allowed after reject/withdraw, full history kept · no per-CCA capacity cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
