### PR TITLE
Fix: opened interview slots invisible (Prisma+Mongo null-vs-absent field)

### DIFF
--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -164,7 +164,7 @@ export const ccaApplicationsRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
       }
 
-      const [profile, membership, apps, openSlotCount] = await Promise.all([
+      const [profile, membership, apps, futureSlots] = await Promise.all([
         ctx.db.ccaProfile.findUnique({
           where: { ccaID: input.ccaID },
           select: { description: true, logoUrl: true, bannerUrl: true },
@@ -184,16 +184,20 @@ export const ccaApplicationsRouter = createTRPCRouter({
           },
           orderBy: { applicationID: "desc" },
         }),
-        ctx.db.ccaInterviewSlot.count({
-          where: {
-            ccaID: input.ccaID,
-            bookedByUserID: null,
-            canceledAt: null,
-            endTime: { gt: now },
-          },
+        // Fetch future slots and count the open ones in JS — a `bookedByUserID:
+        // null` / `canceledAt: null` filter would miss slots where those fields
+        // are ABSENT (Prisma+Mongo's null filter only matches a stored null),
+        // which is every freshly-opened slot. See the note in
+        // ccaApplicationsHead.listSlots.
+        ctx.db.ccaInterviewSlot.findMany({
+          where: { ccaID: input.ccaID, endTime: { gt: now } },
+          select: { bookedByUserID: true, canceledAt: true },
         }),
       ]);
 
+      const openSlotCount = futureSlots.filter(
+        (s) => s.bookedByUserID === null && s.canceledAt === null,
+      ).length;
       const latest = apps[0] ?? null;
       const hasOpenApplication =
         latest !== null && !isTerminalStatus(latest.status);
@@ -399,21 +403,29 @@ export const ccaApplicationsRouter = createTRPCRouter({
         });
       }
 
-      const slots = await ctx.db.ccaInterviewSlot.findMany({
-        where: {
-          ccaID: input.ccaID,
-          bookedByUserID: null,
-          canceledAt: null,
-          endTime: { gt: now },
-        },
+      // Open + future slots. `bookedByUserID`/`canceledAt` are filtered in JS,
+      // not the query: their null filter would miss slots where the field is
+      // ABSENT (every freshly-opened one). See ccaApplicationsHead.listSlots.
+      const candidates = await ctx.db.ccaInterviewSlot.findMany({
+        where: { ccaID: input.ccaID, endTime: { gt: now } },
         select: {
           slotID: true,
           startTime: true,
           endTime: true,
           location: true,
+          bookedByUserID: true,
+          canceledAt: true,
         },
         orderBy: { startTime: "asc" },
       });
+      const slots = candidates
+        .filter((s) => s.bookedByUserID === null && s.canceledAt === null)
+        .map((s) => ({
+          slotID: s.slotID,
+          startTime: s.startTime,
+          endTime: s.endTime,
+          location: s.location,
+        }));
 
       return { slots, mySlotID: live.interviewSlotID };
     }),

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -275,8 +275,14 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       const roles = await getUserRoles(ctx.db, userID); // I-5 live read
       await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
 
-      const slots = await ctx.db.ccaInterviewSlot.findMany({
-        where: { ccaID: input.ccaID, canceledAt: null },
+      // NOTE: do NOT filter `canceledAt: null` in the query. A slot created
+      // before this field was written explicitly has canceledAt ABSENT, and
+      // Prisma+Mongo's `{ canceledAt: null }` matches a stored null but NOT an
+      // absent field — so that filter silently hides every open slot. Prisma
+      // deserializes an absent optional scalar as null, so filtering in JS on
+      // `s.canceledAt === null` catches both the absent and the null case.
+      const all = await ctx.db.ccaInterviewSlot.findMany({
+        where: { ccaID: input.ccaID },
         select: {
           slotID: true,
           startTime: true,
@@ -284,9 +290,11 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           location: true,
           bookedByUserID: true,
           bookedApplicationID: true,
+          canceledAt: true,
         },
         orderBy: { startTime: "asc" },
       });
+      const slots = all.filter((s) => s.canceledAt === null);
 
       const booked = slots
         .map((s) => s.bookedByUserID)
@@ -326,10 +334,16 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
       }
 
-      const existing = await ctx.db.ccaInterviewSlot.findMany({
-        where: { ccaID: input.ccaID, canceledAt: null },
-        select: { startTime: true, endTime: true },
-      });
+      // Same null-vs-absent caveat as listSlots: filter canceled slots in JS,
+      // not with `canceledAt: null` (which would miss absent-field slots and so
+      // skip them in the overlap check, letting a new slot overlap an existing
+      // open one).
+      const existing = (
+        await ctx.db.ccaInterviewSlot.findMany({
+          where: { ccaID: input.ccaID },
+          select: { startTime: true, endTime: true, canceledAt: true },
+        })
+      ).filter((e) => e.canceledAt === null);
 
       // Against existing slots and against slots earlier in this same batch.
       const accepted: { startTime: number; endTime: number }[] = [];
@@ -363,6 +377,14 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             location: s.location ?? null,
             createdBy: userID,
             createdAt: new Date(),
+            // Write these explicitly as null (not left absent) so the
+            // `bookedByUserID: null` / `canceledAt: null` filters other queries
+            // use actually match — Prisma+Mongo's null filter does not match an
+            // absent field. See the note in listSlots.
+            bookedByUserID: null,
+            bookedApplicationID: null,
+            bookedAt: null,
+            canceledAt: null,
           },
         });
         created.push(slotID);


### PR DESCRIPTION
## The bug
Opened interview slots didn't appear in the CCA head's list, and residents saw no bookable slots.

## Root cause
`openSlots` created slot documents **without** `bookedByUserID` or `canceledAt`, so those fields were **absent** in Mongo. The read queries filtered `{ bookedByUserID: null, canceledAt: null }` — but **Prisma + MongoDB's `null` filter matches a stored `null`, not an absent field**, so every freshly-opened slot was silently excluded from:
- `listSlots` (head's schedule)
- `availableSlots` + `getCca` open-slot count (resident booking)
- the `openSlots` overlap check (could let new slots overlap existing ones)

## Fix
- `openSlots` now writes `bookedByUserID` / `bookedApplicationID` / `bookedAt` / `canceledAt` as explicit `null` on create.
- The affected reads no longer filter those nullable fields in the query — they fetch and filter in JS. Prisma returns an absent optional scalar as `null`, so **this also un-hides slots that were already created** before the fix, with no data backfill needed.

## Verification
`tsc --noEmit` clean · `next build` passes. Server-only change; no schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
