### PR TITLE
CCA interviews: prevent duplicate slots + cleaner day-view schedule

### DIFF
--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -54,13 +54,6 @@ function fmtTime(epoch: number | null): string {
     minute: "2-digit",
   });
 }
-function fmtDateHeading(epoch: number): string {
-  return new Date(epoch * 1000).toLocaleDateString(undefined, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-  });
-}
 function overlaps(aS: number, aE: number, bS: number, bE: number): boolean {
   return aS < bE && bS < aE;
 }
@@ -182,13 +175,15 @@ function SlotGenerator({
   const overCap = creatable.length > MAX_SLOTS_PER_OPEN;
 
   const serverError = create.error
-    ? create.error.message === "SLOT_OVERLAP"
-      ? "One of these overlaps a slot that was just taken. Refresh and regenerate."
-      : create.error.message === "SLOT_IN_PAST"
-        ? "Some of these are in the past."
-        : create.error.message === "NOT_A_HEAD_OF_THIS_CCA"
-          ? "You're no longer a head of this CCA."
-          : "Those didn't open. Try again."
+    ? create.error.message === "DUPLICATE_SLOT"
+      ? "One of these is identical to a slot you've already opened."
+      : create.error.message === "SLOT_OVERLAP"
+        ? "One of these overlaps a slot that was just taken. Refresh and regenerate."
+        : create.error.message === "SLOT_IN_PAST"
+          ? "Some of these are in the past."
+          : create.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+            ? "You're no longer a head of this CCA."
+            : "Those didn't open. Try again."
     : null;
 
   const submit = () => {
@@ -399,12 +394,22 @@ function SlotGenerator({
 
 /* ----------------------------- schedule view ------------------------------- */
 
-function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
-  const bookedCount = slots.filter((s) => s.bookedByUserID !== null).length;
-  const openCount = slots.length - bookedCount;
+/** Compact day-tab label, e.g. "Mon 21 Jul". */
+function fmtDayTab(epoch: number): string {
+  return new Date(epoch * 1000).toLocaleDateString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+}
 
-  // Group by local calendar day.
-  const groups = useMemo(() => {
+/**
+ * A day view: pick a day, see that day's slots laid out as cards. Booked slots
+ * are solid green and name who took them; free slots are plain white. This reads
+ * far more like a schedule than one long flat list.
+ */
+function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
+  const days = useMemo(() => {
     const byDay = new Map<string, Slot[]>();
     for (const s of slots) {
       const key = s.startTime !== null ? toDateInput(s.startTime) : "—";
@@ -412,8 +417,13 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
       arr.push(s);
       byDay.set(key, arr);
     }
+    for (const arr of byDay.values()) {
+      arr.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+    }
     return [...byDay.entries()].sort(([a], [b]) => a.localeCompare(b));
   }, [slots]);
+
+  const [selected, setSelected] = useState<string | null>(null);
 
   if (slots.length === 0) {
     return (
@@ -423,33 +433,69 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
     );
   }
 
+  const todayKey = toDateInput(Math.floor(Date.now() / 1000));
+  const defaultDay =
+    days.find(([k]) => k >= todayKey)?.[0] ?? days[0]?.[0] ?? null;
+  const current = days.find(([k]) => k === (selected ?? defaultDay)) ?? days[0]!;
+  const daySlots = current[1];
+  const booked = daySlots.filter((s) => s.bookedByUserID !== null).length;
+
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap gap-2 text-xs">
-        <Stat label="Total" value={slots.length} tone="gray" />
-        <Stat label="Open" value={openCount} tone="sky" />
-        <Stat label="Booked" value={bookedCount} tone="emerald" />
+    <div className="space-y-3">
+      {/* Day picker */}
+      <div className="flex gap-1.5 overflow-x-auto pb-1">
+        {days.map(([key, ds]) => {
+          const active = key === current[0];
+          const b = ds.filter((s) => s.bookedByUserID !== null).length;
+          return (
+            <button
+              key={key}
+              onClick={() => setSelected(key)}
+              className={`shrink-0 rounded-lg border px-3 py-1.5 text-left text-xs transition-colors ${
+                active
+                  ? "border-emerald-600 bg-emerald-50 text-emerald-800"
+                  : "border-gray-200 bg-white text-gray-600 hover:border-gray-300"
+              }`}
+            >
+              <span className="block font-semibold">
+                {ds[0]?.startTime != null
+                  ? fmtDayTab(ds[0].startTime)
+                  : "Undated"}
+              </span>
+              <span className={active ? "text-emerald-600" : "text-gray-400"}>
+                {ds.length} slot{ds.length === 1 ? "" : "s"}
+                {b > 0 ? ` · ${b} booked` : ""}
+              </span>
+            </button>
+          );
+        })}
       </div>
 
-      {groups.map(([day, daySlots]) => (
-        <div key={day}>
-          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">
-            {daySlots[0]?.startTime != null
-              ? fmtDateHeading(daySlots[0].startTime)
-              : "Undated"}
-          </p>
-          <ul className="space-y-2">
-            {daySlots.map((s) => (
-              <SlotRow key={s.slotID} ccaID={ccaID} slot={s} />
-            ))}
-          </ul>
-        </div>
-      ))}
+      {/* Legend */}
+      <div className="flex items-center gap-4 text-xs text-gray-500">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded bg-emerald-600" /> Booked
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded border border-gray-300 bg-white" />{" "}
+          Free
+        </span>
+        <span className="ml-auto tabular-nums">
+          {daySlots.length - booked} free · {booked} booked
+        </span>
+      </div>
+
+      {/* Slots for the selected day */}
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {daySlots.map((s) => (
+          <SlotCard key={s.slotID} ccaID={ccaID} slot={s} />
+        ))}
+      </div>
     </div>
   );
 }
 
-function SlotRow({ ccaID, slot }: { ccaID: number; slot: Slot }) {
+function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
   const utils = api.useUtils();
   const [editing, setEditing] = useState(false);
   const booked = slot.bookedByUserID !== null;
@@ -461,7 +507,7 @@ function SlotRow({ ccaID, slot }: { ccaID: number; slot: Slot }) {
 
   if (editing) {
     return (
-      <li className="rounded-lg border border-emerald-300 bg-white p-3">
+      <div className="rounded-lg border border-emerald-300 bg-white p-3 sm:col-span-2 lg:col-span-3">
         <SlotEditForm
           ccaID={ccaID}
           slot={slot}
@@ -471,44 +517,54 @@ function SlotRow({ ccaID, slot }: { ccaID: number; slot: Slot }) {
           }}
           onCancel={() => setEditing(false)}
         />
-      </li>
+      </div>
     );
   }
 
   return (
-    <li className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3">
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-gray-800">
-          {fmtTime(slot.startTime)} – {fmtTime(slot.endTime)}
+    <div
+      className={`relative rounded-lg border p-3 ${
+        booked
+          ? "border-emerald-600 bg-emerald-600 text-white"
+          : "border-gray-200 bg-white"
+      }`}
+    >
+      <p
+        className={`text-sm font-semibold tabular-nums ${
+          booked ? "text-white" : "text-gray-800"
+        }`}
+      >
+        {fmtTime(slot.startTime)} – {fmtTime(slot.endTime)}
+      </p>
+      {slot.location && (
+        <p
+          className={`mt-0.5 inline-flex items-center gap-1 text-xs ${
+            booked ? "text-emerald-50" : "text-gray-500"
+          }`}
+        >
+          <MapPin className="h-3 w-3" />
+          {slot.location}
         </p>
-        <p className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
-          {slot.location && (
-            <span className="inline-flex items-center gap-1 text-gray-500">
-              <MapPin className="h-3 w-3" />
-              {slot.location}
-            </span>
-          )}
-          {booked ? (
-            <span className="font-medium text-emerald-700">
-              Booked ·{" "}
-              {slot.bookedBy?.displayName ??
-                slot.bookedBy?.email ??
-                "an applicant"}
-            </span>
-          ) : (
-            <span className="text-gray-400">Open</span>
-          )}
-        </p>
-      </div>
+      )}
+      <p
+        className={`mt-1 truncate text-xs ${
+          booked ? "text-emerald-50" : "text-gray-400"
+        }`}
+      >
+        {booked
+          ? (slot.bookedBy?.displayName ?? slot.bookedBy?.email ?? "Booked")
+          : "Free"}
+      </p>
 
-      <div className="flex shrink-0 items-center gap-1">
+      {/* Actions — always visible so they work on touch too. */}
+      <div className="absolute right-1.5 top-1.5 flex items-center gap-0.5">
         {!booked && (
           <button
             onClick={() => setEditing(true)}
             aria-label="Edit slot"
-            className="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
           >
-            <Pencil className="h-4 w-4" />
+            <Pencil className="h-3.5 w-3.5" />
           </button>
         )}
         <button
@@ -525,12 +581,16 @@ function SlotRow({ ccaID, slot }: { ccaID: number; slot: Slot }) {
           }}
           disabled={cancel.isPending}
           aria-label="Cancel slot"
-          className="rounded-md p-2 text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+          className={`rounded p-1 disabled:opacity-50 ${
+            booked
+              ? "text-emerald-100 hover:bg-emerald-700 hover:text-white"
+              : "text-gray-400 hover:bg-red-50 hover:text-red-600"
+          }`}
         >
-          <Trash2 className="h-4 w-4" />
+          <Trash2 className="h-3.5 w-3.5" />
         </button>
       </div>
-    </li>
+    </div>
   );
 }
 
@@ -646,27 +706,5 @@ function Field({
       <span className="font-medium text-gray-700">{label}</span>
       {children}
     </label>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: number;
-  tone: "gray" | "sky" | "emerald";
-}) {
-  const cls = {
-    gray: "bg-gray-100 text-gray-700",
-    sky: "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-600/20",
-    emerald: "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-600/20",
-  }[tone];
-  return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium ${cls}`}>
-      <span className="tabular-nums">{value}</span>
-      {label}
-    </span>
   );
 }

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -335,72 +335,86 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
       }
 
-      // Same null-vs-absent caveat as listSlots: filter canceled slots in JS,
-      // not with `canceledAt: null` (which would miss absent-field slots and so
-      // skip them in the overlap check, letting a new slot overlap an existing
-      // open one).
-      const existing = (
-        await ctx.db.ccaInterviewSlot.findMany({
-          where: { ccaID: input.ccaID },
-          select: { startTime: true, endTime: true, canceledAt: true },
-        })
-      ).filter((e) => e.canceledAt === null);
+      // Serialize per-CCA so two concurrent "open" requests (a double-click, or
+      // two heads at once) cannot both pass the duplicate/overlap check and then
+      // both insert the same slots — the check-then-create must be atomic. Same
+      // lock the booking and decide paths use.
+      return withCcaLock(ctx.db, input.ccaID, async () => {
+        // Existing NON-canceled slots. canceledAt is filtered in JS, not the
+        // query: `canceledAt: null` misses absent-field slots (Prisma+Mongo), so
+        // a DB filter would let the check skip them. See the note in listSlots.
+        const existing = (
+          await ctx.db.ccaInterviewSlot.findMany({
+            where: { ccaID: input.ccaID },
+            select: { startTime: true, endTime: true, canceledAt: true },
+          })
+        ).filter((e) => e.canceledAt === null);
 
-      // Against existing slots and against slots earlier in this same batch.
-      const accepted: { startTime: number; endTime: number }[] = [];
-      for (const s of input.slots) {
-        const clash =
-          existing.some(
-            (e) =>
-              e.startTime !== null &&
-              e.endTime !== null &&
+        const sameTime = (
+          a: { startTime: number | null; endTime: number | null },
+          b: { startTime: number; endTime: number },
+        ) => a.startTime === b.startTime && a.endTime === b.endTime;
+
+        // Validate every incoming slot against the existing ones AND against the
+        // slots earlier in this same batch. An exact DUPLICATE (identical
+        // start+end) is reported distinctly from a partial OVERLAP so the head
+        // gets a clear "already opened" message.
+        const accepted: { startTime: number; endTime: number }[] = [];
+        for (const s of input.slots) {
+          if (existing.some((e) => sameTime(e, s)) || accepted.some((e) => sameTime(e, s))) {
+            throw new TRPCError({ code: "CONFLICT", message: "DUPLICATE_SLOT" });
+          }
+          const clash =
+            existing.some(
+              (e) =>
+                e.startTime !== null &&
+                e.endTime !== null &&
+                overlaps(s.startTime, s.endTime, e.startTime, e.endTime),
+            ) ||
+            accepted.some((e) =>
               overlaps(s.startTime, s.endTime, e.startTime, e.endTime),
-          ) ||
-          accepted.some((e) =>
-            overlaps(s.startTime, s.endTime, e.startTime, e.endTime),
-          );
-        if (clash) {
-          throw new TRPCError({ code: "CONFLICT", message: "SLOT_OVERLAP" });
+            );
+          if (clash) {
+            throw new TRPCError({ code: "CONFLICT", message: "SLOT_OVERLAP" });
+          }
+          accepted.push({ startTime: s.startTime, endTime: s.endTime });
         }
-        accepted.push({ startTime: s.startTime, endTime: s.endTime });
-      }
 
-      const batchId = randomUUID();
-      const created: number[] = [];
-      for (const s of input.slots) {
-        const slotID = await nextCounter(ctx.db, SLOT_COUNTER_KEY);
-        await ctx.db.ccaInterviewSlot.create({
-          data: {
-            slotID,
-            ccaID: input.ccaID,
-            startTime: s.startTime,
-            endTime: s.endTime,
-            location: s.location ?? null,
-            createdBy: userID,
-            createdAt: new Date(),
-            // Write these explicitly as null (not left absent) so the
-            // `bookedByUserID: null` / `canceledAt: null` filters other queries
-            // use actually match — Prisma+Mongo's null filter does not match an
-            // absent field. See the note in listSlots.
-            bookedByUserID: null,
-            bookedApplicationID: null,
-            bookedAt: null,
-            canceledAt: null,
-          },
+        const batchId = randomUUID();
+        const created: number[] = [];
+        for (const s of input.slots) {
+          const slotID = await nextCounter(ctx.db, SLOT_COUNTER_KEY);
+          await ctx.db.ccaInterviewSlot.create({
+            data: {
+              slotID,
+              ccaID: input.ccaID,
+              startTime: s.startTime,
+              endTime: s.endTime,
+              location: s.location ?? null,
+              createdBy: userID,
+              createdAt: new Date(),
+              // Explicit nulls (not absent) so other queries' null filters match
+              // — Prisma+Mongo's null filter does not match an absent field.
+              bookedByUserID: null,
+              bookedApplicationID: null,
+              bookedAt: null,
+              canceledAt: null,
+            },
+          });
+          created.push(slotID);
+        }
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetCcaID: input.ccaID,
+          action: "ccaInterviewSlot.open",
+          batchId,
+          reason: `${scope.via}: opened ${created.length} slot(s)`,
         });
-        created.push(slotID);
-      }
 
-      await writeAudit(ctx.db, {
-        actorUserID: userID,
-        actorRoles: roles,
-        targetCcaID: input.ccaID,
-        action: "ccaInterviewSlot.open",
-        batchId,
-        reason: `${scope.via}: opened ${created.length} slot(s)`,
+        return { ccaID: input.ccaID, opened: created.length, slotIDs: created };
       });
-
-      return { ccaID: input.ccaID, opened: created.length, slotIDs: created };
     }),
 
   /**


### PR DESCRIPTION
Two fixes to the CCA head's Interview slots tab.

## 1. Duplicate slots — validation
Duplicates slipped through because `openSlots` ran its overlap check and its inserts **without a lock**, so a double-click (or two heads) could both pass the check and both insert the same slots.

- `openSlots` now runs the whole check-and-create **inside `withCcaLock`** (the same per-CCA lock booking/decide use) — the check and insert are atomic, so concurrent opens can't both win.
- Added an explicit **`DUPLICATE_SLOT`** guard (an incoming slot whose start+end exactly matches an existing open slot, or another slot in the same batch) — reported distinctly from a partial overlap, with a clear message on the client.

Existing duplicates already in the DB aren't touched — the head can remove them with the cancel (🗑) button on each card.

## 2. Schedule view — cleaner day view
The flat, grouped list was hard to scan. Replaced with a **day view**:
- a **day picker** (one chip per day, with slot/booked counts),
- a **legend**, and
- the selected day's slots as **color-coded cards**: **solid green + the applicant's name when booked, plain white when free** — exactly the green = booked / blank = free the ask called for.

Edit and cancel live on each card.

## Verification
`tsc --noEmit` clean · `next build` passes. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
