### PR TITLE
Add 'My applications' to the profile menu + inline interview rescheduling

### DIFF
--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -9,6 +9,7 @@ import {
   User,
   Users,
   LayoutGrid,
+  ClipboardList,
   LogOut,
   UserCircle,
   ShieldCheck,
@@ -93,6 +94,11 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
 
   const handleProfile = () => {
     router.push("/profile");
+    setIsProfileDropdownOpen(false);
+  };
+
+  const handleMyApplications = () => {
+    router.push("/ccas/applications");
     setIsProfileDropdownOpen(false);
   };
 
@@ -197,6 +203,17 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
                           Profile
                         </button>
 
+                        <button
+                          onClick={handleMyApplications}
+                          className="flex w-full items-center px-4 py-2 text-sm text-gray-700 transition-colors duration-150 hover:bg-gray-50"
+                        >
+                          <ClipboardList
+                            size={16}
+                            className="mr-3 text-gray-400"
+                          />
+                          My applications
+                        </button>
+
                         <hr className="border-gray-100" />
 
                         <button
@@ -260,6 +277,13 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
                     >
                       <UserCircle size={18} />
                       <span>Profile</span>
+                    </button>
+                    <button
+                      onClick={handleMyApplications}
+                      className="flex w-full items-center space-x-3 rounded-lg px-3 py-2 text-left font-medium text-emerald-100 transition-colors duration-200 hover:bg-emerald-700 hover:text-white"
+                    >
+                      <ClipboardList size={18} />
+                      <span>My applications</span>
                     </button>
                     <button
                       onClick={handleLogout}

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowLeft, CalendarClock, MapPin } from "lucide-react";
+import { ArrowLeft, CalendarClock } from "lucide-react";
 
 import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
@@ -12,7 +12,8 @@ import {
   APPLICATION_NOTES_MAX,
   isTerminalStatus,
 } from "~/lib/schemas/ccaApplication";
-import { formatSlot, statusBadgeClass, statusLabel } from "../_lib/status";
+import { statusBadgeClass, statusLabel } from "../_lib/status";
+import SlotPicker from "./SlotPicker";
 
 /** Friendly copy for the machine-readable error tokens the procedures throw. */
 function applyErrorCopy(message: string | undefined): string | null {
@@ -363,119 +364,5 @@ function ApplicationInProgress({
         </div>
       )}
     </Card>
-  );
-}
-
-/** The slot list + confirm. Hand-rolled buttons, not a calendar widget — the
- *  @fullcalendar/interaction plugin isn't installed, and a short list of open
- *  slots reads more clearly as a list anyway. */
-function SlotPicker({
-  ccaID,
-  applicationID,
-  currentSlotID,
-  onDone,
-  onCancel,
-}: {
-  ccaID: number;
-  applicationID: number;
-  currentSlotID: number | null;
-  onDone: () => Promise<void>;
-  onCancel: () => void;
-}) {
-  const slots = api.ccaApplications.availableSlots.useQuery(
-    { ccaID },
-    { retry: false },
-  );
-  const [selected, setSelected] = useState<number | null>(null);
-  const book = api.ccaApplications.bookSlot.useMutation({
-    onSuccess: onDone,
-  });
-
-  if (slots.isPending) {
-    return <div className="h-24 animate-pulse rounded-md bg-gray-100" />;
-  }
-  if (slots.error) {
-    return (
-      <p className="text-sm text-red-600">
-        Couldn&rsquo;t load slots. Close and try again.
-      </p>
-    );
-  }
-
-  const open = slots.data.slots;
-
-  return (
-    <div className="space-y-3">
-      <p className="text-sm font-medium text-gray-700">Pick a time</p>
-      {open.length === 0 ? (
-        <p className="text-sm text-gray-500">
-          No open slots right now. Check back later.
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {open.map((s) => {
-            const isCurrent = s.slotID === currentSlotID;
-            const isSel = s.slotID === selected;
-            return (
-              <li key={s.slotID}>
-                <button
-                  type="button"
-                  onClick={() => setSelected(s.slotID)}
-                  aria-pressed={isSel}
-                  className={`flex w-full items-center justify-between rounded-md border px-3 py-2 text-left text-sm transition-colors ${
-                    isSel
-                      ? "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500"
-                      : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
-                  }`}
-                >
-                  <span className="font-medium text-gray-800">
-                    {formatSlot(s.startTime, s.endTime)}
-                  </span>
-                  <span className="flex items-center gap-3 text-gray-500">
-                    {s.location && (
-                      <span className="inline-flex items-center gap-1">
-                        <MapPin className="h-3.5 w-3.5" />
-                        {s.location}
-                      </span>
-                    )}
-                    {isCurrent && (
-                      <span className="text-xs text-emerald-700">Current</span>
-                    )}
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-
-      {book.error && (
-        <p className="text-sm text-red-600">
-          {book.error.message === "SLOT_TAKEN"
-            ? "Someone just took that slot. Pick another."
-            : book.error.message === "SLOT_IN_PAST"
-              ? "That slot has passed. Pick another."
-              : "That didn't book. Try again."}
-        </p>
-      )}
-
-      <div className="flex items-center gap-3">
-        <Button
-          disabled={selected === null || book.isPending}
-          onClick={() => {
-            if (selected !== null) book.mutate({ applicationID, slotID: selected });
-          }}
-        >
-          {book.isPending ? "Booking…" : "Confirm slot"}
-        </Button>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="text-sm font-medium text-gray-500 hover:text-gray-800"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
   );
 }

--- a/src/app/ccas/_components/MyApplicationsList.tsx
+++ b/src/app/ccas/_components/MyApplicationsList.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { CalendarClock, MapPin } from "lucide-react";
+import { CalendarClock, ChevronRight, MapPin } from "lucide-react";
 
-import { api } from "~/trpc/react";
+import { api, type RouterOutputs } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
 import { formatSlot, statusBadgeClass, statusLabel } from "../_lib/status";
+import SlotPicker from "./SlotPicker";
+
+type MyApp =
+  RouterOutputs["ccaApplications"]["myApplications"]["applications"][number];
 
 export default function MyApplicationsList() {
   const q = api.ccaApplications.myApplications.useQuery(undefined, {
@@ -15,7 +21,7 @@ export default function MyApplicationsList() {
     return (
       <div className="space-y-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="h-24 animate-pulse rounded-lg bg-gray-200" />
+          <div key={i} className="h-28 animate-pulse rounded-lg bg-gray-200" />
         ))}
       </div>
     );
@@ -53,45 +59,109 @@ export default function MyApplicationsList() {
   return (
     <ul className="space-y-3">
       {q.data.applications.map((a) => (
-        <li key={a.applicationID}>
-          <Link
-            href={`/ccas/${a.ccaID}`}
-            className="block rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <p className="font-medium text-gray-900">
-                {a.ccaName ?? `CCA #${a.ccaID}`}
-              </p>
-              <span
-                className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
-                  a.status,
-                )}`}
-              >
-                {statusLabel(a.status)}
-              </span>
-            </div>
-
-            {a.slot && a.status === "interview_scheduled" && (
-              <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
-                <span className="inline-flex items-center gap-1.5">
-                  <CalendarClock className="h-4 w-4 text-gray-400" />
-                  {formatSlot(a.slot.startTime, a.slot.endTime)}
-                </span>
-                {a.slot.location && (
-                  <span className="inline-flex items-center gap-1">
-                    <MapPin className="h-3.5 w-3.5 text-gray-400" />
-                    {a.slot.location}
-                  </span>
-                )}
-              </p>
-            )}
-
-            {a.status === "rejected" && a.decisionReason && (
-              <p className="mt-2 text-sm text-gray-600">{a.decisionReason}</p>
-            )}
-          </Link>
-        </li>
+        <MyApplicationRow key={a.applicationID} app={a} />
       ))}
     </ul>
+  );
+}
+
+function MyApplicationRow({ app }: { app: MyApp }) {
+  const utils = api.useUtils();
+  const [picking, setPicking] = useState(false);
+
+  const scheduled = app.status === "interview_scheduled";
+  const canBook = app.status === "submitted";
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.ccaApplications.myApplications.invalidate(),
+      utils.ccaApplications.availableSlots.invalidate({ ccaID: app.ccaID }),
+    ]);
+  };
+
+  const cancelSlot = api.ccaApplications.cancelSlot.useMutation({
+    onSuccess: refresh,
+  });
+
+  return (
+    <li className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href={`/ccas/${app.ccaID}`}
+          className="group inline-flex items-center gap-1 font-medium text-gray-900 hover:text-emerald-700"
+        >
+          {app.ccaName ?? `CCA #${app.ccaID}`}
+          <ChevronRight className="h-4 w-4 text-gray-300 group-hover:text-emerald-600" />
+        </Link>
+        <span
+          className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeClass(
+            app.status,
+          )}`}
+        >
+          {statusLabel(app.status)}
+        </span>
+      </div>
+
+      {/* Booked interview */}
+      {scheduled && app.slot && (
+        <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
+          <span className="inline-flex items-center gap-1.5">
+            <CalendarClock className="h-4 w-4 text-gray-400" />
+            {formatSlot(app.slot.startTime, app.slot.endTime)}
+          </span>
+          {app.slot.location && (
+            <span className="inline-flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5 text-gray-400" />
+              {app.slot.location}
+            </span>
+          )}
+        </p>
+      )}
+
+      {app.status === "rejected" && app.decisionReason && (
+        <p className="mt-2 text-sm text-gray-600">{app.decisionReason}</p>
+      )}
+
+      {/* Interview scheduling controls — the point of this view: change your
+          timeslot without leaving the page. */}
+      {(scheduled || canBook) && (
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          {picking ? (
+            <SlotPicker
+              ccaID={app.ccaID}
+              applicationID={app.applicationID}
+              currentSlotID={app.interviewSlotID}
+              onDone={async () => {
+                setPicking(false);
+                await refresh();
+              }}
+              onCancel={() => setPicking(false)}
+            />
+          ) : scheduled ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="outline" onClick={() => setPicking(true)}>
+                Reschedule
+              </Button>
+              <button
+                onClick={() =>
+                  cancelSlot.mutate({ applicationID: app.applicationID })
+                }
+                disabled={cancelSlot.isPending}
+                className="text-sm font-medium text-gray-500 hover:text-red-600 disabled:opacity-50"
+              >
+                {cancelSlot.isPending ? "Cancelling…" : "Cancel interview"}
+              </button>
+            </div>
+          ) : (
+            <Button
+              onClick={() => setPicking(true)}
+              className="inline-flex items-center gap-1.5"
+            >
+              <CalendarClock className="h-4 w-4" /> Book an interview
+            </Button>
+          )}
+        </div>
+      )}
+    </li>
   );
 }

--- a/src/app/ccas/_components/SlotPicker.tsx
+++ b/src/app/ccas/_components/SlotPicker.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { MapPin } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { formatSlot } from "../_lib/status";
+
+/**
+ * The interview slot list + confirm, shared by the CCA detail page and the My
+ * Applications view so booking/rebooking behaves identically in both. Hand-rolled
+ * buttons rather than a calendar widget — @fullcalendar/interaction isn't
+ * installed, and a short list of open slots reads more clearly as a list.
+ *
+ * `onDone` fires after a successful book and OWNS the cache invalidation for
+ * whichever surface mounted this (getCca vs myApplications), so the picker stays
+ * agnostic about where it lives.
+ */
+export default function SlotPicker({
+  ccaID,
+  applicationID,
+  currentSlotID,
+  onDone,
+  onCancel,
+}: {
+  ccaID: number;
+  applicationID: number;
+  currentSlotID: number | null;
+  onDone: () => Promise<void>;
+  onCancel: () => void;
+}) {
+  const slots = api.ccaApplications.availableSlots.useQuery(
+    { ccaID },
+    { retry: false },
+  );
+  const [selected, setSelected] = useState<number | null>(null);
+  const book = api.ccaApplications.bookSlot.useMutation({ onSuccess: onDone });
+
+  if (slots.isPending) {
+    return <div className="h-24 animate-pulse rounded-md bg-gray-100" />;
+  }
+  if (slots.error) {
+    return (
+      <p className="text-sm text-red-600">
+        Couldn&rsquo;t load slots. Close and try again.
+      </p>
+    );
+  }
+
+  const open = slots.data.slots;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-gray-700">Pick a time</p>
+      {open.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No open slots right now. Check back later.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {open.map((s) => {
+            const isCurrent = s.slotID === currentSlotID;
+            const isSel = s.slotID === selected;
+            return (
+              <li key={s.slotID}>
+                <button
+                  type="button"
+                  onClick={() => setSelected(s.slotID)}
+                  aria-pressed={isSel}
+                  className={`flex w-full items-center justify-between rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                    isSel
+                      ? "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500"
+                      : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  <span className="font-medium text-gray-800">
+                    {formatSlot(s.startTime, s.endTime)}
+                  </span>
+                  <span className="flex items-center gap-3 text-gray-500">
+                    {s.location && (
+                      <span className="inline-flex items-center gap-1">
+                        <MapPin className="h-3.5 w-3.5" />
+                        {s.location}
+                      </span>
+                    )}
+                    {isCurrent && (
+                      <span className="text-xs text-emerald-700">Current</span>
+                    )}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {book.error && (
+        <p className="text-sm text-red-600">
+          {book.error.message === "SLOT_TAKEN"
+            ? "Someone just took that slot. Pick another."
+            : book.error.message === "SLOT_IN_PAST"
+              ? "That slot has passed. Pick another."
+              : "That didn't book. Try again."}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          disabled={selected === null || book.isPending}
+          onClick={() => {
+            if (selected !== null) {
+              book.mutate({ applicationID, slotID: selected });
+            }
+          }}
+        >
+          {book.isPending ? "Booking…" : "Confirm slot"}
+        </Button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-sm font-medium text-gray-500 hover:text-gray-800"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a **My applications** entry to the profile-photo dropdown (and the mobile menu), linking to `/ccas/applications` — and makes that page able to **change interview timeslots inline**.

- **Header**: new "My applications" item under the profile avatar menu, desktop and mobile.
- **My applications page**: each application can now **book**, **reschedule**, or **cancel** its interview slot right there, via the shared `SlotPicker` — no need to open the CCA page. Scheduled interviews show the booked time/location with Reschedule + Cancel; submitted ones show "Book an interview".
- Refactor: extracted `SlotPicker` from `CcaApplyPanel` into its own component so both surfaces share identical booking behaviour.

## Verification
`tsc --noEmit` clean · `next build` passes.

## Depends on
The slots it books/reschedules only appear once **#63** (the null-vs-absent slot fix) is merged — booking itself works regardless, but open slots won't list until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
