### PR TITLE
Residents: read-only 'My CCAs' dashboard + heads/contact on CCA detail

### DIFF
--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -102,6 +102,11 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
     setIsProfileDropdownOpen(false);
   };
 
+  const handleMyCcas = () => {
+    router.push("/ccas/my");
+    setIsProfileDropdownOpen(false);
+  };
+
   const handleLogout = async () => {
     await signOut();
     setIsProfileDropdownOpen(false);
@@ -204,6 +209,14 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
                         </button>
 
                         <button
+                          onClick={handleMyCcas}
+                          className="flex w-full items-center px-4 py-2 text-sm text-gray-700 transition-colors duration-150 hover:bg-gray-50"
+                        >
+                          <Users size={16} className="mr-3 text-gray-400" />
+                          My CCAs
+                        </button>
+
+                        <button
                           onClick={handleMyApplications}
                           className="flex w-full items-center px-4 py-2 text-sm text-gray-700 transition-colors duration-150 hover:bg-gray-50"
                         >
@@ -277,6 +290,13 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
                     >
                       <UserCircle size={18} />
                       <span>Profile</span>
+                    </button>
+                    <button
+                      onClick={handleMyCcas}
+                      className="flex w-full items-center space-x-3 rounded-lg px-3 py-2 text-left font-medium text-emerald-100 transition-colors duration-200 hover:bg-emerald-700 hover:text-white"
+                    >
+                      <Users size={18} />
+                      <span>My CCAs</span>
                     </button>
                     <button
                       onClick={handleMyApplications}

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowLeft, CalendarClock } from "lucide-react";
+import { ArrowLeft, CalendarClock, Send, Users } from "lucide-react";
 
 import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
@@ -140,6 +140,52 @@ export default function CcaApplyPanel({ ccaID }: { ccaID: number }) {
           </p>
         )}
       </div>
+
+      {/* Who runs it + how big it is */}
+      {(d.heads.length > 0 || d.memberCount > 0) && (
+        <Card>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+                Run by
+              </p>
+              {d.heads.length === 0 ? (
+                <p className="mt-1 text-sm text-gray-400">—</p>
+              ) : (
+                <ul className="mt-1 space-y-1">
+                  {d.heads.map((h) => (
+                    <li
+                      key={h.userID}
+                      className="flex flex-wrap items-center gap-x-2 text-sm text-gray-800"
+                    >
+                      <span>{h.displayName ?? h.userID}</span>
+                      {h.telegramHandle && (
+                        <a
+                          href={`https://t.me/${h.telegramHandle}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-emerald-700 hover:underline"
+                        >
+                          <Send className="h-3 w-3" />@{h.telegramHandle}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="text-right">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+                Members
+              </p>
+              <p className="mt-1 inline-flex items-center gap-1.5 text-sm font-medium text-gray-800">
+                <Users className="h-4 w-4 text-gray-400" />
+                {d.memberCount}
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
 
       {/* Application state */}
       {d.isMember ? (

--- a/src/app/ccas/_components/MyCcasList.tsx
+++ b/src/app/ccas/_components/MyCcasList.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { ChevronRight, Settings } from "lucide-react";
+
+import { api } from "~/trpc/react";
+
+/**
+ * The resident's "My CCAs" dashboard — the CCAs they belong to, VIEW ONLY. No
+ * edit or management affordance appears here; those live on the head dashboard
+ * (/cca), which a plain member can't reach. A CCA the caller also heads shows a
+ * "Manage" shortcut across to it.
+ */
+export default function MyCcasList() {
+  const q = api.ccaApplications.myMemberships.useQuery(undefined, {
+    retry: false,
+  });
+
+  if (q.isPending) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-36 animate-pulse rounded-lg bg-gray-200" />
+        ))}
+      </div>
+    );
+  }
+
+  if (q.error) {
+    if (q.error.message === "CCA_APPLICATIONS_DISABLED") {
+      return (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500">
+          CCAs aren&rsquo;t available right now.
+        </p>
+      );
+    }
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-6 text-sm text-red-800">
+        These couldn&rsquo;t be loaded. Reload the page.
+      </p>
+    );
+  }
+
+  if (q.data.ccas.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center">
+        <p className="text-sm font-medium text-gray-900">
+          You&rsquo;re not in any CCA yet
+        </p>
+        <Link
+          href="/ccas"
+          className="mt-2 inline-block text-sm font-medium text-emerald-700"
+        >
+          Browse CCAs to join →
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {q.data.ccas.map((c) => (
+        <li key={c.ccaID} className="flex flex-col rounded-lg border border-gray-200 bg-white">
+          <Link
+            href={`/ccas/${c.ccaID}`}
+            className="flex flex-1 flex-col p-4 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            <div className="flex items-start gap-3">
+              {c.logoUrl ? (
+                <Image
+                  src={c.logoUrl}
+                  alt=""
+                  width={44}
+                  height={44}
+                  className="h-11 w-11 shrink-0 rounded-md object-cover"
+                />
+              ) : (
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-emerald-100 text-sm font-semibold text-emerald-700">
+                  {c.ccaName.slice(0, 2).toUpperCase()}
+                </div>
+              )}
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <p className="truncate font-medium text-gray-900">
+                    {c.ccaName}
+                  </p>
+                  {c.isHead && (
+                    <span className="shrink-0 rounded-full bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20">
+                      You lead this
+                    </span>
+                  )}
+                </div>
+                {c.category && (
+                  <p className="truncate text-xs text-gray-500">{c.category}</p>
+                )}
+              </div>
+              <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-gray-300" />
+            </div>
+            {c.description && (
+              <p className="mt-3 line-clamp-2 text-sm text-gray-600">
+                {c.description}
+              </p>
+            )}
+          </Link>
+          {c.isHead && (
+            <Link
+              href={`/cca/${c.ccaID}`}
+              className="flex items-center gap-1.5 border-t border-gray-100 px-4 py-2 text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-emerald-700"
+            >
+              <Settings className="h-3.5 w-3.5" />
+              Manage this CCA
+            </Link>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/ccas/my/page.tsx
+++ b/src/app/ccas/my/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+import MyCcasList from "../_components/MyCcasList";
+
+export const dynamic = "force-dynamic";
+
+/** The resident's "My CCAs" — the CCAs they're a member of, view-only. */
+export default function MyCcasPage() {
+  return (
+    <div>
+      <header className="mb-5 flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">My CCAs</h1>
+          <p className="mt-0.5 text-sm text-gray-500">
+            The co-curricular activities you&rsquo;re a member of.
+          </p>
+        </div>
+        <Link
+          href="/ccas"
+          className="text-sm font-medium text-emerald-700 hover:text-emerald-800"
+        >
+          Browse all CCAs →
+        </Link>
+      </header>
+      <MyCcasList />
+    </div>
+  );
+}

--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -9,6 +9,7 @@ import {
 } from "~/server/api/trpc";
 import { writeAudit } from "~/server/api/routers/admin";
 import { membershipKeysFor } from "~/server/api/services/ccaMembers";
+import { canonicalUserID } from "~/lib/identity";
 import {
   APPLICATION_COUNTER_KEY,
   assertApplicationsEnabled,
@@ -76,6 +77,61 @@ async function releaseSlotIfMine(
     where: { slotID, bookedByUserID: userID },
     data: { bookedByUserID: null, bookedApplicationID: null, bookedAt: null },
   });
+}
+
+export type HeadContact = {
+  userID: string;
+  displayName: string | null;
+  telegramHandle: string | null;
+};
+
+/**
+ * Resolve a CCA's head userIDs to display name + Telegram, so a member viewing
+ * their CCA can see who runs it and how to reach them. Same guess-email +
+ * stored-key approach as cca.listHeads; selects fields explicitly (never a bare
+ * User read — I-2). This is the ONLY head info exposed to a non-head: name and
+ * Telegram, both already shown publicly on that person's bookings/profile.
+ */
+async function resolveHeadContacts(
+  db: PrismaClient,
+  userIDs: readonly string[],
+): Promise<HeadContact[]> {
+  const keys = [...new Set(userIDs)];
+  if (keys.length === 0) return [];
+  const guessed = keys.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+  const select = {
+    email: true,
+    displayName: true,
+    telegramHandle: true,
+    userID: true,
+  } as const;
+  const [byEmail, byStored] = await Promise.all([
+    db.user.findMany({
+      where: { email: { in: guessed, mode: "insensitive" } },
+      select,
+    }),
+    db.user.findMany({ where: { userID: { in: keys } }, select }),
+  ]);
+  const byKey = new Map<
+    string,
+    { displayName: string | null; telegramHandle: string | null }
+  >();
+  for (const u of byEmail) {
+    const cid = canonicalUserID(u.email);
+    if (cid && !byKey.has(cid)) {
+      byKey.set(cid, { displayName: u.displayName, telegramHandle: u.telegramHandle });
+    }
+  }
+  for (const u of byStored) {
+    if (u.userID && !byKey.has(u.userID)) {
+      byKey.set(u.userID, { displayName: u.displayName, telegramHandle: u.telegramHandle });
+    }
+  }
+  return keys.map((k) => ({
+    userID: k,
+    displayName: byKey.get(k)?.displayName ?? null,
+    telegramHandle: byKey.get(k)?.telegramHandle ?? null,
+  }));
 }
 
 export const ccaApplicationsRouter = createTRPCRouter({
@@ -164,7 +220,8 @@ export const ccaApplicationsRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
       }
 
-      const [profile, membership, apps, futureSlots] = await Promise.all([
+      const [profile, membership, apps, futureSlots, headRows, memberRows] =
+        await Promise.all([
         ctx.db.ccaProfile.findUnique({
           where: { ccaID: input.ccaID },
           select: { description: true, logoUrl: true, bannerUrl: true },
@@ -193,6 +250,16 @@ export const ccaApplicationsRouter = createTRPCRouter({
           where: { ccaID: input.ccaID, endTime: { gt: now } },
           select: { bookedByUserID: true, canceledAt: true },
         }),
+        ctx.db.ccaHead.findMany({
+          where: { ccaID: input.ccaID },
+          select: { userID: true },
+        }),
+        // Row count, not distinct people (UserCCA is mixed-key); labelled
+        // "members" in the UI, close enough for a member's overview.
+        ctx.db.userCCA.findMany({
+          where: { ccaID: input.ccaID },
+          select: { id: true },
+        }),
       ]);
 
       const openSlotCount = futureSlots.filter(
@@ -202,6 +269,10 @@ export const ccaApplicationsRouter = createTRPCRouter({
       const hasOpenApplication =
         latest !== null && !isTerminalStatus(latest.status);
       const isMember = membership !== null;
+      const heads = await resolveHeadContacts(
+        ctx.db,
+        headRows.map((h) => h.userID),
+      );
 
       return {
         ccaID: cca.ccaID,
@@ -216,8 +287,67 @@ export const ccaApplicationsRouter = createTRPCRouter({
         // just drives the default affordance.
         canApply: !isMember && !hasOpenApplication,
         openSlotCount,
+        heads,
+        memberCount: memberRows.length,
       };
     }),
+
+  /**
+   * The CCAs the caller is a MEMBER of — the resident's read-only "My CCAs"
+   * dashboard. Membership only (heads/managers use /cca); a CCA the caller both
+   * belongs to and heads is flagged `isHead` so the UI can link across.
+   *
+   * NOT a management surface: it returns display data only, and every write path
+   * this router exposes is scoped to the caller's own applications.
+   */
+  myMemberships: identifiedProcedure.query(async ({ ctx }) => {
+    await assertApplicationsEnabled(ctx.db);
+    const userID = ctx.session.user.userID;
+    const keys = membershipKeysFor({
+      email: ctx.session.user.email ?? "",
+      userID,
+    });
+
+    const memberships = await ctx.db.userCCA.findMany({
+      where: { userID: { in: keys } },
+      select: { ccaID: true },
+    });
+    const ccaIDs = [...new Set(memberships.map((m) => m.ccaID))];
+    if (ccaIDs.length === 0) return { ccas: [] };
+
+    const [ccas, profiles, headRows] = await Promise.all([
+      ctx.db.cCA.findMany({
+        where: { ccaID: { in: ccaIDs } },
+        select: { ccaID: true, ccaName: true, category: true },
+      }),
+      ctx.db.ccaProfile.findMany({
+        where: { ccaID: { in: ccaIDs } },
+        select: { ccaID: true, description: true, logoUrl: true },
+      }),
+      ctx.db.ccaHead.findMany({
+        where: { ccaID: { in: ccaIDs }, userID },
+        select: { ccaID: true },
+      }),
+    ]);
+
+    const profileByID = new Map(profiles.map((p) => [p.ccaID, p]));
+    const iHead = new Set(headRows.map((h) => h.ccaID));
+
+    const rows = ccas.map((c) => ({
+      ccaID: c.ccaID,
+      ccaName: c.ccaName,
+      category: c.category,
+      description: profileByID.get(c.ccaID)?.description ?? null,
+      logoUrl: profileByID.get(c.ccaID)?.logoUrl ?? null,
+      isHead: iHead.has(c.ccaID),
+    }));
+    rows.sort(
+      (a, b) =>
+        (a.category ?? "￿").localeCompare(b.category ?? "￿") ||
+        a.ccaName.localeCompare(b.ccaName),
+    );
+    return { ccas: rows };
+  }),
 
   /**
    * The caller's applications across all CCAs, with the CCA name and — for a


### PR DESCRIPTION
Gives residents a **read-only** CCA dashboard for the CCAs they belong to. No editing or management surfaces appear anywhere here — those stay on the head `/cca` dashboard, which a plain member can't reach.

## Resident "My CCAs"
- New **`/ccas/my`** page listing the CCAs the caller is a member of — cards with logo, name, category, description — linking to the existing read-only detail page.
- Added **"My CCAs"** to the profile-photo dropdown (desktop + mobile), next to "My applications".
- If the caller *also heads* a CCA, its card shows a **"You lead this"** badge and a **"Manage this CCA"** shortcut across to `/cca/[id]` — otherwise there's no management affordance at all.

## Richer (still read-only) detail
`getCca` now also returns the CCA's **heads (name + Telegram contact)** and a **member count**, shown on `/ccas/[ccaID]` so a member (or applicant) can see who runs it and how big it is. Head info exposed is only name + Telegram — both already public on that person's bookings/profile.

## Server
- `ccaApplications.myMemberships` — member CCAs for the caller (membership only; `isHead` flag for cross-linking).
- `resolveHeadContacts` helper for the heads block; fields selected explicitly (never a bare User read).

## Verification
`tsc --noEmit` clean · `next build` passes (new `/ccas/my`). No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
