### PR TITLE
Fix: Accept / add-member silently failed (UserCCA validator rejects Prisma's int64 ccaID)

### DIFF
--- a/src/server/api/routers/ccaAdmin.ts
+++ b/src/server/api/routers/ccaAdmin.ts
@@ -10,6 +10,7 @@ import {
 } from "~/server/api/services/ccaScope";
 import { writeAudit } from "~/server/api/routers/admin";
 import {
+  addCcaMember,
   membershipKeysFor,
   removeCcaMember,
   removeMemberTargetSchema,
@@ -291,9 +292,9 @@ export const ccaAdminRouter = createTRPCRouter({
         });
       }
 
-      await ctx.db.userCCA.create({
-        data: { ccaID: input.ccaID, userID: input.userID },
-      });
+      // Raw insert via addCcaMember — a Prisma userCCA.create is rejected by the
+      // UserCCA validator (ccaID must be int32; Prisma sends long, code 121).
+      await addCcaMember(ctx.db, input.ccaID, input.userID);
 
       await writeAudit(ctx.db, {
         actorUserID,

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -7,7 +7,7 @@ import { createTRPCRouter, identifiedProcedure } from "~/server/api/trpc";
 import { getUserRoles } from "~/server/api/services/access";
 import { assertHeadsCca } from "~/server/api/services/ccaScope";
 import { writeAudit } from "~/server/api/routers/admin";
-import { membershipKeysFor } from "~/server/api/services/ccaMembers";
+import { addCcaMember, membershipKeysFor } from "~/server/api/services/ccaMembers";
 import {
   assertApplicationsEnabled,
   nextCounter,
@@ -698,9 +698,9 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             select: { id: true },
           });
           if (!already) {
-            await ctx.db.userCCA.create({
-              data: { ccaID: app.ccaID, userID: app.userID },
-            });
+            // Raw insert via addCcaMember — a Prisma userCCA.create is rejected
+            // by the UserCCA validator (ccaID must be int32; Prisma sends long).
+            await addCcaMember(ctx.db, app.ccaID, app.userID);
           }
 
           await ctx.db.ccaApplication.update({

--- a/src/server/api/services/ccaMembers.ts
+++ b/src/server/api/services/ccaMembers.ts
@@ -63,6 +63,43 @@ export type RemoveMemberResult = {
 };
 
 /**
+ * THE single writer that ADDS a CCA membership — one canonical `UserCCA` row.
+ *
+ * MUST go through `$runCommandRaw`, NOT `db.userCCA.create`. `UserCCA` carries a
+ * DB-level `$jsonSchema` validator that declares `ccaID` as bsonType **"int"**
+ * (int32). Prisma's Mongo connector serializes an `Int` field as a 64-bit
+ * `long`, which the validator REJECTS with code 121 ("Document failed
+ * validation") — so `userCCA.create({ data: { ccaID, userID } })` throws for
+ * EVERY add, silently taking down application-acceptance and admin add-member.
+ * The extended-JSON `{ $numberInt }` forces a true int32 that passes.
+ *
+ * The write reply is INSPECTED (I-8f) rather than trusting a throw: a validation
+ * failure comes back as `ok:1` with a `writeErrors` array, not an exception.
+ *
+ * Caller supplies the CANONICAL userID and has already deduped against both key
+ * formats (UserCCA has no compound unique, so a check-then-insert can still race
+ * — the roster surfaces any duplicate rather than hiding it).
+ */
+export async function addCcaMember(
+  db: PrismaClient,
+  ccaID: number,
+  userID: string,
+): Promise<void> {
+  const reply = (await db.$runCommandRaw({
+    insert: "UserCCA",
+    documents: [{ ccaID: { $numberInt: String(ccaID) }, userID }],
+  })) as { ok?: number; n?: number; writeErrors?: unknown[] };
+
+  const writeErrors = reply?.writeErrors ?? [];
+  if (writeErrors.length > 0 || reply?.n !== 1) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "MEMBERSHIP_WRITE_FAILED",
+    });
+  }
+}
+
+/**
  * MEMBERSHIP LIVES IN THREE PLACES AND THIS CLEANS ALL OF THEM:
  *   1. UserCCA rows under the CANONICAL key
  *   2. UserCCA rows under the LEGACY A-format key (same person, other key)


### PR DESCRIPTION
## The bug
Accepting a CCA application did nothing (and admin **Add member** too): the application stayed *interviewed*, with no member added. Reproduced on prod for applicant **E1356126** — application #2 stuck at `interviewed`, `decidedBy` null, no `UserCCA` row.

## Root cause
`UserCCA` has a DB-level `$jsonSchema` validator that requires `ccaID` to be BSON **`int`** (int32). Prisma's Mongo connector serializes an `Int` field as a 64-bit **`long`**, so `db.userCCA.create({ data: { ccaID, userID } })` is **rejected with code 121 ("Document failed validation")** on *every* membership add. The accept threw at that write, before the application was marked accepted.

Confirmed live: the Prisma `create` fails; a raw insert with `{ $numberInt }` succeeds.

## Fix
- New `services/ccaMembers.addCcaMember()` — the single membership **writer**, via `$runCommandRaw` with an explicit `{ $numberInt }` `ccaID`, **inspecting the write reply** (a validation failure returns `ok:1` + `writeErrors`, not an exception).
- `decide` (accept) and `ccaAdmin.addMember` now call it instead of `userCCA.create`.

## No data repair needed
E1356126's application is still non-terminal (`interviewed`), so once this deploys, clicking **Accept** again completes it cleanly (idempotent).

## Verification
Confirmed the raw insert works against prod; `tsc --noEmit` clean; `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
