### PR TITLE
CCA interviews: redesign Applications review (stepper + Accept/Deny) and Interviews run-sheet

### DIFF
--- a/src/app/cca/_components/ApplicantDetails.tsx
+++ b/src/app/cca/_components/ApplicantDetails.tsx
@@ -1,0 +1,69 @@
+import { type RouterOutputs } from "~/trpc/react";
+
+export type Applicant =
+  RouterOutputs["ccaApplicationsHead"]["listApplications"]["applications"][number]["applicant"];
+
+/**
+ * Everything the head knows about an applicant, plus the free-text notes they
+ * sent with the application. Shared by the Applications and Interviews tabs so
+ * the two always show the same detail set. Missing fields render as "—" rather
+ * than vanishing, so an unresolved account is visibly incomplete, not silently
+ * blank.
+ */
+export default function ApplicantDetails({
+  applicant,
+  userID,
+  notes,
+}: {
+  applicant: Applicant;
+  userID: string;
+  notes: string | null;
+}) {
+  const rows: { label: string; value: string | null }[] = [
+    { label: "Matric", value: applicant.matric },
+    { label: "Block", value: applicant.block != null ? String(applicant.block) : null },
+    { label: "Email", value: applicant.email },
+    {
+      label: "Telegram",
+      value: applicant.telegramHandle ? `@${applicant.telegramHandle}` : null,
+    },
+    { label: "User ID", value: userID },
+  ];
+
+  return (
+    <div className="space-y-3">
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2.5 sm:grid-cols-3">
+        {rows.map((r) => (
+          <div key={r.label} className="min-w-0">
+            <dt className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              {r.label}
+            </dt>
+            <dd className="truncate text-sm text-gray-800" title={r.value ?? undefined}>
+              {r.value ?? <span className="text-gray-300">—</span>}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {applicant.bio?.trim() && (
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+            About
+          </p>
+          <p className="mt-0.5 whitespace-pre-line text-sm text-gray-700">
+            {applicant.bio}
+          </p>
+        </div>
+      )}
+
+      <div>
+        <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+          Notes sent with the application
+        </p>
+        <p className="mt-0.5 whitespace-pre-line text-sm text-gray-700">
+          {notes?.trim() ? notes : <span className="text-gray-300">— none —</span>}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cca/_components/ApplicationsReview.tsx
+++ b/src/app/cca/_components/ApplicationsReview.tsx
@@ -1,24 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { CalendarClock, ChevronDown, MapPin } from "lucide-react";
+import { CalendarClock, Check, ChevronDown, MapPin, X } from "lucide-react";
 
 import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import {
-  addNoteInput,
   APPLICATION_STATUSES,
   DECISION_REASON_MAX,
-  INTERVIEW_NOTE_MAX,
   isTerminalStatus,
   type ApplicationStatus,
 } from "~/lib/schemas/ccaApplication";
-import {
-  formatSlot,
-  statusBadgeClass,
-  statusLabel,
-} from "~/app/ccas/_lib/status";
+import { formatSlot, statusBadgeClass, statusLabel } from "~/app/ccas/_lib/status";
+import ApplicantDetails from "./ApplicantDetails";
 
+type AppRow =
+  RouterOutputs["ccaApplicationsHead"]["listApplications"]["applications"][number];
 type Filter = "all" | ApplicationStatus;
 const FILTERS: Filter[] = ["all", ...APPLICATION_STATUSES];
 
@@ -33,22 +30,23 @@ export default function ApplicationsReview({ ccaID }: { ccaID: number }) {
     return <div className="h-64 animate-pulse rounded-lg bg-gray-200" />;
   }
   if (list.error) {
-    if (list.error.message === "NOT_A_HEAD_OF_THIS_CCA") {
-      return (
-        <Denied text="You can only review applications for CCAs you head." />
-      );
-    }
-    if (list.error.message === "CCA_APPLICATIONS_DISABLED") {
-      return <Denied text="CCA applications aren't open right now." />;
-    }
-    return <Denied text="These couldn't be loaded. Reload the page." tone="error" />;
+    const msg =
+      list.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+        ? "You can only review applications for CCAs you head."
+        : list.error.message === "CCA_APPLICATIONS_DISABLED"
+          ? "CCA applications aren't open right now."
+          : "These couldn't be loaded. Reload the page.";
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-sm text-gray-600">
+        {msg}
+      </div>
+    );
   }
 
   const apps = list.data.applications;
 
   return (
     <div className="space-y-4">
-      {/* Status filter */}
       <div className="flex flex-wrap gap-1.5">
         {FILTERS.map((f) => (
           <button
@@ -82,41 +80,118 @@ export default function ApplicationsReview({ ccaID }: { ccaID: number }) {
   );
 }
 
-function Denied({
-  text,
-  tone = "muted",
-}: {
-  text: string;
-  tone?: "muted" | "error";
-}) {
+/* --------------------------------- stepper --------------------------------- */
+
+const STEP_LABELS = [
+  "Slot to be booked",
+  "Interview booked",
+  "Interviewed",
+] as const;
+
+function stageOf(status: string | null): number {
+  switch (status) {
+    case "submitted":
+      return 0;
+    case "interview_scheduled":
+      return 1;
+    case "interviewed":
+      return 2;
+    case "accepted":
+    case "rejected":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+/** Horizontal progress: Slot to be booked → Interview booked → Interviewed →
+ *  Decision. The final node turns green (accepted) or rose (not accepted). */
+function Stepper({ status }: { status: string | null }) {
+  const decided = status === "accepted" || status === "rejected";
+  const rejected = status === "rejected";
+  const stage = stageOf(status);
+  const steps = [
+    ...STEP_LABELS,
+    decided ? (rejected ? "Not accepted" : "Accepted") : "Decision",
+  ];
+
   return (
-    <div
-      className={`rounded-lg border px-4 py-6 text-sm ${
-        tone === "error"
-          ? "border-red-200 bg-red-50 text-red-800"
-          : "border-gray-200 bg-white text-gray-600"
-      }`}
-    >
-      {text}
+    <div className="flex items-start">
+      {steps.map((label, i) => {
+        const isDecisionNode = i === 3;
+        const done = i < stage || (decided && isDecisionNode);
+        const current = i === stage && !decided;
+
+        // Full class strings only — Tailwind can't see interpolated names.
+        const dot = done
+          ? isDecisionNode && rejected
+            ? "border-rose-600 bg-rose-600 text-white"
+            : "border-emerald-600 bg-emerald-600 text-white"
+          : current
+            ? "border-emerald-600 bg-white text-emerald-700"
+            : "border-gray-300 bg-white text-gray-300";
+        const line = (filled: boolean) =>
+          `h-0.5 flex-1 ${filled ? "bg-emerald-600" : "bg-gray-200"}`;
+
+        return (
+          <div key={i} className="flex flex-1 flex-col items-center">
+            <div className="flex w-full items-center">
+              <div className={i === 0 ? "flex-1 opacity-0" : line(i <= stage)} />
+              <div
+                className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 text-[11px] font-semibold ${dot}`}
+              >
+                {done ? (
+                  isDecisionNode && rejected ? (
+                    <X className="h-3.5 w-3.5" />
+                  ) : (
+                    <Check className="h-3.5 w-3.5" />
+                  )
+                ) : (
+                  i + 1
+                )}
+              </div>
+              <div
+                className={
+                  i === steps.length - 1
+                    ? "flex-1 opacity-0"
+                    : line(i + 1 <= stage)
+                }
+              />
+            </div>
+            <span
+              className={`mt-1 text-center text-[10px] leading-tight ${
+                current
+                  ? "font-semibold text-emerald-700"
+                  : done
+                    ? "text-gray-600"
+                    : "text-gray-400"
+              }`}
+            >
+              {label}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-type AppRow =
-  RouterOutputs["ccaApplicationsHead"]["listApplications"]["applications"][number];
+/* --------------------------------- rows ------------------------------------ */
 
 function ApplicationRow({ ccaID, app }: { ccaID: number; app: AppRow }) {
   const [open, setOpen] = useState(false);
-  const decided = isTerminalStatus(app.status);
   const name = app.applicant.displayName ?? app.userID;
 
   return (
-    <li className="rounded-lg border border-gray-200 bg-white">
+    <li className="overflow-hidden rounded-lg border border-gray-200 bg-white">
       <button
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
-        className="flex w-full items-center gap-3 p-4 text-left"
+        className="flex w-full items-center gap-3 p-4 text-left hover:bg-gray-50"
       >
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-sm font-semibold text-emerald-700">
+          {(name || "?").slice(0, 2).toUpperCase()}
+        </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="truncate font-medium text-gray-900">{name}</span>
@@ -153,142 +228,85 @@ function ApplicationRow({ ccaID, app }: { ccaID: number; app: AppRow }) {
         />
       </button>
 
-      {open && (
-        <ApplicationDetail ccaID={ccaID} applicationID={app.applicationID} decided={decided} />
-      )}
+      {open && <ApplicationDetail ccaID={ccaID} app={app} />}
     </li>
   );
 }
 
-/** Expanded detail: the applicant's notes, interview notes, and the decision
- *  controls. Loads getApplication lazily so a long queue doesn't fetch every
- *  application's full detail up front. */
-function ApplicationDetail({
-  ccaID,
-  applicationID,
-  decided,
-}: {
-  ccaID: number;
-  applicationID: number;
-  decided: boolean;
-}) {
+/** Expanded detail: progress, the applicant's full details + application notes,
+ *  the interview notes (read-only — notes are added on the Interviews tab), and
+ *  the Accept / Deny decision. */
+function ApplicationDetail({ ccaID, app }: { ccaID: number; app: AppRow }) {
   const utils = api.useUtils();
   const detail = api.ccaApplicationsHead.getApplication.useQuery(
-    { ccaID, applicationID },
+    { ccaID, applicationID: app.applicationID },
     { retry: false },
   );
-  const [note, setNote] = useState("");
   const [reason, setReason] = useState("");
 
-  const refresh = async () => {
-    await Promise.all([
-      utils.ccaApplicationsHead.getApplication.invalidate({ ccaID, applicationID }),
-      utils.ccaApplicationsHead.listApplications.invalidate({ ccaID }),
-    ]);
-  };
-
-  const addNote = api.ccaApplicationsHead.addNote.useMutation({
-    onSuccess: async () => {
-      setNote("");
-      await refresh();
-    },
-  });
   const decide = api.ccaApplicationsHead.decide.useMutation({
-    onSuccess: refresh,
-  });
-  const markInterviewed = api.ccaApplicationsHead.markInterviewed.useMutation({
-    onSuccess: refresh,
+    onSuccess: () =>
+      utils.ccaApplicationsHead.listApplications.invalidate({ ccaID }),
   });
 
-  if (detail.isPending) {
-    return (
-      <div className="border-t border-gray-100 p-4">
-        <div className="h-20 animate-pulse rounded bg-gray-100" />
-      </div>
-    );
-  }
-  if (detail.error) {
-    return (
-      <div className="border-t border-gray-100 p-4 text-sm text-red-600">
-        Couldn&rsquo;t load this application.
-      </div>
-    );
-  }
-
-  const d = detail.data;
-  const canInterview =
-    d.status === "submitted" || d.status === "interview_scheduled";
+  const decided = isTerminalStatus(app.status);
+  const withdrawn = app.status === "withdrawn";
 
   return (
-    <div className="space-y-4 border-t border-gray-100 p-4">
-      {/* Applicant's own notes */}
-      <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
-          Applicant&rsquo;s notes
-        </p>
-        <p className="mt-1 whitespace-pre-line text-sm text-gray-700">
-          {d.notes?.trim() ? d.notes : "— none —"}
-        </p>
+    <div className="space-y-4 border-t border-gray-100 bg-gray-50/50 p-4">
+      {!withdrawn && (
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <Stepper status={app.status} />
+        </div>
+      )}
+
+      {/* Full applicant details + application notes */}
+      <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <ApplicantDetails
+          applicant={app.applicant}
+          userID={app.userID}
+          notes={app.notes}
+        />
       </div>
 
-      {/* Interview notes */}
-      <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+      {/* Interview notes — read only here */}
+      <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
           Interview notes
         </p>
-        <NoteList notes={d.interviewNotes} />
+        {detail.isPending ? (
+          <div className="mt-1 h-10 animate-pulse rounded bg-gray-100" />
+        ) : detail.error ? (
+          <p className="mt-1 text-sm text-red-600">
+            Couldn&rsquo;t load interview notes.
+          </p>
+        ) : (
+          <NoteList notes={detail.data.interviewNotes} />
+        )}
       </div>
 
-      {/* Add a note */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const parsed = addNoteInput.safeParse({ ccaID, applicationID, body: note });
-          if (!parsed.success) return;
-          addNote.mutate(parsed.data);
-        }}
-        className="space-y-2"
-      >
-        <textarea
-          value={note}
-          maxLength={INTERVIEW_NOTE_MAX}
-          rows={2}
-          onChange={(e) => setNote(e.target.value)}
-          placeholder="Add an interview note…"
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        />
-        <Button
-          type="submit"
-          variant="outline"
-          disabled={addNote.isPending || note.trim().length === 0}
-        >
-          {addNote.isPending ? "Adding…" : "Add note"}
-        </Button>
-      </form>
-
       {/* Decision */}
-      {decided ? (
-        <div className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-600">
-          Decision: <span className="font-medium">{statusLabel(d.status)}</span>
-          {d.decisionReason ? ` — ${d.decisionReason}` : ""}
+      {withdrawn ? (
+        <p className="text-sm text-gray-500">Withdrawn by the applicant.</p>
+      ) : decided ? (
+        <div
+          className={`rounded-lg px-3 py-2 text-sm ${
+            app.status === "accepted"
+              ? "bg-green-50 text-green-800"
+              : "bg-rose-50 text-rose-800"
+          }`}
+        >
+          <span className="font-medium">{statusLabel(app.status)}</span>
+          {app.decisionReason ? ` — ${app.decisionReason}` : ""}
         </div>
       ) : (
-        <div className="space-y-2 border-t border-gray-100 pt-4">
-          {canInterview && (
-            <button
-              onClick={() => markInterviewed.mutate({ ccaID, applicationID })}
-              disabled={markInterviewed.isPending}
-              className="text-xs font-medium text-gray-500 hover:text-gray-800 disabled:opacity-50"
-            >
-              {markInterviewed.isPending ? "…" : "Mark as interviewed"}
-            </button>
-          )}
+        <div className="space-y-2">
           <input
             type="text"
             value={reason}
             maxLength={DECISION_REASON_MAX}
             onChange={(e) => setReason(e.target.value)}
-            placeholder="Reason (optional, shared with applicant on rejection)"
+            placeholder="Reason (optional — shared with the applicant if you deny)"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
           />
           {decide.error && (
@@ -304,27 +322,30 @@ function ApplicationDetail({
               onClick={() =>
                 decide.mutate({
                   ccaID,
-                  applicationID,
+                  applicationID: app.applicationID,
                   decision: "accepted",
                   reason: reason.trim() || undefined,
                 })
               }
+              className="inline-flex items-center gap-1.5"
             >
-              {decide.isPending ? "…" : "Accept"}
+              <Check className="h-4 w-4" />
+              {decide.isPending ? "Saving…" : "Accept"}
             </Button>
             <button
               disabled={decide.isPending}
               onClick={() =>
                 decide.mutate({
                   ccaID,
-                  applicationID,
+                  applicationID: app.applicationID,
                   decision: "rejected",
                   reason: reason.trim() || undefined,
                 })
               }
-              className="rounded-md px-3 py-2 text-sm font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-md border border-rose-200 px-3 py-2 text-sm font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
             >
-              Reject
+              <X className="h-4 w-4" />
+              Deny
             </button>
           </div>
         </div>
@@ -347,15 +368,13 @@ function NoteList({
     return <p className="mt-1 text-sm text-gray-400">No interview notes yet.</p>;
   }
   return (
-    <ul className="mt-1 space-y-2">
+    <ul className="mt-1.5 space-y-2">
       {notes.map((n) => (
         <li key={n.id} className="rounded-md bg-gray-50 px-3 py-2 text-sm">
           <p className="whitespace-pre-line text-gray-700">{n.body}</p>
           <p className="mt-1 text-xs text-gray-400">
             {n.authorName ?? "Head"}
-            {n.createdAt
-              ? ` · ${new Date(n.createdAt).toLocaleString()}`
-              : ""}
+            {n.createdAt ? ` · ${new Date(n.createdAt).toLocaleString()}` : ""}
           </p>
         </li>
       ))}

--- a/src/app/cca/_components/InterviewSessions.tsx
+++ b/src/app/cca/_components/InterviewSessions.tsx
@@ -7,16 +7,25 @@ import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import { addNoteInput, INTERVIEW_NOTE_MAX } from "~/lib/schemas/ccaApplication";
 import { formatSlot } from "~/app/ccas/_lib/status";
+import ApplicantDetails from "./ApplicantDetails";
 
 type AppRow =
   RouterOutputs["ccaApplicationsHead"]["listApplications"]["applications"][number];
 
+/** Local calendar-day key (YYYY-MM-DD) for an epoch-seconds time. */
+function dayKey(epoch: number): string {
+  const d = new Date(epoch * 1000);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
 /**
- * The "Interviews" tab — the head's run-sheet for booked interviews, distinct
- * from "Interview slots" (which is about opening availability). It answers "how
- * do I mark an interview as done": each booked interview has a Mark done button
- * that moves it to Interviewed; from there it's reviewed/decided in the
- * Applications tab. Notes can be added here, during the interview.
+ * The "Interviews" tab — the head's run-sheet, distinct from "Interview slots"
+ * (availability). Today's interviews sit at the top, then everything else still
+ * to be interviewed, then the ones already done at the bottom. Each row's Mark
+ * done button moves it to Interviewed; accept/reject happens on the Applications
+ * tab. Expanding a row shows the applicant's full details, the notes they sent,
+ * and the interview notes (which can be added here, during the interview).
  */
 export default function InterviewSessions({ ccaID }: { ccaID: number }) {
   const list = api.ccaApplicationsHead.listApplications.useQuery(
@@ -44,11 +53,18 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
   const byTime = (a: AppRow, b: AppRow) =>
     (a.slot?.startTime ?? Number.MAX_SAFE_INTEGER) -
     (b.slot?.startTime ?? Number.MAX_SAFE_INTEGER);
+
   const apps = list.data.applications;
   const scheduled = apps
     .filter((a) => a.status === "interview_scheduled")
     .sort(byTime);
   const completed = apps.filter((a) => a.status === "interviewed").sort(byTime);
+
+  const today = dayKey(Math.floor(Date.now() / 1000));
+  const isToday = (a: AppRow) =>
+    a.slot?.startTime != null && dayKey(a.slot.startTime) === today;
+  const todays = scheduled.filter(isToday);
+  const upcoming = scheduled.filter((a) => !isToday(a));
 
   if (scheduled.length === 0 && completed.length === 0) {
     return (
@@ -57,8 +73,9 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
           No interviews booked yet
         </p>
         <p className="mx-auto mt-1 max-w-sm text-sm text-gray-500">
-          Open availability under <span className="font-medium">Interview
-          slots</span>; once residents book, their interviews show up here.
+          Open availability under{" "}
+          <span className="font-medium">Interview slots</span>; once residents
+          book, their interviews show up here.
         </p>
       </div>
     );
@@ -66,22 +83,34 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
 
   return (
     <div className="space-y-6">
-      <Section
-        title="To interview"
-        subtitle="Booked interviews. Mark each done once you've met the applicant."
-        rows={scheduled}
-        ccaID={ccaID}
-        markable
-        emptyText="Nothing booked right now."
-      />
-      <Section
-        title="Interviewed"
-        subtitle="Done — review and accept or reject from the Applications tab."
-        rows={completed}
-        ccaID={ccaID}
-        markable={false}
-        emptyText="No completed interviews yet."
-      />
+      {todays.length > 0 && (
+        <Section
+          title="Today"
+          subtitle="Interviews happening today."
+          rows={todays}
+          ccaID={ccaID}
+          markable
+          highlight
+        />
+      )}
+      {upcoming.length > 0 && (
+        <Section
+          title="To be interviewed"
+          subtitle="Booked — mark each done once you've met the applicant."
+          rows={upcoming}
+          ccaID={ccaID}
+          markable
+        />
+      )}
+      {completed.length > 0 && (
+        <Section
+          title="Already interviewed"
+          subtitle="Done — review and accept or reject on the Applications tab."
+          rows={completed}
+          ccaID={ccaID}
+          markable={false}
+        />
+      )}
     </div>
   );
 }
@@ -92,38 +121,42 @@ function Section({
   rows,
   ccaID,
   markable,
-  emptyText,
+  highlight = false,
 }: {
   title: string;
   subtitle: string;
   rows: AppRow[];
   ccaID: number;
   markable: boolean;
-  emptyText: string;
+  highlight?: boolean;
 }) {
   return (
-    <section>
+    <section
+      className={
+        highlight ? "rounded-lg border border-emerald-200 bg-emerald-50/40 p-3" : ""
+      }
+    >
       <div className="mb-2 flex items-baseline gap-2">
-        <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
+        <h2
+          className={`text-sm font-semibold ${
+            highlight ? "text-emerald-800" : "text-gray-900"
+          }`}
+        >
+          {title}
+        </h2>
         <span className="text-xs text-gray-400">{rows.length}</span>
       </div>
       <p className="mb-2 text-xs text-gray-500">{subtitle}</p>
-      {rows.length === 0 ? (
-        <p className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-400">
-          {emptyText}
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {rows.map((a) => (
-            <SessionRow
-              key={a.applicationID}
-              ccaID={ccaID}
-              app={a}
-              markable={markable}
-            />
-          ))}
-        </ul>
-      )}
+      <ul className="space-y-2">
+        {rows.map((a) => (
+          <SessionRow
+            key={a.applicationID}
+            ccaID={ccaID}
+            app={a}
+            markable={markable}
+          />
+        ))}
+      </ul>
     </section>
   );
 }
@@ -150,7 +183,7 @@ function SessionRow({
     app.userID;
 
   return (
-    <li className="rounded-lg border border-gray-200 bg-white">
+    <li className="overflow-hidden rounded-lg border border-gray-200 bg-white">
       <div className="flex items-center gap-3 p-3">
         <button
           onClick={() => setOpen((o) => !o)}
@@ -158,7 +191,9 @@ function SessionRow({
           className="flex min-w-0 flex-1 items-center gap-3 text-left"
         >
           <span className="shrink-0 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium tabular-nums text-gray-700">
-            {app.slot ? formatSlot(app.slot.startTime, app.slot.endTime) : "No time"}
+            {app.slot
+              ? formatSlot(app.slot.startTime, app.slot.endTime)
+              : "No time"}
           </span>
           <span className="min-w-0">
             <span className="block truncate text-sm font-medium text-gray-900">
@@ -185,27 +220,14 @@ function SessionRow({
           </Button>
         )}
       </div>
-      {open && (
-        <SessionDetail
-          ccaID={ccaID}
-          applicationID={app.applicationID}
-          applicantNotes={app.notes}
-        />
-      )}
+      {open && <SessionDetail ccaID={ccaID} app={app} />}
     </li>
   );
 }
 
-function SessionDetail({
-  ccaID,
-  applicationID,
-  applicantNotes,
-}: {
-  ccaID: number;
-  applicationID: number;
-  applicantNotes: string | null;
-}) {
+function SessionDetail({ ccaID, app }: { ccaID: number; app: AppRow }) {
   const utils = api.useUtils();
+  const applicationID = app.applicationID;
   const detail = api.ccaApplicationsHead.getApplication.useQuery(
     { ccaID, applicationID },
     { retry: false },
@@ -222,18 +244,19 @@ function SessionDetail({
   });
 
   return (
-    <div className="space-y-3 border-t border-gray-100 p-3">
-      <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
-          Applicant&rsquo;s notes
-        </p>
-        <p className="mt-1 whitespace-pre-line text-sm text-gray-700">
-          {applicantNotes?.trim() ? applicantNotes : "— none —"}
-        </p>
+    <div className="space-y-3 border-t border-gray-100 bg-gray-50/50 p-3">
+      {/* Full details + the notes they sent with the application */}
+      <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <ApplicantDetails
+          applicant={app.applicant}
+          userID={app.userID}
+          notes={app.notes}
+        />
       </div>
 
-      <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+      {/* Interview notes + add */}
+      <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
           Interview notes
         </p>
         {detail.isPending ? (
@@ -243,12 +266,9 @@ function SessionDetail({
         ) : detail.data.interviewNotes.length === 0 ? (
           <p className="mt-1 text-sm text-gray-400">No interview notes yet.</p>
         ) : (
-          <ul className="mt-1 space-y-2">
+          <ul className="mt-1.5 space-y-2">
             {detail.data.interviewNotes.map((n) => (
-              <li
-                key={n.id}
-                className="rounded-md bg-gray-50 px-3 py-2 text-sm"
-              >
+              <li key={n.id} className="rounded-md bg-gray-50 px-3 py-2 text-sm">
                 <p className="whitespace-pre-line text-gray-700">{n.body}</p>
                 <p className="mt-1 text-xs text-gray-400">
                   {n.authorName ?? "Head"}
@@ -260,37 +280,37 @@ function SessionDetail({
             ))}
           </ul>
         )}
-      </div>
 
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const parsed = addNoteInput.safeParse({
-            ccaID,
-            applicationID,
-            body: note,
-          });
-          if (!parsed.success) return;
-          addNote.mutate(parsed.data);
-        }}
-        className="space-y-2"
-      >
-        <textarea
-          value={note}
-          maxLength={INTERVIEW_NOTE_MAX}
-          rows={2}
-          onChange={(e) => setNote(e.target.value)}
-          placeholder="Add an interview note…"
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
-        />
-        <Button
-          type="submit"
-          variant="outline"
-          disabled={addNote.isPending || note.trim().length === 0}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const parsed = addNoteInput.safeParse({
+              ccaID,
+              applicationID,
+              body: note,
+            });
+            if (!parsed.success) return;
+            addNote.mutate(parsed.data);
+          }}
+          className="mt-3 space-y-2"
         >
-          {addNote.isPending ? "Adding…" : "Add note"}
-        </Button>
-      </form>
+          <textarea
+            value={note}
+            maxLength={INTERVIEW_NOTE_MAX}
+            rows={2}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Add an interview note…"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          />
+          <Button
+            type="submit"
+            variant="outline"
+            disabled={addNote.isPending || note.trim().length === 0}
+          >
+            {addNote.isPending ? "Adding…" : "Add note"}
+          </Button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -45,33 +45,60 @@ import { canonicalUserID } from "~/lib/identity";
  */
 
 /**
- * Resolve canonical applicant ids to a human: displayName, email, matric. Same
- * approach as cca.listHeads (there is no reverse canonical→User query, so guess
- * the email AND match the stored key), plus the matric from UserMatric.
+ * Everything the head surfaces know about an applicant. Resolved from User +
+ * UserMatric; any field can be null for an unresolved/partial account (rendered
+ * as "—" in the UI, never dropped).
+ */
+export type Applicant = {
+  displayName: string | null;
+  email: string | null;
+  matric: string | null;
+  telegramHandle: string | null;
+  block: number | null;
+  bio: string | null;
+};
+
+const EMPTY_APPLICANT: Applicant = {
+  displayName: null,
+  email: null,
+  matric: null,
+  telegramHandle: null,
+  block: null,
+  bio: null,
+};
+
+/**
+ * Resolve canonical applicant ids to their profile details. Same approach as
+ * cca.listHeads (no reverse canonical→User query, so guess the email AND match
+ * the stored key), plus the matric from UserMatric. Selects profile fields
+ * EXPLICITLY — never a bare User read (passwordHash must not leave the server,
+ * and a Google-adapter row missing it throws on deserialization, I-2).
  */
 async function resolveApplicants(
   db: PrismaClient,
   userIDs: readonly string[],
-): Promise<
-  Map<string, { displayName: string | null; email: string | null; matric: string | null }>
-> {
+): Promise<Map<string, Applicant>> {
   const keys = [...new Set(userIDs)];
-  const out = new Map<
-    string,
-    { displayName: string | null; email: string | null; matric: string | null }
-  >();
+  const out = new Map<string, Applicant>();
   if (keys.length === 0) return out;
 
   const guessedEmails = keys.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+  const profileSelect = {
+    email: true,
+    displayName: true,
+    userID: true,
+    telegramHandle: true,
+    block: true,
+    bio: true,
+  } as const;
   const [byEmail, byStored, matrics] = await Promise.all([
     db.user.findMany({
       where: { email: { in: guessedEmails, mode: "insensitive" } },
-      // Never a bare read: passwordHash must not leave the server (I-2).
-      select: { email: true, displayName: true, userID: true },
+      select: profileSelect,
     }),
     db.user.findMany({
       where: { userID: { in: keys } },
-      select: { email: true, displayName: true, userID: true },
+      select: profileSelect,
     }),
     db.userMatric.findMany({
       where: { userID: { in: keys } },
@@ -80,25 +107,30 @@ async function resolveApplicants(
   ]);
 
   const matricByKey = new Map(matrics.map((m) => [m.userID, m.matric]));
-  const set = (
-    key: string,
-    v: { displayName: string | null; email: string | null },
-  ) => {
+  type Row = (typeof byEmail)[number];
+  const set = (key: string, u: Row) => {
     if (!out.has(key)) {
-      out.set(key, { ...v, matric: matricByKey.get(key) ?? null });
+      out.set(key, {
+        displayName: u.displayName,
+        email: u.email,
+        matric: matricByKey.get(key) ?? null,
+        telegramHandle: u.telegramHandle,
+        block: u.block,
+        bio: u.bio,
+      });
     }
   };
   for (const u of byEmail) {
     const cid = canonicalUserID(u.email);
-    if (cid) set(cid, { displayName: u.displayName, email: u.email });
+    if (cid) set(cid, u);
   }
   for (const u of byStored) {
-    if (u.userID) set(u.userID, { displayName: u.displayName, email: u.email });
+    if (u.userID) set(u.userID, u);
   }
   // Ensure every requested key is present, even if unresolved (amber in the UI).
   for (const k of keys) {
     if (!out.has(k)) {
-      out.set(k, { displayName: null, email: null, matric: matricByKey.get(k) ?? null });
+      out.set(k, { ...EMPTY_APPLICANT, matric: matricByKey.get(k) ?? null });
     }
   }
   return out;
@@ -166,11 +198,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           createdAt: a.createdAt,
           decidedAt: a.decidedAt,
           decisionReason: a.decisionReason,
-          applicant: people.get(a.userID) ?? {
-            displayName: null,
-            email: null,
-            matric: null,
-          },
+          applicant: people.get(a.userID) ?? EMPTY_APPLICANT,
           slot:
             a.interviewSlotID !== null
               ? (slots.get(a.interviewSlotID) ?? null)
@@ -248,11 +276,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         // collide (an earlier version overwrote `notes` and lost the applicant
         // text).
         ...app,
-        applicant: people.get(app.userID) ?? {
-          displayName: null,
-          email: null,
-          matric: null,
-        },
+        applicant: people.get(app.userID) ?? EMPTY_APPLICANT,
         slot,
         interviewNotes: notes.map((n) => ({
           id: n.id,
@@ -307,11 +331,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           ...s,
           bookedBy:
             s.bookedByUserID !== null
-              ? (people.get(s.bookedByUserID) ?? {
-                  displayName: null,
-                  email: null,
-                  matric: null,
-                })
+              ? (people.get(s.bookedByUserID) ?? EMPTY_APPLICANT)
               : null,
         })),
       };


### PR DESCRIPTION
Reworks the head's review + interview experience, per feedback.

## Applications tab — cleaner, decision-focused
- **Removed** the "Mark interviewed" action and the add-note form. Interview notes are now **read-only** here (they're added on the Interviews tab).
- **Status stepper** on each application: **Slot to be booked → Interview booked → Interviewed → Decision**, the final node turning green (Accepted) or rose (Not accepted).
- Shows the applicant's **full details + the notes they sent** (shared `ApplicantDetails`), an avatar, and prominent **Accept / Deny** buttons with an optional reason.
- Terminal (accepted/rejected) and withdrawn applications render their outcome with no action buttons.

## Interviews tab — a run-sheet ordered by date
- **Today** at the top (highlighted), then **To be interviewed**, then **Already interviewed** at the bottom.
- Expanding a row shows **all the applicant details we have** (name, matric, block, email, Telegram, about) **+ the notes they sent with the application + the interview notes** (which can be added here).

## Server
- `resolveApplicants` now also returns `telegramHandle`, `block` and `bio` (shared `Applicant` type + `EMPTY_APPLICANT`), so both tabs show the full detail set. Fields are selected explicitly (never a bare User read).

## Cases handled
Null interview slot ("No time"), unresolved/partial accounts (fields show "—"), withdrawn applications, already-decided guard (server + UI), and the local-date "today" grouping.

## Verification
`tsc --noEmit` clean · `next build` passes. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
