### PR TITLE
Events: CCA event proposals, JCRC review, resident timeline + signup

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -319,10 +319,17 @@ model RoleAuditLog {
   /// Reserved now so the future CCA system's history is queryable alongside
   /// role history with no backfill. See 07-cca-future.md.
   targetCcaID      Int?
+  /// The event an action concerns, for the Events feature's decision/export
+  /// trail. Nullable and additive (I-2) — no backfill, no validator (this
+  /// collection has none). Set by event.approve / event.reject / event.publish /
+  /// event.cancel / event.attendees.export.
+  targetEventID    Int?
   /// One of AUDIT_ACTIONS in src/server/api/services/roles.ts:
   /// grant | revoke | set | facilityAccess.set | denied | pending.create |
   /// pending.claim | pending.revoke | booking.denied.shadow |
-  /// ccaHead.grant | ccaHead.revoke | ccaHead.transfer
+  /// ccaHead.grant | ccaHead.revoke | ccaHead.transfer |
+  /// event.approve | event.reject | event.publish | event.cancel |
+  /// event.attendees.export
   action           String
   rolesBefore      String[] @default([])
   rolesAfter       String[] @default([])
@@ -337,6 +344,7 @@ model RoleAuditLog {
   @@index([actorUserID, at(sort: Desc)], map: "actor_at")
   @@index([batchId], map: "batch")
   @@index([targetCcaID, at(sort: Desc)], map: "cca_at")
+  @@index([targetEventID, at(sort: Desc)], map: "event_at")
 }
 
 /// A role grant for someone who has NOT signed up yet (D-8). Applied at their
@@ -552,6 +560,109 @@ model CcaInterviewNote {
   createdAt     DateTime? @default(now())
 
   @@index([applicationID], map: "application")
+}
+
+/// A CCA event, from proposal through to a published, signup-able listing.
+///
+/// BRAND-NEW, UNVALIDATED collection (no $jsonSchema) — so, unlike CCA/User,
+/// fields may be added here freely. It deliberately holds BOTH the proposal
+/// (title/description/proposalUrl/start/end/location/capacity, entered at
+/// application time) AND the public content (publicDescription/bannerUrl/
+/// photoUrls, added by the head only AFTER JCRC approval). One row, one
+/// lifecycle, so there is no join to keep in step.
+///
+/// I-2: every scalar is NULLABLE and every list has a default. This collection
+/// is read on the resident timeline and the head/review portals; a row written
+/// by a script or a partial hand-fix that omitted a required scalar would break
+/// Prisma deserialization for every subsequent reader. `status` is nullable with
+/// a default rather than a required enum for the same reason.
+///
+/// Keyed on `eventID` (a stable human int from the Counter collection, key
+/// "eventID" — see nextEventId in services/events.ts), NOT the ObjectId, so URLs
+/// and the blob path scheme (event/{eventID}/...) are stable and readable.
+///
+/// `createdBy`/`decidedBy`/`updatedBy` are CANONICAL userIDs (I-1), the same key
+/// as session.user.userID and CcaHead.userID. NEVER User.userID.
+///
+/// Authorisation is PER-EVENT via assertHeadsCca(db, actor, event.ccaID) — never
+/// a role check — because `cca_head` is scope-free. Times are UNIX epoch SECONDS
+/// (UTC), the same convention as Bookings.startTime.
+///
+/// status vocabulary (enforced in code, src/lib/schemas/event.ts):
+///   draft | submitted | approved | rejected | published | canceled
+/// `draft` exists so the proposal PDF (which needs an eventID in its blob path)
+/// can be uploaded before "Submit for review". `rejected` is editable and
+/// resubmittable; `canceled` is terminal.
+model Event {
+  id                String    @id @default(auto()) @map("_id") @db.ObjectId
+  eventID           Int       @unique(map: "eventID")
+  ccaID             Int
+  createdBy         String
+
+  // Proposal — entered at application time.
+  title             String?
+  description       String?
+  /// Vercel Blob URL of the proposal PDF. VALIDATED before persist
+  /// (isOwnEventBlobUrl), never trusted from the client. Reviewers + owning head
+  /// only — never returned to residents.
+  proposalUrl       String?
+  /// UNIX epoch seconds, UTC (like Bookings). start required to submit.
+  startTime         Int?
+  endTime           Int?
+  location          String?
+  /// null = unlimited. Enforced under EventLock at signup time.
+  capacity          Int?
+
+  // Lifecycle / review decision.
+  status            String?   @default("submitted")
+  decidedAt         DateTime?
+  decidedBy         String?
+  decisionReason    String?
+
+  // Public content — added by the head only after approval, shown to residents.
+  publicDescription String?
+  /// Vercel Blob URLs, validated before persist (isOwnEventBlobUrl). photoUrls
+  /// is the gallery; order is display order.
+  bannerUrl         String?
+  photoUrls         String[]  @default([])
+  publishedAt       DateTime?
+
+  createdAt         DateTime? @default(now())
+  updatedAt         DateTime?
+  updatedBy         String?
+
+  @@index([ccaID, status], map: "cca_status")
+  @@index([status, startTime], map: "status_start")
+  @@index([startTime], map: "start")
+}
+
+/// One resident's signup for one event. Cancel is a HARD delete (the row is
+/// removed), which keeps the unique index clean and makes capacity a simple row
+/// count. Attendee PII (matric/block/telegram) is joined LIVE from User/
+/// UserMatric at export time, never snapshotted here, so an exported list always
+/// reflects current profile data.
+///
+/// I-2: userID keyed on the CANONICAL id; createdAt nullable with a default.
+model EventSignup {
+  id        String    @id @default(auto()) @map("_id") @db.ObjectId
+  eventID   Int
+  userID    String
+  createdAt DateTime? @default(now())
+
+  @@unique([eventID, userID], map: "event_user")
+  @@index([eventID], map: "eventID")
+  @@index([userID], map: "userID")
+}
+
+/// Advisory mutex documents for per-event signup serialization, so a capacity
+/// check and the subsequent create cannot interleave and overbook. Same shape
+/// and reclaim strategy as BookingLock; driven by withEventLock in
+/// services/events.ts. `prisma db push` must create the unique index on `key` —
+/// that index is what makes the lock safe.
+model EventLock {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  key       String   @unique
+  createdAt DateTime @default(now())
 }
 
 /// Matric number stored as an ATTRIBUTE (not identity), kept out of the

--- a/scripts/remediation/set-events-flag.mjs
+++ b/scripts/remediation/set-events-flag.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turns the Events feature kill switch on or off (services/events.ts).
+ *
+ *   key:  events.enabled   value: "on" | "off"   default (no row): OFF
+ *
+ * The whole Events surface — the resident timeline, head authoring, JCRC review,
+ * signup, the upload route — is INERT until this row is "on". It fails CLOSED
+ * exactly like isCcaManagementEnabled: a new write surface behaves as it did
+ * yesterday (i.e. absent) unless someone deliberately enables it.
+ *
+ *   node scripts/remediation/set-events-flag.mjs             # show current
+ *   node scripts/remediation/set-events-flag.mjs on          # dry run
+ *   node scripts/remediation/set-events-flag.mjs on --commit # apply
+ *   node scripts/remediation/set-events-flag.mjs off --commit
+ *
+ * Run `npx prisma db push` FIRST so the Event / EventSignup / EventLock
+ * collections and their unique indexes exist before the feature is switched on.
+ */
+import { PrismaClient } from "@prisma/client";
+import { inspectWriteReply, isCommit, abort, nowExt } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+
+const KEY = "events.enabled";
+const MODES = ["on", "off"];
+
+const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const MODE = positional[0];
+const COMMIT = isCommit();
+
+async function current() {
+  const r = await db.$runCommandRaw({
+    find: "SystemFlag",
+    filter: { key: KEY },
+    limit: 1,
+  });
+  return r?.cursor?.firstBatch?.[0] ?? null;
+}
+
+async function main() {
+  console.log(`\n=== set-events-flag.mjs ===`);
+  const before = await current();
+  console.log(
+    `current: ${before ? JSON.stringify(before.value) : '(no row — feature is OFF)'}`,
+  );
+
+  if (!MODE) {
+    console.log(
+      `\nusage: node scripts/remediation/set-events-flag.mjs <${MODES.join("|")}> [--commit]`,
+    );
+    return;
+  }
+  if (!MODES.includes(MODE)) {
+    return abort(`mode must be one of ${MODES.join(" | ")} — got ${JSON.stringify(MODE)}`);
+  }
+
+  console.log(
+    `\n  ${COMMIT ? "+" : "~"} ${KEY}: ${JSON.stringify(before?.value ?? null)} -> ${JSON.stringify(MODE)}`,
+  );
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing changed. Re-run with --commit to apply.`);
+    return;
+  }
+
+  const reply = await db.$runCommandRaw({
+    update: "SystemFlag",
+    updates: [
+      {
+        q: { key: KEY },
+        u: {
+          $set: {
+            key: KEY,
+            value: MODE,
+            updatedAt: nowExt(),
+            updatedBy: "script:set-events-flag",
+          },
+        },
+        upsert: true,
+      },
+    ],
+  });
+  const r = inspectWriteReply(reply, KEY);
+  if (r.writeErrors.length) {
+    console.error(`  ! WRITE FAILED: ${JSON.stringify(r.writeErrors)}`);
+    return abort(`the flag was NOT changed.`);
+  }
+
+  const after = await current();
+  console.log(`\n=== VERIFY ===`);
+  console.log(`${KEY} = ${JSON.stringify(after?.value ?? null)}`);
+  if (after?.value !== MODE) {
+    return abort(`read-back mismatch: expected ${MODE}, got ${JSON.stringify(after?.value ?? null)}`);
+  }
+}
+
+main()
+  .then(() => console.log("\nDone."))
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -6,6 +6,7 @@ import {
   X,
   Home,
   Calendar,
+  CalendarDays,
   User,
   Users,
   LayoutGrid,
@@ -70,6 +71,7 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
     // the page itself is inert until cca.applications.enabled is on, so this is
     // a link to a "not open yet" state at worst, never a broken route.
     { name: "CCAs", href: "/ccas", icon: LayoutGrid },
+    { name: "Events", href: "/events", icon: CalendarDays },
     ...(isCcaHead ? [{ name: "My CCAs", href: "/cca", icon: Users }] : []),
     ...(canReachAdmin
       ? [{ name: "Admin", href: "/admin", icon: ShieldCheck }]

--- a/src/app/admin/_components/AdminShell.tsx
+++ b/src/app/admin/_components/AdminShell.tsx
@@ -10,6 +10,7 @@ import {
   DoorOpen,
   ScrollText,
   Settings2,
+  CalendarCheck,
 } from "lucide-react";
 
 import Header from "~/app/_components/header";
@@ -51,6 +52,14 @@ const ADMIN_TABS = [
     label: "Manage CCAs",
     icon: Settings2,
     requires: "manageCcas",
+  },
+  // Event review queue — admin + jcrc (reviewEvents). Behind the events.enabled
+  // kill switch checked in the procedures.
+  {
+    href: "/admin/events",
+    label: "Events",
+    icon: CalendarCheck,
+    requires: "reviewEvents",
   },
   {
     href: "/admin/facilities",

--- a/src/app/admin/_components/events/EventReviewDetail.tsx
+++ b/src/app/admin/_components/events/EventReviewDetail.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FileText, Check, X } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { EVENT_DECISION_REASON_MAX } from "~/lib/schemas/event";
+import { formatDateRange, STATUS_META } from "~/app/events/_lib/format";
+
+/**
+ * The reviewer's view of one submitted event: its proposal text, the proposal
+ * PDF, and Approve / Reject controls. decide() is the boundary (re-reads
+ * reviewEvents live); this is the UI. A rejection requires a reason.
+ */
+export default function EventReviewDetail({ eventID }: { eventID: number }) {
+  const router = useRouter();
+  const utils = api.useUtils();
+  const query = api.event.getForReview.useQuery({ eventID }, { retry: false });
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const decide = api.event.decide.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.event.getForReview.invalidate({ eventID }),
+        utils.event.listForReview.invalidate(),
+      ]);
+      router.push("/admin/events");
+    },
+    onError: (e) => {
+      setError(
+        e.message === "NOT_UNDER_REVIEW"
+          ? "This event has already been decided. Reload the page."
+          : e.message.includes("reason")
+            ? "A reason is required to reject."
+            : "That didn't go through. Try again.",
+      );
+    },
+  });
+
+  if (query.isPending) {
+    return <div className="h-64 animate-pulse rounded-xl bg-gray-200" />;
+  }
+  if (query.error || !query.data) {
+    return (
+      <div className="rounded-xl bg-white p-6 shadow-lg">
+        <p className="text-sm text-gray-900">
+          {query.error?.message === "NO_SUCH_EVENT"
+            ? "This event no longer exists."
+            : "This event couldn’t be loaded."}
+        </p>
+        <Link
+          href="/admin/events"
+          className="mt-2 inline-block text-sm text-emerald-700 hover:underline"
+        >
+          ← Back to the queue
+        </Link>
+      </div>
+    );
+  }
+
+  const { event, ccaName } = query.data;
+  const meta = STATUS_META[event.status];
+  const decided = event.status !== "submitted";
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <Link
+        href="/admin/events"
+        className="text-sm text-emerald-700 hover:underline"
+      >
+        ← Back to the queue
+      </Link>
+
+      <div className="rounded-xl bg-white p-6 shadow-lg">
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-semibold text-gray-900">
+            {event.title?.trim() || "Untitled event"}
+          </h1>
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}
+          >
+            {meta.label}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-gray-500">
+          {ccaName ?? `CCA #${event.ccaID}`}
+        </p>
+
+        <dl className="mt-4 grid gap-3 border-t border-gray-100 pt-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-gray-500">When</dt>
+            <dd className="text-gray-900">
+              {formatDateRange(event.startTime, event.endTime)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Where</dt>
+            <dd className="text-gray-900">{event.location ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Capacity</dt>
+            <dd className="text-gray-900">
+              {event.capacity != null ? event.capacity : "Unlimited"}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-4 border-t border-gray-100 pt-4">
+          <dt className="text-sm text-gray-500">Description</dt>
+          <p className="mt-1 whitespace-pre-wrap text-sm text-gray-900">
+            {event.description ?? "—"}
+          </p>
+        </div>
+
+        {event.proposalUrl && (
+          <a
+            href={event.proposalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50"
+          >
+            <FileText className="h-4 w-4" />
+            View proposal PDF
+          </a>
+        )}
+      </div>
+
+      {decided ? (
+        <div className="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100">
+          <p className="text-sm text-gray-900">
+            This event has been {meta.label.toLowerCase()}.
+          </p>
+          {event.decisionReason && (
+            <p className="mt-1 text-sm text-gray-500">
+              Reason: {event.decisionReason}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100">
+          <label className="block text-sm font-medium text-gray-700">
+            Reason{" "}
+            <span className="text-gray-400">(required to reject)</span>
+          </label>
+          <textarea
+            value={reason}
+            maxLength={EVENT_DECISION_REASON_MAX}
+            rows={3}
+            onChange={(e) => setReason(e.target.value)}
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            placeholder="Feedback for the CCA head…"
+          />
+
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+
+          <div className="mt-4 flex items-center gap-3">
+            <Button
+              type="button"
+              disabled={decide.isPending}
+              onClick={() => {
+                setError(null);
+                decide.mutate({
+                  eventID,
+                  decision: "approve",
+                  reason: reason.trim() || undefined,
+                });
+              }}
+            >
+              <Check className="mr-1.5 h-4 w-4" />
+              Approve
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+              disabled={decide.isPending || !reason.trim()}
+              onClick={() => {
+                setError(null);
+                decide.mutate({
+                  eventID,
+                  decision: "reject",
+                  reason: reason.trim(),
+                });
+              }}
+            >
+              <X className="mr-1.5 h-4 w-4" />
+              Reject
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/_components/events/EventReviewQueue.tsx
+++ b/src/app/admin/_components/events/EventReviewQueue.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarClock, ChevronRight } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { formatDateTime } from "~/app/events/_lib/format";
+
+/**
+ * The JCRC review queue: events awaiting a decision, oldest first. Rows link to
+ * the detail page where the proposal is read and approved/rejected. NOT a guard
+ * — listForReview is roleManagerProcedure.
+ */
+export default function EventReviewQueue() {
+  const list = api.event.listForReview.useQuery(undefined, { retry: false });
+
+  if (list.isPending) {
+    return <div className="h-48 animate-pulse rounded-xl bg-gray-200" />;
+  }
+  if (list.error) {
+    return (
+      <div className="rounded-xl bg-white p-6 shadow-lg">
+        <p className="text-sm text-gray-900">
+          {list.error.message === "EVENTS_DISABLED"
+            ? "Events aren’t switched on yet."
+            : "The review queue couldn’t load."}
+        </p>
+      </div>
+    );
+  }
+
+  const events = list.data.events;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">Event review</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {events.length === 0
+            ? "Nothing waiting for review."
+            : `${events.length} event${events.length === 1 ? "" : "s"} awaiting a decision.`}
+        </p>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="rounded-xl bg-white p-10 text-center shadow-lg">
+          <CalendarClock className="mx-auto h-8 w-8 text-gray-300" />
+          <p className="mt-2 text-sm font-medium text-gray-900">
+            The queue is empty
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            Submitted events appear here for approval.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {events.map((e) => (
+            <li key={e.eventID}>
+              <Link
+                href={`/admin/events/${e.eventID}`}
+                className="flex items-center gap-4 rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-100 transition hover:ring-emerald-200"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-gray-900">
+                    {e.title?.trim() || "Untitled event"}
+                  </p>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    {e.ccaName ?? `CCA #${e.ccaID}`} · {formatDateTime(e.startTime)}
+                    {e.location ? ` · ${e.location}` : ""}
+                  </p>
+                </div>
+                <ChevronRight className="h-5 w-5 shrink-0 text-gray-300" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/events/[eventID]/page.tsx
+++ b/src/app/admin/events/[eventID]/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation";
+
+import EventReviewDetail from "../../_components/events/EventReviewDetail";
+import { parseCcaID } from "~/app/cca/_lib/ccaParam";
+
+export default function AdminEventDetailPage({
+  params,
+}: {
+  params: { eventID: string };
+}) {
+  const eventID = parseCcaID(params.eventID);
+  if (eventID === null) notFound();
+
+  return <EventReviewDetail eventID={eventID} />;
+}

--- a/src/app/admin/events/layout.tsx
+++ b/src/app/admin/events/layout.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+
+/** Session-dependent — never cached. */
+export const dynamic = "force-dynamic";
+
+/**
+ * The narrow guard for the event review surface (03 §2, layer 2). DEFENCE IN
+ * DEPTH — every event.* reviewer procedure re-checks (roleManagerProcedure +
+ * assertEventsEnabled, and decide re-reads reviewEvents live). This only keeps
+ * review markup from streaming to someone without the capability. Sits inside
+ * /admin/layout.tsx's AdminShell, so it returns children unwrapped.
+ */
+export default async function AdminEventsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRoles(db, session.user.userID); // I-5 live read
+  } catch {
+    redirect("/"); // fail closed, swallow — see admin/layout.tsx
+  }
+
+  if (!computeCapabilities(roles).reviewEvents) redirect("/");
+
+  return <>{children}</>;
+}

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -1,0 +1,5 @@
+import EventReviewQueue from "../_components/events/EventReviewQueue";
+
+export default function AdminEventsPage() {
+  return <EventReviewQueue />;
+}

--- a/src/app/api/event/upload/route.ts
+++ b/src/app/api/event/upload/route.ts
@@ -1,0 +1,105 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import { areEventsEnabled } from "~/server/api/services/events";
+import {
+  parseEventUploadPath,
+  eventUploadConstraints,
+} from "~/lib/schemas/event";
+
+/**
+ * Vercel Blob client-upload token route for event assets (proposal PDF, banner,
+ * gallery photos). READ src/app/api/cca/upload/route.ts FIRST — this is the same
+ * pattern and every note there applies:
+ *
+ *   1. onBeforeGenerateToken is the ENTIRE authorisation boundary.
+ *   2. It cannot be a tRPC procedure (handleUpload needs the raw Request).
+ *   3. The browser uploads directly to Blob; this only mints a scoped token.
+ *   4. onUploadCompleted is observability only and does NOT fire on localhost —
+ *      the URL is persisted by the guarded event.updateDraft /
+ *      event.updatePublicContent mutations, never from here.
+ *
+ * The one difference from the CCA route: the scope key is an eventID, so the
+ * event must be LOADED to learn its ccaID before assertHeadsCca can run. A
+ * token for a non-existent event is refused.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname) => {
+        const session = await auth();
+        if (!session?.user?.userID) {
+          throw new Error("UNAUTHENTICATED");
+        }
+
+        // The whole feature is inert unless the kill switch is on.
+        if (!(await areEventsEnabled(db))) {
+          throw new Error("EVENTS_DISABLED");
+        }
+
+        // `pathname` is CLIENT-SUPPLIED. Parsing only guarantees a well-formed,
+        // event-scoped path; the authorisation is assertHeadsCca below.
+        const target = parseEventUploadPath(pathname);
+        if (target === null) {
+          throw new Error("BAD_PATHNAME");
+        }
+
+        // The event must exist so we can authorise against ITS ccaID — never a
+        // client-supplied one.
+        const event = await db.event.findUnique({
+          where: { eventID: target.eventID },
+          select: { ccaID: true },
+        });
+        if (!event) {
+          throw new Error("NO_SUCH_EVENT");
+        }
+
+        // I-5: LIVE role read, never session.user.roles.
+        const roles = await getUserRoles(db, session.user.userID);
+        await assertHeadsCca(
+          db,
+          { userID: session.user.userID, roles },
+          event.ccaID,
+        );
+
+        const { allowedContentTypes, maximumSizeInBytes } =
+          eventUploadConstraints(target.kind);
+
+        return {
+          allowedContentTypes,
+          maximumSizeInBytes,
+          addRandomSuffix: true,
+          tokenPayload: JSON.stringify({
+            eventID: target.eventID,
+            kind: target.kind,
+            userID: session.user.userID,
+          }),
+        };
+      },
+
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        // Observability only — does not fire on localhost. Never persist here.
+        console.log(
+          JSON.stringify({
+            evt: "event_asset_uploaded",
+            url: blob.url,
+            payload: tokenPayload,
+          }),
+        );
+      },
+    });
+
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "UPLOAD_FAILED";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/cca/[ccaID]/events/[eventID]/page.tsx
+++ b/src/app/cca/[ccaID]/events/[eventID]/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+
+import EventManage from "../../../_components/EventManage";
+import { parseCcaID } from "../../../_lib/ccaParam";
+
+/**
+ * Manage one event. The flow inside EventManage depends on the event's status.
+ * No server guard — every event.* procedure carries the object-scoped check.
+ * parseCcaID doubles as a positive-int parser for the eventID segment.
+ */
+export default function ManageEventPage({
+  params,
+}: {
+  params: { ccaID: string; eventID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  const eventID = parseCcaID(params.eventID);
+  if (ccaID === null || eventID === null) notFound();
+
+  return <EventManage ccaID={ccaID} eventID={eventID} />;
+}

--- a/src/app/cca/[ccaID]/events/new/page.tsx
+++ b/src/app/cca/[ccaID]/events/new/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+
+import EventCreateForm from "../../../_components/EventCreateForm";
+import { parseCcaID } from "../../../_lib/ccaParam";
+
+export default function NewEventPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  if (ccaID === null) notFound();
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900">New event</h2>
+      <EventCreateForm ccaID={ccaID} />
+    </div>
+  );
+}

--- a/src/app/cca/[ccaID]/events/page.tsx
+++ b/src/app/cca/[ccaID]/events/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+
+import EventsListPanel from "../../_components/EventsListPanel";
+import { parseCcaID } from "../../_lib/ccaParam";
+
+/**
+ * The CCA's events. No server guard — listMineForCca carries the object-scoped
+ * check (I-7), the same policy as the details section.
+ */
+export default function CcaEventsPage({
+  params,
+}: {
+  params: { ccaID: string };
+}) {
+  const ccaID = parseCcaID(params.ccaID);
+  if (ccaID === null) notFound();
+
+  return <EventsListPanel ccaID={ccaID} />;
+}

--- a/src/app/cca/_components/CcaDashboardShell.tsx
+++ b/src/app/cca/_components/CcaDashboardShell.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardList,
   ClipboardCheck,
   CalendarClock,
+  CalendarDays,
 } from "lucide-react";
 
 import { api } from "~/trpc/react";
@@ -28,6 +29,7 @@ const SECTIONS = [
   { slug: "sessions", label: "Interviews", icon: ClipboardCheck },
   { slug: "members", label: "View member list", icon: Users },
   { slug: "details", label: "CCA details", icon: Pencil },
+  { slug: "events", label: "Events", icon: CalendarDays },
 ] as const;
 
 /**

--- a/src/app/cca/_components/EventAnalytics.tsx
+++ b/src/app/cca/_components/EventAnalytics.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { api } from "~/trpc/react";
+
+/**
+ * Light signup analytics for the head's monitor page — cumulative signups over
+ * time and a by-block breakdown. Deliberately nothing fancy. recharts is already
+ * in the bundle (src/components/ui/chart.tsx); used directly here for two small
+ * charts.
+ */
+export default function EventAnalytics({ eventID }: { eventID: number }) {
+  const stats = api.event.getSignupStats.useQuery({ eventID }, { retry: false });
+
+  if (stats.isPending) {
+    return <div className="h-40 animate-pulse rounded-lg bg-gray-100" />;
+  }
+  if (stats.error || !stats.data) {
+    return (
+      <p className="text-sm text-gray-500">Signup analytics couldn’t load.</p>
+    );
+  }
+
+  const { total, byDay, byBlock } = stats.data;
+
+  // Cumulative running total for the area chart.
+  let running = 0;
+  const cumulative = byDay.map((d) => {
+    running += d.count;
+    return { date: d.date.slice(5), total: running };
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+            Total signups
+          </p>
+          <p className="mt-1 text-3xl font-semibold tabular-nums text-gray-900">
+            {total}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+            Blocks represented
+          </p>
+          <p className="mt-1 text-3xl font-semibold tabular-nums text-gray-900">
+            {byBlock.filter((b) => b.block !== "Unknown").length}
+          </p>
+        </div>
+      </div>
+
+      {total === 0 ? (
+        <p className="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-8 text-center text-sm text-gray-500">
+          No signups yet — charts appear once people register.
+        </p>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-lg border border-gray-200 bg-white p-4">
+            <p className="mb-3 text-sm font-medium text-gray-700">
+              Signups over time
+            </p>
+            <div className="h-48 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={cumulative}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis dataKey="date" fontSize={11} tickLine={false} />
+                  <YAxis allowDecimals={false} fontSize={11} width={28} />
+                  <Tooltip />
+                  <Area
+                    type="monotone"
+                    dataKey="total"
+                    stroke="#059669"
+                    fill="#a7f3d0"
+                    strokeWidth={2}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-white p-4">
+            <p className="mb-3 text-sm font-medium text-gray-700">
+              Signups by block
+            </p>
+            <div className="h-48 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={byBlock}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis dataKey="block" fontSize={11} tickLine={false} />
+                  <YAxis allowDecimals={false} fontSize={11} width={28} />
+                  <Tooltip />
+                  <Bar dataKey="count" fill="#059669" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventAttendees.tsx
+++ b/src/app/cca/_components/EventAttendees.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { Download } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  serializeCsv,
+  downloadTextFile,
+  formatDateTime,
+} from "~/app/events/_lib/format";
+
+/**
+ * The attendee list for the head's monitor page, plus the audited CSV export.
+ *
+ * The on-screen table uses the (un-audited) getAttendees query — the head is
+ * already authorised to see it. The DOWNLOAD calls the exportAttendees mutation,
+ * which writes an event.attendees.export audit row (the file carries matric /
+ * block / telegram — PII), and builds the CSV from what it returns.
+ */
+export default function EventAttendees({ eventID }: { eventID: number }) {
+  const list = api.event.getAttendees.useQuery({ eventID }, { retry: false });
+  const [exporting, setExporting] = useState(false);
+  const exportMut = api.event.exportAttendees.useMutation();
+
+  async function download() {
+    setExporting(true);
+    try {
+      const res = await exportMut.mutateAsync({ eventID });
+      const rows: (string | number | null)[][] = [
+        ["Name", "Matric", "Block", "Telegram", "Signed up at"],
+        ...res.attendees.map((a) => [
+          a.displayName ?? "",
+          a.matric ?? "",
+          a.block ?? "",
+          a.telegramHandle ? `@${a.telegramHandle}` : "",
+          a.signedUpAt ? new Date(a.signedUpAt).toISOString() : "",
+        ]),
+      ];
+      downloadTextFile(
+        `attendees-event-${res.eventID}.csv`,
+        serializeCsv(rows),
+      );
+    } catch {
+      // surfaced below via exportMut.error
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  if (list.isPending) {
+    return <div className="h-32 animate-pulse rounded-lg bg-gray-100" />;
+  }
+  if (list.error || !list.data) {
+    return <p className="text-sm text-gray-500">Attendees couldn’t load.</p>;
+  }
+
+  const attendees = list.data.attendees;
+  const missingMatric = attendees.filter((a) => !a.matric).length;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-700">
+          {attendees.length} attendee{attendees.length === 1 ? "" : "s"}
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={exporting || attendees.length === 0}
+          onClick={download}
+        >
+          <Download className="mr-1.5 h-4 w-4" />
+          {exporting ? "Preparing…" : "Download CSV"}
+        </Button>
+      </div>
+
+      {missingMatric > 0 && (
+        <p className="text-xs text-amber-700">
+          {missingMatric} attendee{missingMatric === 1 ? "" : "s"} have no matric
+          on file — those cells will be blank.
+        </p>
+      )}
+
+      {attendees.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-8 text-center text-sm text-gray-500">
+          No signups yet.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">Matric</th>
+                <th className="px-4 py-2 font-medium">Block</th>
+                <th className="px-4 py-2 font-medium">Telegram</th>
+                <th className="px-4 py-2 font-medium">Signed up</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white">
+              {attendees.map((a) => (
+                <tr key={a.userID}>
+                  <td className="px-4 py-2 text-gray-900">
+                    {a.displayName ?? a.userID}
+                  </td>
+                  <td className="px-4 py-2 tabular-nums text-gray-700">
+                    {a.matric ?? (
+                      <span className="text-amber-600">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 tabular-nums text-gray-700">
+                    {a.block ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-gray-700">
+                    {a.telegramHandle ? `@${a.telegramHandle}` : "—"}
+                  </td>
+                  <td className="px-4 py-2 text-gray-500">
+                    {a.signedUpAt ? formatDateTime(
+                      Math.floor(new Date(a.signedUpAt).getTime() / 1000),
+                    ) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventCreateForm.tsx
+++ b/src/app/cca/_components/EventCreateForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { createDraftInput } from "~/lib/schemas/event";
+import { localInputToEpoch } from "~/app/events/_lib/format";
+import EventProposalFields, {
+  EMPTY_PROPOSAL,
+  type ProposalValue,
+} from "./EventProposalFields";
+
+/**
+ * New-event form. Saving creates a DRAFT and redirects to the manage page,
+ * where the proposal PDF (which needs the event's id in its blob path) is
+ * attached and the event is submitted for review. Fields are optional at draft
+ * time; completeness is enforced at submit.
+ */
+export default function EventCreateForm({ ccaID }: { ccaID: number }) {
+  const router = useRouter();
+  const [value, setValue] = useState<ProposalValue>(EMPTY_PROPOSAL);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const create = api.event.createDraft.useMutation({
+    onSuccess: (res) => {
+      router.push(`/cca/${ccaID}/events/${res.eventID}`);
+    },
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setFieldError(null);
+
+    // Only send non-empty fields — the schema treats them as optional at draft
+    // time, and empty strings would fail the min-length rules.
+    const start = localInputToEpoch(value.startLocal);
+    const end = localInputToEpoch(value.endLocal);
+    const payload = {
+      ccaID,
+      title: value.title.trim() || undefined,
+      description: value.description.trim() || undefined,
+      startTime: start ?? undefined,
+      endTime: end ?? undefined,
+      location: value.location.trim() || undefined,
+      capacity: value.capacity.trim() ? Number(value.capacity) : undefined,
+    };
+    const parsed = createDraftInput.safeParse(payload);
+    if (!parsed.success) {
+      setFieldError(
+        parsed.error.issues[0]?.message ?? "Please check the fields.",
+      );
+      return;
+    }
+    create.mutate(parsed.data);
+  }
+
+  const serverError = create.error
+    ? create.error.message === "NO_SUCH_CCA"
+      ? "This CCA no longer exists."
+      : create.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+        ? "You're no longer a head of this CCA."
+        : create.error.message === "EVENTS_DISABLED"
+          ? "Events aren't switched on yet."
+          : "That didn't save. Try again."
+    : null;
+
+  return (
+    <form
+      onSubmit={submit}
+      className="max-w-3xl space-y-5 rounded-lg border border-gray-200 bg-white p-5"
+    >
+      <EventProposalFields
+        value={value}
+        onChange={(patch) => setValue((v) => ({ ...v, ...patch }))}
+        disabled={create.isPending}
+      />
+
+      <p className="rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-500">
+        Save the draft first — then you can attach the proposal PDF and submit it
+        for review.
+      </p>
+
+      {fieldError && <p className="text-sm text-red-600">{fieldError}</p>}
+      {serverError && <p className="text-sm text-red-600">{serverError}</p>}
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={create.isPending}>
+          {create.isPending ? "Saving…" : "Save draft"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={create.isPending}
+          onClick={() => router.push(`/cca/${ccaID}/events`)}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/cca/_components/EventFileField.tsx
+++ b/src/app/cca/_components/EventFileField.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { FileText } from "lucide-react";
+import { upload } from "@vercel/blob/client";
+
+import { Button } from "~/components/ui/button";
+import { eventUploadPath, EVENT_PDF_MAX_BYTES } from "~/lib/schemas/event";
+
+/**
+ * Proposal PDF slot. Like EventImageField but for a PDF: no resize, uploaded
+ * as-is with contentType application/pdf. The event must already exist (draft)
+ * so its eventID can key the blob path — the parent disables this until then.
+ */
+export default function EventFileField({
+  eventID,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  eventID: number;
+  value: string | null;
+  onChange: (url: string | null) => void;
+  disabled?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setError(null);
+    if (file.size > EVENT_PDF_MAX_BYTES) {
+      setError("That PDF is too large (max 10 MB).");
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+    setBusy(true);
+    try {
+      const blob = await upload(eventUploadPath(eventID, "proposal"), file, {
+        access: "public",
+        contentType: "application/pdf",
+        handleUploadUrl: "/api/event/upload",
+      });
+      onChange(blob.url);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      setError(
+        msg.includes("NOT_A_HEAD")
+          ? "You're no longer a head of this CCA."
+          : "That file couldn't be uploaded. Try again.",
+      );
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="text-sm font-medium text-gray-700">Event proposal (PDF)</p>
+        <p className="text-xs text-gray-500">
+          The document JCRC reviews. Residents never see this.
+        </p>
+      </div>
+
+      {value ? (
+        <div className="flex items-center gap-3">
+          <a
+            href={value}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50"
+          >
+            <FileText className="h-4 w-4" />
+            View uploaded proposal
+          </a>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled || busy}
+            onClick={() => inputRef.current?.click()}
+          >
+            Replace
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled || busy}
+            onClick={() => onChange(null)}
+          >
+            Remove
+          </Button>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          {busy ? "Uploading…" : "Upload proposal PDF"}
+        </Button>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFile(file);
+        }}
+      />
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventGalleryField.tsx
+++ b/src/app/cca/_components/EventGalleryField.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useRef } from "react";
+import Image from "next/image";
+import { X } from "lucide-react";
+import { upload } from "@vercel/blob/client";
+
+import { Button } from "~/components/ui/button";
+import {
+  eventUploadPath,
+  EVENT_IMAGE_MAX_BYTES,
+  EVENT_MAX_PHOTOS,
+} from "~/lib/schemas/event";
+import { resizeToWebp } from "~/app/events/_lib/resizeImage";
+
+/**
+ * Gallery field: a list of photo URLs the head adds to and removes from. Each
+ * pick uploads one photo (event/{eventID}/photo) and appends its URL. Capped at
+ * EVENT_MAX_PHOTOS, matching the server schema. No reorder in v1.
+ */
+export default function EventGalleryField({
+  eventID,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  eventID: number;
+  value: string[];
+  onChange: (urls: string[]) => void;
+  disabled?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const atCap = value.length >= EVENT_MAX_PHOTOS;
+
+  async function handleFile(file: File) {
+    setError(null);
+    setBusy(true);
+    try {
+      const resized = await resizeToWebp(file, 1600, 1200);
+      if (resized.size > EVENT_IMAGE_MAX_BYTES) throw new Error("TOO_LARGE");
+      const blob = await upload(eventUploadPath(eventID, "photo"), resized, {
+        access: "public",
+        contentType: "image/webp",
+        handleUploadUrl: "/api/event/upload",
+      });
+      onChange([...value, blob.url]);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      setError(
+        msg === "TOO_LARGE"
+          ? "That photo is still too large after resizing. Try a smaller one."
+          : "That photo couldn't be uploaded. Try again.",
+      );
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="text-sm font-medium text-gray-700">Photos</p>
+        <p className="text-xs text-gray-500">
+          Up to {EVENT_MAX_PHOTOS}. Residents scroll through these on the event
+          page.
+        </p>
+      </div>
+
+      {value.length > 0 && (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {value.map((url, i) => (
+            <div
+              key={url}
+              className="group relative aspect-video overflow-hidden rounded-md border border-gray-200 bg-gray-50"
+            >
+              <Image
+                src={url}
+                alt={`Photo ${i + 1}`}
+                fill
+                className="object-cover"
+                sizes="200px"
+                unoptimized
+              />
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => onChange(value.filter((u) => u !== url))}
+                className="absolute right-1 top-1 rounded-full bg-black/60 p-1 text-white opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Remove photo"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled || busy || atCap}
+        onClick={() => inputRef.current?.click()}
+      >
+        {busy ? "Uploading…" : atCap ? "Photo limit reached" : "Add a photo"}
+      </Button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFile(file);
+        }}
+      />
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventImageField.tsx
+++ b/src/app/cca/_components/EventImageField.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useRef } from "react";
+import Image from "next/image";
+import { upload } from "@vercel/blob/client";
+
+import { Button } from "~/components/ui/button";
+import {
+  eventUploadPath,
+  EVENT_IMAGE_MAX_BYTES,
+} from "~/lib/schemas/event";
+import { resizeToWebp } from "~/app/events/_lib/resizeImage";
+
+/**
+ * Single-image slot for an event's banner. Same pattern as CcaImageField —
+ * pick, downscale in the browser, upload straight to Vercel Blob, hand the URL
+ * to the parent. Uploads on SELECT; abandoning the form leaves an orphaned blob
+ * (accepted, reconcilable by diffing list() against Event rows).
+ */
+export default function EventImageField({
+  eventID,
+  label,
+  help,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  eventID: number;
+  label: string;
+  help: string;
+  value: string | null;
+  onChange: (url: string | null) => void;
+  disabled?: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setError(null);
+    setBusy(true);
+    try {
+      const resized = await resizeToWebp(file, 1600, 600);
+      if (resized.size > EVENT_IMAGE_MAX_BYTES) throw new Error("TOO_LARGE");
+      const blob = await upload(eventUploadPath(eventID, "banner"), resized, {
+        access: "public",
+        contentType: "image/webp",
+        handleUploadUrl: "/api/event/upload",
+      });
+      onChange(blob.url);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      setError(
+        msg === "TOO_LARGE"
+          ? "That image is still too large after resizing. Try a smaller one."
+          : msg.includes("NOT_A_HEAD")
+            ? "You're no longer a head of this CCA."
+            : "That image couldn't be uploaded. Try again.",
+      );
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="text-sm font-medium text-gray-700">{label}</p>
+        <p className="text-xs text-gray-500">{help}</p>
+      </div>
+
+      {value ? (
+        <div className="flex items-start gap-3">
+          <div className="relative h-24 w-64 overflow-hidden rounded-md border border-gray-200 bg-gray-50">
+            <Image
+              src={value}
+              alt={`${label} preview`}
+              fill
+              className="object-cover"
+              sizes="256px"
+              unoptimized
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled || busy}
+              onClick={() => inputRef.current?.click()}
+            >
+              Replace
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || busy}
+              onClick={() => onChange(null)}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          {busy ? "Uploading…" : `Upload ${label.toLowerCase()}`}
+        </Button>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFile(file);
+        }}
+      />
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventManage.tsx
+++ b/src/app/cca/_components/EventManage.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, AlertTriangle } from "lucide-react";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  updatePublicContentInput,
+  EVENT_PUBLIC_DESCRIPTION_MAX,
+  type EventStatus,
+} from "~/lib/schemas/event";
+import {
+  STATUS_META,
+  formatDateRange,
+  epochToLocalInput,
+  localInputToEpoch,
+} from "~/app/events/_lib/format";
+import EventProposalFields, {
+  type ProposalValue,
+} from "./EventProposalFields";
+import EventFileField from "./EventFileField";
+import EventImageField from "./EventImageField";
+import EventGalleryField from "./EventGalleryField";
+import EventAnalytics from "./EventAnalytics";
+import EventAttendees from "./EventAttendees";
+
+type HeadEvent = RouterOutputs["event"]["getForHead"]["event"];
+
+const FIELD_LABELS: Record<string, string> = {
+  title: "event name",
+  description: "description",
+  startTime: "start time",
+  location: "location",
+  proposalUrl: "proposal PDF",
+  banner: "banner image",
+  publicDescription: "public description",
+};
+
+function incompleteMessage(message: string): string | null {
+  if (!message.startsWith("INCOMPLETE:")) return null;
+  const missing = message
+    .slice("INCOMPLETE:".length)
+    .split(",")
+    .map((f) => FIELD_LABELS[f] ?? f);
+  return `Please add: ${missing.join(", ")}.`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Proposal editor (draft / rejected)                                          */
+/* -------------------------------------------------------------------------- */
+
+function ProposalEditor({ event }: { event: HeadEvent }) {
+  const utils = api.useUtils();
+  const [value, setValue] = useState<ProposalValue>({
+    title: event.title ?? "",
+    description: event.description ?? "",
+    startLocal: epochToLocalInput(event.startTime),
+    endLocal: epochToLocalInput(event.endTime),
+    location: event.location ?? "",
+    capacity: event.capacity != null ? String(event.capacity) : "",
+  });
+  const [proposalUrl, setProposalUrl] = useState<string | null>(
+    event.proposalUrl,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const update = api.event.updateDraft.useMutation();
+  const submit = api.event.submitForReview.useMutation();
+
+  function buildPatch() {
+    return {
+      eventID: event.eventID,
+      title: value.title.trim() || undefined,
+      description: value.description.trim() || undefined,
+      startTime: localInputToEpoch(value.startLocal) ?? undefined,
+      endTime: value.endLocal ? localInputToEpoch(value.endLocal) : null,
+      location: value.location.trim() || undefined,
+      capacity: value.capacity.trim() ? Number(value.capacity) : null,
+      proposalUrl,
+    };
+  }
+
+  async function invalidate() {
+    await Promise.all([
+      utils.event.getForHead.invalidate({ eventID: event.eventID }),
+      utils.event.listMineForCca.invalidate({ ccaID: event.ccaID }),
+    ]);
+  }
+
+  async function save() {
+    setError(null);
+    setSaved(false);
+    try {
+      await update.mutateAsync(buildPatch());
+      setSaved(true);
+      await invalidate();
+    } catch (e) {
+      setError(mapError(e));
+    }
+  }
+
+  async function submitForReview() {
+    setError(null);
+    setSaved(false);
+    try {
+      await update.mutateAsync(buildPatch());
+      await submit.mutateAsync({ eventID: event.eventID });
+      await invalidate();
+    } catch (e) {
+      setError(mapError(e));
+    }
+  }
+
+  const busy = update.isPending || submit.isPending;
+
+  return (
+    <div className="max-w-3xl space-y-5 rounded-lg border border-gray-200 bg-white p-5">
+      {event.status === "rejected" && event.decisionReason && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <p className="font-medium">JCRC asked for changes</p>
+          <p className="mt-0.5">{event.decisionReason}</p>
+          <p className="mt-1 text-xs text-red-600">
+            Edit below and submit again.
+          </p>
+        </div>
+      )}
+
+      <EventProposalFields
+        value={value}
+        onChange={(patch) => {
+          setValue((v) => ({ ...v, ...patch }));
+          setSaved(false);
+        }}
+        disabled={busy}
+      />
+
+      <div className="border-t border-gray-100 pt-4">
+        <EventFileField
+          eventID={event.eventID}
+          value={proposalUrl}
+          onChange={(url) => {
+            setProposalUrl(url);
+            setSaved(false);
+          }}
+          disabled={busy}
+        />
+      </div>
+
+      <p className="text-xs text-gray-400">
+        Uploads attach immediately but only save with the draft.
+      </p>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex flex-wrap items-center gap-3 border-t border-gray-100 pt-4">
+        <Button type="button" variant="outline" disabled={busy} onClick={save}>
+          {update.isPending && !submit.isPending ? "Saving…" : "Save draft"}
+        </Button>
+        <Button type="button" disabled={busy} onClick={submitForReview}>
+          {submit.isPending ? "Submitting…" : "Submit for review"}
+        </Button>
+        {saved && (
+          <span className="text-sm text-emerald-700">Saved.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public content editor (approved / published)                                */
+/* -------------------------------------------------------------------------- */
+
+function PublicEditor({
+  event,
+  mode,
+}: {
+  event: HeadEvent;
+  mode: "publish" | "edit";
+}) {
+  const utils = api.useUtils();
+  const [bannerUrl, setBannerUrl] = useState<string | null>(event.bannerUrl);
+  const [photoUrls, setPhotoUrls] = useState<string[]>(event.photoUrls);
+  const [publicDescription, setPublicDescription] = useState(
+    event.publicDescription ?? "",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const update = api.event.updatePublicContent.useMutation();
+  const publish = api.event.publish.useMutation();
+
+  function buildPayload() {
+    return {
+      eventID: event.eventID,
+      publicDescription: publicDescription.trim(),
+      bannerUrl,
+      photoUrls,
+    };
+  }
+
+  async function invalidate() {
+    await Promise.all([
+      utils.event.getForHead.invalidate({ eventID: event.eventID }),
+      utils.event.listMineForCca.invalidate({ ccaID: event.ccaID }),
+    ]);
+  }
+
+  function validate(): boolean {
+    const parsed = updatePublicContentInput.safeParse(buildPayload());
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      setError(
+        issue?.message === "NOT_A_VALID_EVENT_BLOB_URL"
+          ? "An image doesn't belong to this event. Re-upload it."
+          : (issue?.message ?? "Please check the fields."),
+      );
+      return false;
+    }
+    return true;
+  }
+
+  async function save() {
+    setError(null);
+    setSaved(false);
+    if (!validate()) return;
+    try {
+      await update.mutateAsync(buildPayload());
+      setSaved(true);
+      await invalidate();
+    } catch (e) {
+      setError(mapError(e));
+    }
+  }
+
+  async function saveAndPublish() {
+    setError(null);
+    setSaved(false);
+    if (!validate()) return;
+    try {
+      await update.mutateAsync(buildPayload());
+      await publish.mutateAsync({ eventID: event.eventID });
+      await invalidate();
+    } catch (e) {
+      setError(mapError(e));
+    }
+  }
+
+  const busy = update.isPending || publish.isPending;
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <EventImageField
+        eventID={event.eventID}
+        label="Banner"
+        help="The wide hero image residents see first. Required to publish."
+        value={bannerUrl}
+        onChange={(url) => {
+          setBannerUrl(url);
+          setSaved(false);
+        }}
+        disabled={busy}
+      />
+
+      <EventGalleryField
+        eventID={event.eventID}
+        value={photoUrls}
+        onChange={(urls) => {
+          setPhotoUrls(urls);
+          setSaved(false);
+        }}
+        disabled={busy}
+      />
+
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-gray-700">
+          Public description
+        </label>
+        <p className="text-xs text-gray-500">
+          What residents read on the event page. This can differ from your JCRC
+          proposal.
+        </p>
+        <textarea
+          value={publicDescription}
+          maxLength={EVENT_PUBLIC_DESCRIPTION_MAX}
+          rows={6}
+          disabled={busy}
+          onChange={(e) => {
+            setPublicDescription(e.target.value);
+            setSaved(false);
+          }}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          placeholder="Tell residents what to expect…"
+        />
+        <p className="text-right text-xs text-gray-500">
+          {publicDescription.length}/{EVENT_PUBLIC_DESCRIPTION_MAX}
+        </p>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex flex-wrap items-center gap-3">
+        {mode === "publish" ? (
+          <>
+            <Button type="button" variant="outline" disabled={busy} onClick={save}>
+              Save
+            </Button>
+            <Button type="button" disabled={busy} onClick={saveAndPublish}>
+              {publish.isPending ? "Publishing…" : "Publish event"}
+            </Button>
+          </>
+        ) : (
+          <Button type="button" disabled={busy} onClick={save}>
+            {update.isPending ? "Saving…" : "Save changes"}
+          </Button>
+        )}
+        {saved && <span className="text-sm text-emerald-700">Saved.</span>}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cancel button                                                               */
+/* -------------------------------------------------------------------------- */
+
+function CancelEventButton({ event }: { event: HeadEvent }) {
+  const utils = api.useUtils();
+  const [confirming, setConfirming] = useState(false);
+  const cancel = api.event.cancelEvent.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.event.getForHead.invalidate({ eventID: event.eventID }),
+        utils.event.listMineForCca.invalidate({ ccaID: event.ccaID }),
+      ]);
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        className="text-red-600 hover:bg-red-50 hover:text-red-700"
+        onClick={() => setConfirming(true)}
+      >
+        Cancel event
+      </Button>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 p-2">
+      <span className="text-sm text-red-800">Cancel this event?</span>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        disabled={cancel.isPending}
+        onClick={() => setConfirming(false)}
+      >
+        No
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        className="bg-red-600 hover:bg-red-700"
+        disabled={cancel.isPending}
+        onClick={() => cancel.mutate({ eventID: event.eventID })}
+      >
+        {cancel.isPending ? "Cancelling…" : "Yes, cancel"}
+      </Button>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Orchestrator                                                                */
+/* -------------------------------------------------------------------------- */
+
+function mapError(e: unknown): string {
+  const message = e instanceof Error ? e.message : "";
+  const incomplete = incompleteMessage(message);
+  if (incomplete) return incomplete;
+  if (message === "END_BEFORE_START")
+    return "The end time must be after the start time.";
+  if (message === "NOT_A_HEAD_OF_THIS_CCA")
+    return "You're no longer a head of this CCA.";
+  if (message === "EVENTS_DISABLED") return "Events aren't switched on yet.";
+  if (message.includes("NOT_APPROVED"))
+    return "This event isn't approved yet.";
+  return "That didn't save. Try again.";
+}
+
+export default function EventManage({
+  ccaID,
+  eventID,
+}: {
+  ccaID: number;
+  eventID: number;
+}) {
+  const query = api.event.getForHead.useQuery({ eventID }, { retry: false });
+  // Keep the collapsible public editor state across refetches.
+  const [editingPublic, setEditingPublic] = useState(false);
+  useEffect(() => {
+    setEditingPublic(false);
+  }, [eventID]);
+
+  if (query.isPending) {
+    return <div className="h-64 animate-pulse rounded-lg bg-gray-200" />;
+  }
+  if (query.error || !query.data) {
+    const msg = query.error?.message;
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-6">
+        <p className="text-sm font-medium text-gray-900">
+          {msg === "NOT_A_HEAD_OF_THIS_CCA"
+            ? "You don’t have access to this event."
+            : msg === "NO_SUCH_EVENT"
+              ? "This event no longer exists."
+              : "This event couldn’t be loaded."}
+        </p>
+        <Link
+          href={`/cca/${ccaID}/events`}
+          className="mt-2 inline-block text-sm text-emerald-700 hover:underline"
+        >
+          ← Back to events
+        </Link>
+      </div>
+    );
+  }
+
+  const event = query.data.event;
+  const status: EventStatus = event.status;
+  const meta = STATUS_META[status];
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link
+            href={`/cca/${ccaID}/events`}
+            className="text-sm text-emerald-700 hover:underline"
+          >
+            ← All events
+          </Link>
+          <div className="mt-1 flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-gray-900">
+              {event.title?.trim() || "Untitled event"}
+            </h2>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}
+            >
+              {meta.label}
+            </span>
+          </div>
+          <p className="mt-0.5 text-sm text-gray-500">
+            {formatDateRange(event.startTime, event.endTime)}
+            {event.location ? ` · ${event.location}` : ""}
+          </p>
+        </div>
+        {status === "published" && (
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/events/${event.eventID}`} target="_blank">
+              <ExternalLink className="mr-1.5 h-4 w-4" />
+              View public page
+            </Link>
+          </Button>
+        )}
+      </div>
+
+      {/* DRAFT / REJECTED — edit the proposal and submit. */}
+      {(status === "draft" || status === "rejected") && (
+        <ProposalEditor event={event} />
+      )}
+
+      {/* SUBMITTED — waiting on JCRC. */}
+      {status === "submitted" && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-6">
+          <p className="text-sm font-medium text-amber-900">
+            Submitted — waiting for JCRC review.
+          </p>
+          <p className="mt-1 text-sm text-amber-700">
+            You’ll be able to add a banner, photos and a public description once
+            it’s approved.
+          </p>
+        </div>
+      )}
+
+      {/* APPROVED — add public content and publish. */}
+      {status === "approved" && (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-900">
+            Approved. Add a banner, photos and a public description, then publish
+            to put it on the residents’ timeline.
+          </div>
+          <PublicEditor event={event} mode="publish" />
+          <div className="border-t border-gray-100 pt-4">
+            <CancelEventButton event={event} />
+          </div>
+        </div>
+      )}
+
+      {/* PUBLISHED — monitor + edit. */}
+      {status === "published" && (
+        <div className="space-y-8">
+          <section>
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              Signups
+            </h3>
+            <EventAnalytics eventID={event.eventID} />
+          </section>
+
+          <section>
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              Attendees
+            </h3>
+            <EventAttendees eventID={event.eventID} />
+          </section>
+
+          <section>
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                Event details
+              </h3>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setEditingPublic((v) => !v)}
+              >
+                {editingPublic ? "Close" : "Edit details"}
+              </Button>
+            </div>
+            {editingPublic && <PublicEditor event={event} mode="edit" />}
+          </section>
+
+          <div className="border-t border-gray-100 pt-4">
+            <CancelEventButton event={event} />
+          </div>
+        </div>
+      )}
+
+      {/* CANCELED — read-only. */}
+      {status === "canceled" && (
+        <div className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-6">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+          <div>
+            <p className="text-sm font-medium text-gray-900">
+              This event was cancelled.
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              It no longer appears on the residents’ timeline.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventProposalFields.tsx
+++ b/src/app/cca/_components/EventProposalFields.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  EVENT_TITLE_MAX,
+  EVENT_DESCRIPTION_MAX,
+  EVENT_LOCATION_MAX,
+} from "~/lib/schemas/event";
+
+/**
+ * The proposal fields a head fills in at application time. A controlled block
+ * shared by the create form and the draft editor so they can't drift. Times are
+ * held as <input type="datetime-local"> strings and capacity as a raw string;
+ * the parent converts to epoch seconds / number on save.
+ */
+export type ProposalValue = {
+  title: string;
+  description: string;
+  startLocal: string;
+  endLocal: string;
+  location: string;
+  capacity: string;
+};
+
+export const EMPTY_PROPOSAL: ProposalValue = {
+  title: "",
+  description: "",
+  startLocal: "",
+  endLocal: "",
+  location: "",
+  capacity: "",
+};
+
+export default function EventProposalFields({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: ProposalValue;
+  onChange: (patch: Partial<ProposalValue>) => void;
+  disabled?: boolean;
+}) {
+  const field =
+    "mt-1 w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:bg-gray-50";
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-gray-700">
+          Event name
+        </label>
+        <input
+          type="text"
+          value={value.title}
+          maxLength={EVENT_TITLE_MAX}
+          disabled={disabled}
+          onChange={(e) => onChange({ title: e.target.value })}
+          className={field}
+          placeholder="e.g. Hall Night 2026"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-gray-700">
+          Detailed description
+        </label>
+        <p className="text-xs text-gray-500">
+          What the event is, who it&rsquo;s for, and what happens. JCRC reads this
+          alongside your proposal.
+        </p>
+        <textarea
+          value={value.description}
+          maxLength={EVENT_DESCRIPTION_MAX}
+          rows={6}
+          disabled={disabled}
+          onChange={(e) => onChange({ description: e.target.value })}
+          className={field}
+          placeholder="Tell JCRC about your event…"
+        />
+        <p className="text-right text-xs text-gray-500">
+          {value.description.length}/{EVENT_DESCRIPTION_MAX}
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-gray-700">
+            Starts
+          </label>
+          <input
+            type="datetime-local"
+            value={value.startLocal}
+            disabled={disabled}
+            onChange={(e) => onChange({ startLocal: e.target.value })}
+            className={field}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-gray-700">
+            Ends <span className="text-gray-400">(optional)</span>
+          </label>
+          <input
+            type="datetime-local"
+            value={value.endLocal}
+            disabled={disabled}
+            onChange={(e) => onChange({ endLocal: e.target.value })}
+            className={field}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-gray-700">
+            Location
+          </label>
+          <input
+            type="text"
+            value={value.location}
+            maxLength={EVENT_LOCATION_MAX}
+            disabled={disabled}
+            onChange={(e) => onChange({ location: e.target.value })}
+            className={field}
+            placeholder="e.g. Raffles Hall Dining Hall"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-gray-700">
+            Capacity <span className="text-gray-400">(optional)</span>
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={value.capacity}
+            disabled={disabled}
+            onChange={(e) => onChange({ capacity: e.target.value })}
+            className={field}
+            placeholder="Leave blank for unlimited"
+          />
+          <p className="text-xs text-gray-500">
+            Blank means no cap. Signups close automatically when full.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cca/_components/EventsListPanel.tsx
+++ b/src/app/cca/_components/EventsListPanel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { Plus, CalendarDays, Users } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { formatDateTime, STATUS_META } from "~/app/events/_lib/format";
+
+/**
+ * The head's list of their CCA's events. Every card links into the manage page,
+ * where the flow depends on the event's status. NOT a guard — listMineForCca
+ * carries the object-scoped check.
+ */
+export default function EventsListPanel({ ccaID }: { ccaID: number }) {
+  const list = api.event.listMineForCca.useQuery({ ccaID }, { retry: false });
+
+  if (list.isPending) {
+    return <div className="h-48 animate-pulse rounded-lg bg-gray-200" />;
+  }
+
+  if (list.error) {
+    const msg = list.error.message;
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white px-4 py-6">
+        <p className="text-sm font-medium text-gray-900">
+          {msg === "NOT_A_HEAD_OF_THIS_CCA"
+            ? "You don’t have access to this CCA’s events."
+            : msg === "EVENTS_DISABLED"
+              ? "Events aren’t switched on yet."
+              : "These events couldn’t be loaded. Reload the page."}
+        </p>
+      </div>
+    );
+  }
+
+  const events = list.data.events;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-500">
+          {events.length === 0
+            ? "No events yet."
+            : `${events.length} event${events.length === 1 ? "" : "s"}`}
+        </p>
+        <Button asChild size="sm">
+          <Link href={`/cca/${ccaID}/events/new`}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            New event
+          </Link>
+        </Button>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-10 text-center">
+          <CalendarDays className="mx-auto h-8 w-8 text-gray-300" />
+          <p className="mt-2 text-sm font-medium text-gray-900">
+            Propose your first event
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            Add the details and a proposal, and JCRC will review it.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {events.map((e) => {
+            const meta = STATUS_META[e.status];
+            return (
+              <li key={e.eventID}>
+                <Link
+                  href={`/cca/${ccaID}/events/${e.eventID}`}
+                  className="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-emerald-300 hover:bg-emerald-50/40"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-semibold text-gray-900">
+                        {e.title?.trim() || "Untitled event"}
+                      </span>
+                      <span
+                        className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}
+                      >
+                        {meta.label}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {formatDateTime(e.startTime)}
+                      {e.location ? ` · ${e.location}` : ""}
+                    </p>
+                    {e.status === "rejected" && e.decisionReason && (
+                      <p className="mt-1 text-xs text-red-600">
+                        JCRC: {e.decisionReason}
+                      </p>
+                    )}
+                  </div>
+                  {(e.status === "published" || e.status === "approved") && (
+                    <div className="flex shrink-0 items-center gap-1 text-sm text-gray-600">
+                      <Users className="h-4 w-4 text-gray-400" />
+                      {e.signupCount}
+                      {e.capacity != null ? `/${e.capacity}` : ""}
+                    </div>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/events/[eventID]/page.tsx
+++ b/src/app/events/[eventID]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+
+import { HydrateClient } from "~/trpc/server";
+import Header from "~/app/_components/header";
+import EventDetail from "../_components/EventDetail";
+import { parseCcaID } from "~/app/cca/_lib/ccaParam";
+
+export default function EventPage({
+  params,
+}: {
+  params: { eventID: string };
+}) {
+  const eventID = parseCcaID(params.eventID);
+  if (eventID === null) notFound();
+
+  return (
+    <HydrateClient>
+      <Header currentPage="Events" />
+      <div className="min-h-[calc(100vh-4rem)] bg-gradient-to-br from-gray-50 to-gray-100 pb-20">
+        <EventDetail eventID={eventID} />
+      </div>
+    </HydrateClient>
+  );
+}

--- a/src/app/events/_components/EventDetail.tsx
+++ b/src/app/events/_components/EventDetail.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { useSession } from "next-auth/react";
+import { CalendarDays, MapPin, Users, Check, ArrowLeft } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "~/components/ui/carousel";
+import { formatDateRange } from "~/app/events/_lib/format";
+
+/**
+ * The resident's event page: banner, photo gallery, description and signup.
+ * getPublic never returns the proposal — this view has no way to reach it.
+ * Signup requires a matric on file (matricProcedure); a resident without one is
+ * pointed at onboarding instead of the button.
+ */
+export default function EventDetail({ eventID }: { eventID: number }) {
+  const { data: session } = useSession();
+  const utils = api.useUtils();
+  const query = api.event.getPublic.useQuery({ eventID }, { retry: false });
+  const [error, setError] = useState<string | null>(null);
+
+  const hasMatric = Boolean(session?.user?.hasMatric);
+
+  async function invalidate() {
+    await Promise.all([
+      utils.event.getPublic.invalidate({ eventID }),
+      utils.event.listPublished.invalidate(),
+    ]);
+  }
+
+  const signup = api.event.signup.useMutation({
+    onSuccess: invalidate,
+    onError: (e) =>
+      setError(
+        e.message === "MATRIC_REQUIRED"
+          ? "Add your matric number to sign up."
+          : e.message === "EVENT_FULL"
+            ? "This event just filled up."
+            : e.message === "SIGNUP_CLOSED"
+              ? "Signups have closed for this event."
+              : "That didn't work. Try again.",
+      ),
+  });
+  const cancel = api.event.cancelSignup.useMutation({ onSuccess: invalidate });
+
+  if (query.isPending) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-6">
+        <div className="h-64 animate-pulse rounded-2xl bg-gray-200" />
+      </div>
+    );
+  }
+  if (query.error || !query.data) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 text-center">
+        <p className="text-sm font-medium text-gray-900">
+          This event isn’t available.
+        </p>
+        <Link
+          href="/events"
+          className="mt-2 inline-block text-sm text-emerald-700 hover:underline"
+        >
+          ← All events
+        </Link>
+      </div>
+    );
+  }
+
+  const e = query.data;
+  const busy = signup.isPending || cancel.isPending;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6">
+      <Link
+        href="/events"
+        className="mb-4 inline-flex items-center gap-1 text-sm text-emerald-700 hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" /> All events
+      </Link>
+
+      {e.bannerUrl && (
+        <div className="relative mb-5 aspect-[16/6] w-full overflow-hidden rounded-2xl bg-gray-100">
+          <Image
+            src={e.bannerUrl}
+            alt={e.title ?? "Event banner"}
+            fill
+            className="object-cover"
+            sizes="768px"
+            priority
+            unoptimized
+          />
+        </div>
+      )}
+
+      {e.canceled && (
+        <div className="mb-4 rounded-lg border border-gray-300 bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600">
+          This event has been cancelled.
+        </div>
+      )}
+
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          {e.ccaName && (
+            <p className="text-sm font-medium text-emerald-700">{e.ccaName}</p>
+          )}
+          <h1 className="mt-1 text-2xl font-bold tracking-tight text-gray-900">
+            {e.title?.trim() || "Untitled event"}
+          </h1>
+          <div className="mt-3 space-y-1.5 text-sm text-gray-600">
+            <p className="flex items-center gap-2">
+              <CalendarDays className="h-4 w-4 text-gray-400" />
+              {formatDateRange(e.startTime, e.endTime)}
+            </p>
+            {e.location && (
+              <p className="flex items-center gap-2">
+                <MapPin className="h-4 w-4 text-gray-400" />
+                {e.location}
+              </p>
+            )}
+            <p className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-gray-400" />
+              {e.signupCount}
+              {e.capacity != null ? `/${e.capacity}` : ""} going
+            </p>
+          </div>
+        </div>
+
+        {/* Signup box */}
+        <div className="w-full shrink-0 rounded-xl border border-gray-200 bg-white p-4 sm:w-64">
+          {e.canceled ? (
+            <p className="text-sm text-gray-500">Signups are closed.</p>
+          ) : e.mySignup ? (
+            <div className="space-y-3">
+              <p className="flex items-center gap-2 text-sm font-medium text-emerald-700">
+                <Check className="h-4 w-4" /> You&rsquo;re going
+              </p>
+              <Button
+                variant="outline"
+                className="w-full"
+                disabled={busy}
+                onClick={() => {
+                  setError(null);
+                  cancel.mutate({ eventID });
+                }}
+              >
+                {cancel.isPending ? "Cancelling…" : "Cancel signup"}
+              </Button>
+            </div>
+          ) : e.started ? (
+            <p className="text-sm text-gray-500">Signups have closed.</p>
+          ) : e.full ? (
+            <p className="text-sm font-medium text-gray-700">
+              This event is full.
+            </p>
+          ) : !hasMatric ? (
+            <div className="space-y-2">
+              <p className="text-sm text-gray-600">
+                Add your matric number to sign up.
+              </p>
+              <Button asChild className="w-full">
+                <Link href="/onboarding/matric">Add matric &amp; sign up</Link>
+              </Button>
+            </div>
+          ) : (
+            <Button
+              className="w-full"
+              disabled={busy}
+              onClick={() => {
+                setError(null);
+                signup.mutate({ eventID });
+              }}
+            >
+              {signup.isPending ? "Signing up…" : "Sign up"}
+            </Button>
+          )}
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+        </div>
+      </div>
+
+      {e.publicDescription && (
+        <div className="mt-6 whitespace-pre-wrap border-t border-gray-100 pt-6 text-sm leading-relaxed text-gray-700">
+          {e.publicDescription}
+        </div>
+      )}
+
+      {e.photoUrls.length > 0 && (
+        <div className="mt-8">
+          <Carousel className="w-full">
+            <CarouselContent>
+              {e.photoUrls.map((url, i) => (
+                <CarouselItem key={url} className="sm:basis-1/2">
+                  <div className="relative aspect-video overflow-hidden rounded-xl bg-gray-100">
+                    <Image
+                      src={url}
+                      alt={`Photo ${i + 1}`}
+                      fill
+                      className="object-cover"
+                      sizes="384px"
+                      unoptimized
+                    />
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            {e.photoUrls.length > 1 && (
+              <>
+                <CarouselPrevious />
+                <CarouselNext />
+              </>
+            )}
+          </Carousel>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/events/_components/EventsTimeline.tsx
+++ b/src/app/events/_components/EventsTimeline.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { CalendarDays, MapPin, Users, Check } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import type { RouterOutputs } from "~/trpc/react";
+import {
+  formatDateTime,
+  formatDayHeading,
+  dayKey,
+  nowSec,
+} from "~/app/events/_lib/format";
+
+type PublicEvent = RouterOutputs["event"]["listPublished"]["events"][number];
+
+type Tab = "upcoming" | "mine" | "past";
+
+/**
+ * The resident timeline — a Luma-style vertical list grouped by day, with a
+ * left date rail. Three views: what's coming up, the events you're going to, and
+ * a past archive. All published events come from one query; the tabs filter
+ * client-side.
+ */
+export default function EventsTimeline() {
+  const list = api.event.listPublished.useQuery(undefined, { retry: false });
+  const [tab, setTab] = useState<Tab>("upcoming");
+
+  const now = nowSec();
+
+  const groups = useMemo(() => {
+    const events = list.data?.events ?? [];
+    const filtered = events.filter((e) => {
+      const upcoming = e.startTime == null || e.startTime >= now;
+      if (tab === "upcoming") return upcoming;
+      if (tab === "past") return !upcoming;
+      return e.mySignup; // "mine"
+    });
+
+    // Past reads newest-first; everything else soonest-first.
+    const ordered = [...filtered].sort((a, b) => {
+      const av = a.startTime ?? Number.MAX_SAFE_INTEGER;
+      const bv = b.startTime ?? Number.MAX_SAFE_INTEGER;
+      return tab === "past" ? bv - av : av - bv;
+    });
+
+    const byDay = new Map<string, { heading: string; events: PublicEvent[] }>();
+    for (const e of ordered) {
+      const key = e.startTime == null ? "tbc" : dayKey(e.startTime);
+      const heading =
+        e.startTime == null ? "Date to be confirmed" : formatDayHeading(e.startTime);
+      if (!byDay.has(key)) byDay.set(key, { heading, events: [] });
+      byDay.get(key)!.events.push(e);
+    }
+    return [...byDay.values()];
+  }, [list.data, tab, now]);
+
+  const TABS: { key: Tab; label: string }[] = [
+    { key: "upcoming", label: "Upcoming" },
+    { key: "mine", label: "My events" },
+    { key: "past", label: "Past" },
+  ];
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Events
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          What&rsquo;s happening around Raffles Hall.
+        </p>
+      </div>
+
+      <div className="mb-6 inline-flex rounded-lg bg-gray-100 p-1">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+              tab === t.key
+                ? "bg-white text-emerald-700 shadow-sm"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {list.isPending ? (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-28 animate-pulse rounded-xl bg-gray-200" />
+          ))}
+        </div>
+      ) : list.error ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+          {list.error.message === "EVENTS_DISABLED"
+            ? "Events aren’t available yet — check back soon."
+            : "Events couldn’t load. Reload the page."}
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-white p-12 text-center">
+          <CalendarDays className="mx-auto h-10 w-10 text-gray-300" />
+          <p className="mt-3 text-sm font-medium text-gray-900">
+            {tab === "mine"
+              ? "You haven’t signed up for anything yet"
+              : tab === "past"
+                ? "No past events"
+                : "No upcoming events"}
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            {tab === "mine"
+              ? "Browse Upcoming and sign up for something."
+              : "New events show up here once they’re published."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {groups.map((g, gi) => (
+            <div key={gi} className="flex gap-4">
+              {/* Date rail */}
+              <div className="w-20 shrink-0 pt-1 sm:w-28">
+                <p className="sticky top-20 text-sm font-semibold text-gray-900">
+                  {g.heading}
+                </p>
+              </div>
+              {/* Cards */}
+              <div className="min-w-0 flex-1 space-y-3 border-l border-gray-200 pl-4">
+                {g.events.map((e) => (
+                  <EventCard key={e.eventID} event={e} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EventCard({ event: e }: { event: PublicEvent }) {
+  // Past events are genuinely done → a muted filled dot. Upcoming events are
+  // open, not "completed" → a hollow ring, so the rail never reads as a
+  // finished stepper.
+  const isPast = e.startTime != null && e.startTime < nowSec();
+  return (
+    <Link
+      href={`/events/${e.eventID}`}
+      className="group relative -ml-[1.05rem] block"
+    >
+      {/* Timeline node — hollow ring = upcoming/open, filled grey = past.
+          bg masks the rail line behind it; never a solid green "completed" dot. */}
+      <span
+        className={`absolute left-0 top-[1.6rem] h-3 w-3 -translate-x-1/2 rounded-full border-2 ${
+          isPast
+            ? "border-gray-300 bg-gray-300"
+            : "border-emerald-500 bg-white"
+        }`}
+      />
+      <div className="ml-4 overflow-hidden rounded-xl border border-gray-200 bg-white transition-all group-hover:border-emerald-300 group-hover:shadow-md">
+        <div className="flex">
+          {e.bannerUrl && (
+            <div className="relative hidden h-auto w-40 shrink-0 sm:block">
+              <Image
+                src={e.bannerUrl}
+                alt=""
+                fill
+                className="object-cover"
+                sizes="160px"
+                unoptimized
+              />
+            </div>
+          )}
+          <div className="min-w-0 flex-1 p-4">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="truncate text-base font-semibold text-gray-900">
+                {e.title?.trim() || "Untitled event"}
+              </h3>
+              {e.mySignup && (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+                  <Check className="h-3 w-3" /> Going
+                </span>
+              )}
+            </div>
+            {e.ccaName && (
+              <p className="mt-0.5 text-xs font-medium text-emerald-700">
+                {e.ccaName}
+              </p>
+            )}
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+              <span className="inline-flex items-center gap-1">
+                <CalendarDays className="h-3.5 w-3.5" />
+                {formatDateTime(e.startTime)}
+              </span>
+              {e.location && (
+                <span className="inline-flex items-center gap-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {e.location}
+                </span>
+              )}
+              <span className="inline-flex items-center gap-1">
+                <Users className="h-3.5 w-3.5" />
+                {e.signupCount}
+                {e.capacity != null ? `/${e.capacity} going` : " going"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/events/_lib/format.ts
+++ b/src/app/events/_lib/format.ts
@@ -1,0 +1,139 @@
+import type { EventStatus } from "~/lib/schemas/event";
+
+/**
+ * Client-safe display helpers for the Events feature — pure functions, no server
+ * imports, so both the resident pages and the head/admin components can share
+ * them. Times are UNIX epoch SECONDS (the stored convention); the hall is in
+ * SGT, so the browser's local time is used directly rather than a fixed zone.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Dates                                                                       */
+/* -------------------------------------------------------------------------- */
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** epoch seconds → the value an <input type="datetime-local"> expects (local). */
+export function epochToLocalInput(sec: number | null | undefined): string {
+  if (sec == null) return "";
+  const d = new Date(sec * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+/** <input type="datetime-local"> value (local wall time) → epoch seconds. */
+export function localInputToEpoch(value: string): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  if (Number.isNaN(ms)) return null;
+  return Math.floor(ms / 1000);
+}
+
+const DATE_FMT: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  day: "numeric",
+  month: "short",
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true,
+};
+
+export function formatDateTime(sec: number | null | undefined): string {
+  if (sec == null) return "Date TBC";
+  return new Date(sec * 1000).toLocaleString("en-SG", DATE_FMT);
+}
+
+/** A start–end range, collapsing the date when both fall on the same day. */
+export function formatDateRange(
+  start: number | null | undefined,
+  end: number | null | undefined,
+): string {
+  if (start == null) return "Date TBC";
+  const startStr = formatDateTime(start);
+  if (end == null) return startStr;
+  const sameDay =
+    new Date(start * 1000).toDateString() ===
+    new Date(end * 1000).toDateString();
+  const endStr = sameDay
+    ? new Date(end * 1000).toLocaleTimeString("en-SG", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      })
+    : formatDateTime(end);
+  return `${startStr} – ${endStr}`;
+}
+
+/** Local YYYY-MM-DD key, for grouping the timeline by day. */
+export function dayKey(sec: number): string {
+  const d = new Date(sec * 1000);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** A heading like "Thu, 6 Aug" for a timeline day group. */
+export function formatDayHeading(sec: number): string {
+  return new Date(sec * 1000).toLocaleDateString("en-SG", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Status display                                                              */
+/* -------------------------------------------------------------------------- */
+
+export const STATUS_META: Record<
+  EventStatus,
+  { label: string; className: string }
+> = {
+  draft: { label: "Draft", className: "bg-gray-100 text-gray-700" },
+  submitted: { label: "In review", className: "bg-amber-100 text-amber-800" },
+  approved: { label: "Approved", className: "bg-sky-100 text-sky-800" },
+  rejected: { label: "Rejected", className: "bg-red-100 text-red-700" },
+  published: { label: "Published", className: "bg-emerald-100 text-emerald-800" },
+  canceled: { label: "Canceled", className: "bg-gray-200 text-gray-500" },
+};
+
+/* -------------------------------------------------------------------------- */
+/* CSV                                                                         */
+/* -------------------------------------------------------------------------- */
+
+/** Escape one field per RFC 4180: quote when it contains "," | '"' | newline. */
+function csvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Serialize a table (header + rows) to an RFC-4180 CSV string with CRLF. */
+export function serializeCsv(rows: (string | number | null | undefined)[][]): string {
+  return rows
+    .map((row) => row.map((c) => csvField(c == null ? "" : String(c))).join(","))
+    .join("\r\n");
+}
+
+/** Trigger a client-side download of `content` as `filename`. */
+export function downloadTextFile(
+  filename: string,
+  content: string,
+  mime = "text/csv;charset=utf-8",
+): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/app/events/_lib/resizeImage.ts
+++ b/src/app/events/_lib/resizeImage.ts
@@ -1,0 +1,33 @@
+/**
+ * Downscale an image in the browser to fit maxW×maxH (preserving aspect ratio)
+ * and re-encode as WebP. Lifted verbatim from CcaImageField's resizeToWebp — the
+ * resize is CONVENIENCE, not a control; the authoritative cap is
+ * maximumSizeInBytes in /api/event/upload. Kept in its own client-only module so
+ * the banner and gallery fields share exactly one implementation.
+ */
+export async function resizeToWebp(
+  file: File,
+  maxW: number,
+  maxH: number,
+): Promise<Blob> {
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: "from-image",
+  });
+  const scale = Math.min(1, maxW / bitmap.width, maxH / bitmap.height);
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("CANVAS_UNAVAILABLE");
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/webp", 0.85),
+  );
+  if (!blob) throw new Error("ENCODE_FAILED");
+  return blob;
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,14 @@
+import { HydrateClient } from "~/trpc/server";
+import Header from "../_components/header";
+import EventsTimeline from "./_components/EventsTimeline";
+
+export default function EventsPage() {
+  return (
+    <HydrateClient>
+      <Header currentPage="Events" />
+      <div className="min-h-[calc(100vh-4rem)] bg-gradient-to-br from-gray-50 to-gray-100 pb-20">
+        <EventsTimeline />
+      </div>
+    </HydrateClient>
+  );
+}

--- a/src/lib/schemas/event.ts
+++ b/src/lib/schemas/event.ts
@@ -1,0 +1,306 @@
+import { z } from "zod";
+
+import { CCA_BLOB_HOST } from "~/lib/schemas/cca";
+
+/**
+ * Shared Events validation. Deliberately NOT under `src/server/`: the client
+ * mirrors this validation with a real `safeParse`, so it needs the runtime
+ * VALUE, and a `"use client"` component value-importing from the server tree
+ * risks pulling Prisma into the browser bundle. Same reasoning, same location,
+ * as `cca.ts` and `profile.ts` beside it.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Status vocabulary                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The lifecycle. Enforced HERE, in code — `Event.status` is a nullable String
+ * with a default in the schema (I-2), never a DB enum. The DB cannot police it,
+ * so every transition is checked in the router.
+ *
+ *   draft      — created, proposal being filled; PDF uploadable (needs eventID)
+ *   submitted  — sent to JCRC, awaiting a decision
+ *   approved   — JCRC said yes; head may now add public content
+ *   rejected   — JCRC said no; editable and resubmittable
+ *   published  — head added banner/photos/desc and published; visible to all
+ *   canceled   — head withdrew a published/approved event; TERMINAL
+ */
+export const EVENT_STATUSES = [
+  "draft",
+  "submitted",
+  "approved",
+  "rejected",
+  "published",
+  "canceled",
+] as const;
+export type EventStatus = (typeof EVENT_STATUSES)[number];
+
+/** A head may edit the proposal fields only in these states. */
+export const PROPOSAL_EDITABLE: readonly EventStatus[] = ["draft", "rejected"];
+/** A head may edit the public content only in these states. */
+export const PUBLIC_EDITABLE: readonly EventStatus[] = ["approved", "published"];
+
+export function normalizeStatus(raw: string | null | undefined): EventStatus {
+  return (EVENT_STATUSES as readonly string[]).includes(raw ?? "")
+    ? (raw as EventStatus)
+    : "draft";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Field limits                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const EVENT_TITLE_MAX = 120;
+export const EVENT_DESCRIPTION_MAX = 4000;
+export const EVENT_LOCATION_MAX = 200;
+export const EVENT_PUBLIC_DESCRIPTION_MAX = 4000;
+export const EVENT_DECISION_REASON_MAX = 500;
+/** How many gallery photos one event may carry. A soft product cap. */
+export const EVENT_MAX_PHOTOS = 8;
+/** Sanity ceiling on capacity — larger than any real hall event. */
+export const EVENT_CAPACITY_MAX = 100_000;
+
+/* Reusable field schemas. Trim + length only; React escapes on render (same
+ * reasoning as `bio`/CCA `description` — see cca.ts). */
+const titleField = z.string().trim().min(1, "Title is required").max(EVENT_TITLE_MAX);
+const descriptionField = z.string().trim().min(1, "Description is required").max(EVENT_DESCRIPTION_MAX);
+const locationField = z.string().trim().min(1, "Location is required").max(EVENT_LOCATION_MAX);
+/** UNIX epoch SECONDS, UTC — the Bookings convention. */
+const epochSecondsField = z.number().int().positive();
+const capacityField = z.number().int().positive().max(EVENT_CAPACITY_MAX);
+
+/* -------------------------------------------------------------------------- */
+/* Blob uploads (reuse the CCA store, new path prefix)                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Events reuse the SAME public Vercel Blob store as CCA images (its host is
+ * already whitelisted in next.config.js's remotePatterns), under a distinct
+ * `event/` path prefix. Re-exported so the upload route and client field import
+ * one host constant.
+ */
+export const EVENT_BLOB_HOST = CCA_BLOB_HOST;
+
+export const EVENT_UPLOAD_KINDS = ["proposal", "banner", "photo"] as const;
+export type EventUploadKind = (typeof EVENT_UPLOAD_KINDS)[number];
+
+export const EVENT_IMAGE_CONTENT_TYPES = [
+  "image/webp",
+  "image/png",
+  "image/jpeg",
+] as const;
+export const EVENT_PDF_CONTENT_TYPES = ["application/pdf"] as const;
+
+/** Images are client-downscaled to WebP; the cap stops a crafted upload. */
+export const EVENT_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+/** Proposals are real PDFs, so a larger ceiling — still bounded. */
+export const EVENT_PDF_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * The upload constraints Vercel enforces when it mints a token, chosen by kind.
+ * The route passes these straight into `onBeforeGenerateToken`.
+ */
+export function eventUploadConstraints(kind: EventUploadKind): {
+  allowedContentTypes: string[];
+  maximumSizeInBytes: number;
+} {
+  if (kind === "proposal") {
+    return {
+      allowedContentTypes: [...EVENT_PDF_CONTENT_TYPES],
+      maximumSizeInBytes: EVENT_PDF_MAX_BYTES,
+    };
+  }
+  return {
+    allowedContentTypes: [...EVENT_IMAGE_CONTENT_TYPES],
+    maximumSizeInBytes: EVENT_IMAGE_MAX_BYTES,
+  };
+}
+
+/**
+ * Upload pathname for an event asset. Vercel appends a random suffix, so the
+ * stored blob is e.g. `event/12/photo-Xy7Qa1.webp` — unguessable and immutable.
+ * Built here so the client (requests the token) and the route (authorises it)
+ * cannot disagree about the shape.
+ */
+export function eventUploadPath(eventID: number, kind: EventUploadKind): string {
+  return `event/${eventID}/${kind}`;
+}
+
+/**
+ * Inverse of eventUploadPath, used by the upload route to learn WHICH event a
+ * token is for. Client-supplied, so this parse is NOT the security boundary —
+ * the caller must load the event and pass its ccaID to assertHeadsCca. It only
+ * guarantees a well-formed, event-scoped path so a token can never be minted
+ * for an arbitrary location in the store.
+ */
+export function parseEventUploadPath(
+  pathname: string,
+): { eventID: number; kind: EventUploadKind } | null {
+  const m = /^event\/(\d+)\/(proposal|banner|photo)$/.exec(pathname);
+  if (!m) return null;
+  const eventID = Number(m[1]);
+  if (!Number.isSafeInteger(eventID) || eventID <= 0) return null;
+  return { eventID, kind: m[2] as EventUploadKind };
+}
+
+/**
+ * Is this URL one of OUR blobs, for THIS event, of THIS kind? THE load-bearing
+ * check — URLs reach the server from the client (browser uploads to Blob, then
+ * calls a mutation with whatever URL it got back). Mirrors isOwnCcaBlobUrl:
+ *   - protocol https (blocks javascript:/data:)
+ *   - host EXACTLY the store's (not a suffix match)
+ *   - path under this event's own prefix
+ */
+export function isOwnEventBlobUrl(
+  url: string,
+  eventID: number,
+  kind: EventUploadKind,
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.host !== EVENT_BLOB_HOST) return false;
+  return parsed.pathname.startsWith(`/${eventUploadPath(eventID, kind)}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mutation payloads                                                           */
+/* -------------------------------------------------------------------------- */
+
+const eventIDField = z.number().int().positive();
+const ccaIDField = z.number().int().positive();
+
+/** Cross-field time check reused by draft edits: end must be after start. */
+function refineTimes(
+  val: { startTime?: number | null; endTime?: number | null },
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    typeof val.startTime === "number" &&
+    typeof val.endTime === "number" &&
+    val.endTime <= val.startTime
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endTime"],
+      message: "End time must be after the start time",
+    });
+  }
+}
+
+/**
+ * Create a draft. Only `ccaID` is required — a draft is work-in-progress and
+ * everything else is filled in and validated for completeness at submit time.
+ * Returning an eventID immediately is what lets the proposal PDF (whose blob
+ * path needs the id) be uploaded next.
+ */
+export const createDraftInput = z
+  .object({
+    ccaID: ccaIDField,
+    title: titleField.optional(),
+    description: descriptionField.optional(),
+    startTime: epochSecondsField.optional(),
+    endTime: epochSecondsField.optional(),
+    location: locationField.optional(),
+    capacity: capacityField.nullable().optional(),
+  })
+  .superRefine(refineTimes);
+export type CreateDraftInput = z.input<typeof createDraftInput>;
+
+/**
+ * Patch a draft's proposal fields (and attach the proposal PDF URL). All
+ * optional — the form saves partial progress. proposalUrl is validated against
+ * this event's own blob prefix; null clears it.
+ */
+export const updateDraftInput = z
+  .object({
+    eventID: eventIDField,
+    title: titleField.optional(),
+    description: descriptionField.optional(),
+    startTime: epochSecondsField.optional(),
+    endTime: epochSecondsField.nullable().optional(),
+    location: locationField.optional(),
+    capacity: capacityField.nullable().optional(),
+    proposalUrl: z.string().url().nullable().optional(),
+  })
+  .superRefine((val, ctx) => {
+    refineTimes(val, ctx);
+    if (
+      typeof val.proposalUrl === "string" &&
+      !isOwnEventBlobUrl(val.proposalUrl, val.eventID, "proposal")
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["proposalUrl"],
+        message: "NOT_A_VALID_EVENT_BLOB_URL",
+      });
+    }
+  });
+export type UpdateDraftInput = z.input<typeof updateDraftInput>;
+
+/**
+ * The public content a head adds after approval. bannerUrl / photoUrls are
+ * validated against this event's own blob prefix, exactly like ccaProfileInput.
+ * null bannerUrl removes the banner; an empty photoUrls array clears the gallery.
+ */
+export const updatePublicContentInput = z
+  .object({
+    eventID: eventIDField,
+    publicDescription: z
+      .string()
+      .trim()
+      .max(EVENT_PUBLIC_DESCRIPTION_MAX)
+      .optional(),
+    bannerUrl: z.string().url().nullable().optional(),
+    photoUrls: z.array(z.string().url()).max(EVENT_MAX_PHOTOS).optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (
+      typeof val.bannerUrl === "string" &&
+      !isOwnEventBlobUrl(val.bannerUrl, val.eventID, "banner")
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["bannerUrl"],
+        message: "NOT_A_VALID_EVENT_BLOB_URL",
+      });
+    }
+    if (val.photoUrls) {
+      val.photoUrls.forEach((u, i) => {
+        if (!isOwnEventBlobUrl(u, val.eventID, "photo")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["photoUrls", i],
+            message: "NOT_A_VALID_EVENT_BLOB_URL",
+          });
+        }
+      });
+    }
+  });
+export type UpdatePublicContentInput = z.input<typeof updatePublicContentInput>;
+
+/** JCRC decision. A rejection must carry a reason; approval's reason is optional. */
+export const decideInput = z
+  .object({
+    eventID: eventIDField,
+    decision: z.enum(["approve", "reject"]),
+    reason: z.string().trim().max(EVENT_DECISION_REASON_MAX).optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.decision === "reject" && !val.reason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["reason"],
+        message: "A reason is required when rejecting",
+      });
+    }
+  });
+export type DecideInput = z.input<typeof decideInput>;
+
+export const eventIdInput = z.object({ eventID: eventIDField });
+export const ccaIdInput = z.object({ ccaID: ccaIDField });

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -7,6 +7,7 @@ import { ccaRouter } from "./routers/cca";
 import { ccaAdminRouter } from "./routers/ccaAdmin";
 import { ccaApplicationsRouter } from "./routers/ccaApplications";
 import { ccaApplicationsHeadRouter } from "./routers/ccaApplicationsHead";
+import { eventRouter } from "./routers/event";
 
 /**
  * This is the primary router for your server.
@@ -26,6 +27,9 @@ export const appRouter = createTRPCRouter({
   ccaApplications: ccaApplicationsRouter,
   /** CCA-head review/interview/decide, object-scoped by assertHeadsCca. */
   ccaApplicationsHead: ccaApplicationsHeadRouter,
+  /** Events: head authoring, JCRC review, resident timeline + signup. Behind
+   * the events.enabled switch; object-scoped per event's ccaID. */
+  event: eventRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -247,6 +247,7 @@ export type AuditEntry = {
   targetUserID?: string;
   targetFacilityID?: number;
   targetCcaID?: number;
+  targetEventID?: number;
   action: string;
   rolesBefore?: string[];
   rolesAfter?: string[];
@@ -281,6 +282,7 @@ export async function writeAudit(
         targetUserID: e.targetUserID ?? null,
         targetFacilityID: e.targetFacilityID ?? null,
         targetCcaID: e.targetCcaID ?? null,
+        targetEventID: e.targetEventID ?? null,
         action: e.action,
         rolesBefore: e.rolesBefore ?? [],
         rolesAfter: e.rolesAfter ?? [],

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -1,0 +1,940 @@
+import { TRPCError } from "@trpc/server";
+import { del } from "@vercel/blob";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  createTRPCRouter,
+  identifiedProcedure,
+  protectedProcedure,
+  roleManagerProcedure,
+  requireMatric,
+} from "~/server/api/trpc";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import { writeAudit } from "~/server/api/routers/admin";
+import {
+  assertEventsEnabled,
+  nextEventId,
+  withEventLock,
+} from "~/server/api/services/events";
+import { canonicalUserID } from "~/lib/identity";
+import {
+  createDraftInput,
+  updateDraftInput,
+  updatePublicContentInput,
+  decideInput,
+  eventIdInput,
+  ccaIdInput,
+  normalizeStatus,
+  PROPOSAL_EDITABLE,
+  PUBLIC_EDITABLE,
+} from "~/lib/schemas/event";
+
+/**
+ * The Events feature.
+ *
+ * THREE authorization CLASSES live here, deliberately in one router because they
+ * are one feature, but each procedure states which it uses:
+ *
+ *   - HEAD-scoped (identifiedProcedure + assertHeadsCca on the event's ccaID):
+ *     create/edit/publish/cancel/monitor. Same rule as cca.ts — every procedure
+ *     that reaches an event MUST authorise via the event's ccaID, never a role
+ *     string. `cca_head` is scope-free.
+ *   - REVIEWER (roleManagerProcedure = admin + jcrc): the JCRC review queue and
+ *     approve/reject. `decide` additionally re-reads roles live (I-5).
+ *   - RESIDENT (protectedProcedure, + requireMatric for signup): the public
+ *     timeline, detail and signup. getPublic NEVER returns proposalUrl or the
+ *     internal proposal description.
+ *
+ * EVERY procedure calls assertEventsEnabled first — the kill switch is the
+ * boundary, the page guards are cosmetic.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Shared helpers                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Load an event and prove the caller heads its CCA. The head-facing counterpart
+ * to assertHeadsCca: the ccaID comes from the STORED event, never the client, so
+ * a head cannot act on another CCA's event by supplying a foreign ccaID.
+ */
+async function loadHeadedEvent(
+  db: PrismaClient,
+  userID: string,
+  roles: readonly string[],
+  eventID: number,
+) {
+  const event = await db.event.findUnique({ where: { eventID } });
+  if (!event) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+  }
+  await assertHeadsCca(db, { userID, roles }, event.ccaID);
+  return event;
+}
+
+type ResolvedAttendee = {
+  userID: string;
+  displayName: string | null;
+  matric: string | null;
+  block: number | null;
+  telegramHandle: string | null;
+};
+
+/**
+ * Resolve canonical userIDs to attendee detail for the export and the by-block
+ * stat. matric comes from UserMatric (canonical-keyed, reliable). name/block/
+ * telegram come from User, which has no reverse canonical lookup, so — exactly
+ * like cca.listHeads — we guess the @u.nus.edu email AND match the stored
+ * User.userID, then key by canonicalUserID(email) with a stored-key fallback.
+ */
+async function resolveAttendees(
+  db: PrismaClient,
+  userIDs: string[],
+): Promise<Map<string, ResolvedAttendee>> {
+  const out = new Map<string, ResolvedAttendee>();
+  if (userIDs.length === 0) return out;
+
+  const guessedEmails = userIDs.map((k) => `${k.toLowerCase()}@u.nus.edu`);
+  const [users, matrics] = await Promise.all([
+    db.user.findMany({
+      where: {
+        OR: [
+          { email: { in: guessedEmails, mode: "insensitive" } },
+          { userID: { in: userIDs } },
+        ],
+      },
+      // Never a bare read: passwordHash must not leave the server (I-2).
+      select: {
+        email: true,
+        displayName: true,
+        telegramHandle: true,
+        block: true,
+        userID: true,
+      },
+    }),
+    db.userMatric.findMany({
+      where: { userID: { in: userIDs } },
+      select: { userID: true, matric: true },
+    }),
+  ]);
+
+  const matricByKey = new Map(matrics.map((m) => [m.userID, m.matric]));
+  const profileByKey = new Map<
+    string,
+    { displayName: string | null; telegramHandle: string | null; block: number | null }
+  >();
+  for (const u of users) {
+    const cid = canonicalUserID(u.email);
+    const value = {
+      displayName: u.displayName,
+      telegramHandle: u.telegramHandle,
+      block: u.block,
+    };
+    if (cid && !profileByKey.has(cid)) profileByKey.set(cid, value);
+    if (u.userID && !profileByKey.has(u.userID)) profileByKey.set(u.userID, value);
+  }
+
+  for (const userID of userIDs) {
+    const p = profileByKey.get(userID);
+    out.set(userID, {
+      userID,
+      displayName: p?.displayName ?? null,
+      matric: matricByKey.get(userID) ?? null,
+      block: p?.block ?? null,
+      telegramHandle: p?.telegramHandle ?? null,
+    });
+  }
+  return out;
+}
+
+/** Count signups per event without groupBy (Mongo-safe; hall-scale volumes). */
+async function signupCounts(
+  db: PrismaClient,
+  eventIDs: number[],
+): Promise<Map<number, number>> {
+  const counts = new Map<number, number>();
+  if (eventIDs.length === 0) return counts;
+  const rows = await db.eventSignup.findMany({
+    where: { eventID: { in: eventIDs } },
+    select: { eventID: true },
+  });
+  for (const r of rows) counts.set(r.eventID, (counts.get(r.eventID) ?? 0) + 1);
+  return counts;
+}
+
+/** Public-safe projection — the ONLY fields a resident may ever see. */
+function toPublicCard(e: {
+  eventID: number;
+  ccaID: number;
+  title: string | null;
+  publicDescription: string | null;
+  bannerUrl: string | null;
+  photoUrls: string[];
+  startTime: number | null;
+  endTime: number | null;
+  location: string | null;
+  capacity: number | null;
+  status: string | null;
+}) {
+  return {
+    eventID: e.eventID,
+    ccaID: e.ccaID,
+    title: e.title,
+    publicDescription: e.publicDescription,
+    bannerUrl: e.bannerUrl,
+    photoUrls: e.photoUrls,
+    startTime: e.startTime,
+    endTime: e.endTime,
+    location: e.location,
+    capacity: e.capacity,
+    status: normalizeStatus(e.status),
+  };
+}
+
+async function attachCcaNames(
+  db: PrismaClient,
+  ccaIDs: number[],
+): Promise<Map<number, string | null>> {
+  const byID = new Map<number, string | null>();
+  if (ccaIDs.length === 0) return byID;
+  const rows = await db.cCA.findMany({
+    where: { ccaID: { in: [...new Set(ccaIDs)] } },
+    select: { ccaID: true, ccaName: true },
+  });
+  for (const r of rows) byID.set(r.ccaID, r.ccaName);
+  return byID;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Router                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const eventRouter = createTRPCRouter({
+  /* ----------------------------- HEAD: authoring ------------------------- */
+
+  createDraft: identifiedProcedure
+    .input(createDraftInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      // The CCA must exist, else the draft points at nothing and is invisible
+      // everywhere (same guard as cca.updateProfile).
+      const cca = await ctx.db.cCA.findUnique({
+        where: { ccaID: input.ccaID },
+        select: { ccaID: true },
+      });
+      if (!cca) throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
+
+      const eventID = await nextEventId(ctx.db);
+      await ctx.db.event.create({
+        data: {
+          eventID,
+          ccaID: input.ccaID,
+          createdBy: userID,
+          title: input.title ?? null,
+          description: input.description ?? null,
+          startTime: input.startTime ?? null,
+          endTime: input.endTime ?? null,
+          location: input.location ?? null,
+          capacity: input.capacity ?? null,
+          status: "draft",
+          createdAt: new Date(),
+        },
+      });
+      return { eventID };
+    }),
+
+  updateDraft: identifiedProcedure
+    .input(updateDraftInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      if (!PROPOSAL_EDITABLE.includes(normalizeStatus(event.status))) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "PROPOSAL_NOT_EDITABLE",
+        });
+      }
+
+      // Merge-then-check: a client may send endTime alone, so validate against
+      // the value on file, not only the payload (the schema can only see both
+      // when both are present).
+      const nextStart = input.startTime ?? event.startTime;
+      const nextEnd =
+        input.endTime === undefined ? event.endTime : input.endTime;
+      if (nextStart != null && nextEnd != null && nextEnd <= nextStart) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "END_BEFORE_START",
+        });
+      }
+
+      const data: Record<string, unknown> = {
+        updatedAt: new Date(),
+        updatedBy: userID,
+      };
+      if (input.title !== undefined) data.title = input.title;
+      if (input.description !== undefined) data.description = input.description;
+      if (input.startTime !== undefined) data.startTime = input.startTime;
+      if (input.endTime !== undefined) data.endTime = input.endTime;
+      if (input.location !== undefined) data.location = input.location;
+      if (input.capacity !== undefined) data.capacity = input.capacity;
+      if (input.proposalUrl !== undefined) data.proposalUrl = input.proposalUrl;
+
+      await ctx.db.event.update({ where: { eventID: input.eventID }, data });
+
+      // Clean up a replaced proposal PDF (non-fatal, mirrors updateProfile).
+      if (
+        input.proposalUrl !== undefined &&
+        event.proposalUrl &&
+        event.proposalUrl !== input.proposalUrl
+      ) {
+        try {
+          await del(event.proposalUrl);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              evt: "event_blob_delete_failed",
+              eventID: input.eventID,
+              url: event.proposalUrl,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      }
+      return { ok: true };
+    }),
+
+  submitForReview: identifiedProcedure
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      if (!PROPOSAL_EDITABLE.includes(normalizeStatus(event.status))) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "NOT_SUBMITTABLE",
+        });
+      }
+      // Completeness is enforced HERE, not on the draft, so partial saves work.
+      const missing: string[] = [];
+      if (!event.title?.trim()) missing.push("title");
+      if (!event.description?.trim()) missing.push("description");
+      if (event.startTime == null) missing.push("startTime");
+      if (!event.location?.trim()) missing.push("location");
+      if (!event.proposalUrl) missing.push("proposalUrl");
+      if (missing.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `INCOMPLETE:${missing.join(",")}`,
+        });
+      }
+
+      await ctx.db.event.update({
+        where: { eventID: input.eventID },
+        data: {
+          status: "submitted",
+          // Clear a prior rejection so the reviewer sees a clean submission.
+          decidedAt: null,
+          decidedBy: null,
+          decisionReason: null,
+          updatedAt: new Date(),
+          updatedBy: userID,
+        },
+      });
+      return { status: "submitted" as const };
+    }),
+
+  updatePublicContent: identifiedProcedure
+    .input(updatePublicContentInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      if (!PUBLIC_EDITABLE.includes(normalizeStatus(event.status))) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "PUBLIC_CONTENT_LOCKED",
+        });
+      }
+
+      const data: Record<string, unknown> = {
+        updatedAt: new Date(),
+        updatedBy: userID,
+      };
+      if (input.publicDescription !== undefined)
+        data.publicDescription = input.publicDescription;
+      if (input.bannerUrl !== undefined) data.bannerUrl = input.bannerUrl;
+      if (input.photoUrls !== undefined) data.photoUrls = input.photoUrls;
+
+      await ctx.db.event.update({ where: { eventID: input.eventID }, data });
+
+      // Delete blobs this save replaced/removed (non-fatal). Every URL here was
+      // proven ours by updatePublicContentInput; `event.*` came from our row.
+      const replaced: string[] = [];
+      if (
+        input.bannerUrl !== undefined &&
+        event.bannerUrl &&
+        event.bannerUrl !== input.bannerUrl
+      ) {
+        replaced.push(event.bannerUrl);
+      }
+      if (input.photoUrls !== undefined) {
+        const kept = new Set(input.photoUrls);
+        for (const url of event.photoUrls) if (!kept.has(url)) replaced.push(url);
+      }
+      if (replaced.length > 0) {
+        try {
+          await del(replaced);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              evt: "event_blob_delete_failed",
+              eventID: input.eventID,
+              urls: replaced,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      }
+      return { ok: true };
+    }),
+
+  publish: identifiedProcedure
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      const status = normalizeStatus(event.status);
+      if (status === "published") return { status: "published" as const };
+      if (status !== "approved") {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "NOT_APPROVED",
+        });
+      }
+      // The public minimum: residents must not land on a bare event.
+      const missing: string[] = [];
+      if (!event.bannerUrl) missing.push("banner");
+      if (!event.publicDescription?.trim()) missing.push("publicDescription");
+      if (missing.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `INCOMPLETE:${missing.join(",")}`,
+        });
+      }
+
+      await ctx.db.event.update({
+        where: { eventID: input.eventID },
+        data: {
+          status: "published",
+          publishedAt: new Date(),
+          updatedAt: new Date(),
+          updatedBy: userID,
+        },
+      });
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: event.ccaID,
+        targetEventID: event.eventID,
+        action: "event.publish",
+        reason: event.title ?? undefined,
+      });
+      return { status: "published" as const };
+    }),
+
+  cancelEvent: identifiedProcedure
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      const status = normalizeStatus(event.status);
+      if (status !== "approved" && status !== "published") {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "NOT_CANCELABLE",
+        });
+      }
+      await ctx.db.event.update({
+        where: { eventID: input.eventID },
+        data: {
+          status: "canceled",
+          updatedAt: new Date(),
+          updatedBy: userID,
+        },
+      });
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: event.ccaID,
+        targetEventID: event.eventID,
+        action: "event.cancel",
+        reason: event.title ?? undefined,
+      });
+      return { status: "canceled" as const };
+    }),
+
+  /* ----------------------------- HEAD: monitoring ------------------------ */
+
+  listMineForCca: identifiedProcedure
+    .input(ccaIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      const events = await ctx.db.event.findMany({
+        where: { ccaID: input.ccaID },
+        orderBy: { createdAt: "desc" },
+      });
+      const counts = await signupCounts(
+        ctx.db,
+        events.map((e) => e.eventID),
+      );
+      return {
+        events: events.map((e) => ({
+          eventID: e.eventID,
+          title: e.title,
+          status: normalizeStatus(e.status),
+          startTime: e.startTime,
+          location: e.location,
+          capacity: e.capacity,
+          bannerUrl: e.bannerUrl,
+          decisionReason: e.decisionReason,
+          signupCount: counts.get(e.eventID) ?? 0,
+        })),
+      };
+    }),
+
+  getForHead: identifiedProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+      const signupCount = await ctx.db.eventSignup.count({
+        where: { eventID: input.eventID },
+      });
+      return { event: { ...event, status: normalizeStatus(event.status) }, signupCount };
+    }),
+
+  getSignupStats: identifiedProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      const signups = await ctx.db.eventSignup.findMany({
+        where: { eventID: input.eventID },
+        select: { userID: true, createdAt: true },
+        orderBy: { createdAt: "asc" },
+      });
+
+      // Signups per calendar day (UTC date key) — the client cumulates.
+      const perDay = new Map<string, number>();
+      for (const s of signups) {
+        const day = (s.createdAt ?? new Date()).toISOString().slice(0, 10);
+        perDay.set(day, (perDay.get(day) ?? 0) + 1);
+      }
+      const byDay = [...perDay.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, count]) => ({ date, count }));
+
+      // By block, resolved live.
+      const resolved = await resolveAttendees(
+        ctx.db,
+        signups.map((s) => s.userID),
+      );
+      const perBlock = new Map<string, number>();
+      for (const s of signups) {
+        const block = resolved.get(s.userID)?.block;
+        const key = block == null ? "Unknown" : String(block);
+        perBlock.set(key, (perBlock.get(key) ?? 0) + 1);
+      }
+      const byBlock = [...perBlock.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([block, count]) => ({ block, count }));
+
+      return { total: signups.length, byDay, byBlock };
+    }),
+
+  /** Render-only attendee list for the head's monitor table (no audit). */
+  getAttendees: identifiedProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      const signups = await ctx.db.eventSignup.findMany({
+        where: { eventID: input.eventID },
+        select: { userID: true, createdAt: true },
+        orderBy: { createdAt: "asc" },
+      });
+      const resolved = await resolveAttendees(
+        ctx.db,
+        signups.map((s) => s.userID),
+      );
+      return {
+        attendees: signups.map((s) => ({
+          ...(resolved.get(s.userID) ?? {
+            userID: s.userID,
+            displayName: null,
+            matric: null,
+            block: null,
+            telegramHandle: null,
+          }),
+          signedUpAt: s.createdAt,
+        })),
+      };
+    }),
+
+  /**
+   * The AUDITED PII export. A mutation, not a query, so it fires exactly once
+   * per download and writes an event.attendees.export audit row carrying the
+   * exported count. Returns the same rows the CSV is built from client-side.
+   */
+  exportAttendees: identifiedProcedure
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const event = await loadHeadedEvent(ctx.db, userID, roles, input.eventID);
+
+      const signups = await ctx.db.eventSignup.findMany({
+        where: { eventID: input.eventID },
+        select: { userID: true, createdAt: true },
+        orderBy: { createdAt: "asc" },
+      });
+      const resolved = await resolveAttendees(
+        ctx.db,
+        signups.map((s) => s.userID),
+      );
+      const attendees = signups.map((s) => ({
+        ...(resolved.get(s.userID) ?? {
+          userID: s.userID,
+          displayName: null,
+          matric: null,
+          block: null,
+          telegramHandle: null,
+        }),
+        signedUpAt: s.createdAt,
+      }));
+
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: event.ccaID,
+        targetEventID: event.eventID,
+        action: "event.attendees.export",
+        reason: `${attendees.length} attendee(s)`,
+      });
+      return { attendees, title: event.title, eventID: event.eventID };
+    }),
+
+  /* ------------------------------ REVIEWER ------------------------------- */
+
+  listForReview: roleManagerProcedure.query(async ({ ctx }) => {
+    await assertEventsEnabled(ctx.db);
+    const events = await ctx.db.event.findMany({
+      where: { status: "submitted" },
+      orderBy: { updatedAt: "asc" }, // oldest waiting first — a queue
+    });
+    const names = await attachCcaNames(
+      ctx.db,
+      events.map((e) => e.ccaID),
+    );
+    return {
+      events: events.map((e) => ({
+        eventID: e.eventID,
+        ccaID: e.ccaID,
+        ccaName: names.get(e.ccaID) ?? null,
+        title: e.title,
+        startTime: e.startTime,
+        location: e.location,
+        updatedAt: e.updatedAt,
+      })),
+    };
+  }),
+
+  getForReview: roleManagerProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const event = await ctx.db.event.findUnique({
+        where: { eventID: input.eventID },
+      });
+      if (!event) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+      }
+      const names = await attachCcaNames(ctx.db, [event.ccaID]);
+      return {
+        event: { ...event, status: normalizeStatus(event.status) },
+        ccaName: names.get(event.ccaID) ?? null,
+      };
+    }),
+
+  decide: roleManagerProcedure
+    .input(decideInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      if (!computeCapabilities(roles).reviewEvents) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "CAPABILITY_REQUIRED:reviewEvents",
+        });
+      }
+
+      const event = await ctx.db.event.findUnique({
+        where: { eventID: input.eventID },
+      });
+      if (!event) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+      }
+      if (normalizeStatus(event.status) !== "submitted") {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "NOT_UNDER_REVIEW",
+        });
+      }
+
+      const nextStatus = input.decision === "approve" ? "approved" : "rejected";
+      await ctx.db.event.update({
+        where: { eventID: input.eventID },
+        data: {
+          status: nextStatus,
+          decidedAt: new Date(),
+          decidedBy: userID,
+          decisionReason: input.reason ?? null,
+        },
+      });
+      await writeAudit(ctx.db, {
+        actorUserID: userID,
+        actorRoles: roles,
+        targetCcaID: event.ccaID,
+        targetEventID: event.eventID,
+        action: input.decision === "approve" ? "event.approve" : "event.reject",
+        reason: input.reason ?? undefined,
+      });
+      return { status: nextStatus as "approved" | "rejected" };
+    }),
+
+  /* ------------------------------ RESIDENT ------------------------------- */
+
+  listPublished: protectedProcedure.query(async ({ ctx }) => {
+    await assertEventsEnabled(ctx.db);
+    const events = await ctx.db.event.findMany({
+      where: { status: "published" },
+      orderBy: { startTime: "asc" },
+    });
+    const [names, counts, mine] = await Promise.all([
+      attachCcaNames(
+        ctx.db,
+        events.map((e) => e.ccaID),
+      ),
+      signupCounts(
+        ctx.db,
+        events.map((e) => e.eventID),
+      ),
+      ctx.session.user.userID
+        ? ctx.db.eventSignup.findMany({
+            where: {
+              userID: ctx.session.user.userID,
+              eventID: { in: events.map((e) => e.eventID) },
+            },
+            select: { eventID: true },
+          })
+        : Promise.resolve([] as { eventID: number }[]),
+    ]);
+    const mineSet = new Set(mine.map((m) => m.eventID));
+    return {
+      events: events.map((e) => ({
+        ...toPublicCard(e),
+        ccaName: names.get(e.ccaID) ?? null,
+        signupCount: counts.get(e.eventID) ?? 0,
+        mySignup: mineSet.has(e.eventID),
+      })),
+    };
+  }),
+
+  getPublic: protectedProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const event = await ctx.db.event.findUnique({
+        where: { eventID: input.eventID },
+      });
+      // Only published (or a canceled event someone still has the link to) is
+      // public. draft/submitted/approved are NOT — treat as not found so their
+      // existence isn't disclosed.
+      const status = normalizeStatus(event?.status);
+      if (!event || (status !== "published" && status !== "canceled")) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+      }
+
+      const [names, signupCount, mine] = await Promise.all([
+        attachCcaNames(ctx.db, [event.ccaID]),
+        ctx.db.eventSignup.count({ where: { eventID: event.eventID } }),
+        ctx.session.user.userID
+          ? ctx.db.eventSignup.findUnique({
+              where: {
+                eventID_userID: {
+                  eventID: event.eventID,
+                  userID: ctx.session.user.userID,
+                },
+              },
+              select: { eventID: true },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      const nowSec = Math.floor(Date.now() / 1000);
+      const started = event.startTime != null && nowSec >= event.startTime;
+      const full = event.capacity != null && signupCount >= event.capacity;
+      return {
+        ...toPublicCard(event),
+        ccaName: names.get(event.ccaID) ?? null,
+        signupCount,
+        mySignup: mine !== null,
+        canceled: status === "canceled",
+        started,
+        full,
+        // The client still shows the button; the server is the real gate.
+        signupOpen: status === "published" && !started && !full,
+      };
+    }),
+
+  signup: identifiedProcedure
+    .use(requireMatric)
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+
+      const event = await ctx.db.event.findUnique({
+        where: { eventID: input.eventID },
+        select: { eventID: true, status: true, startTime: true, capacity: true },
+      });
+      if (!event || normalizeStatus(event.status) !== "published") {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+      }
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (event.startTime != null && nowSec >= event.startTime) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "SIGNUP_CLOSED",
+        });
+      }
+
+      return withEventLock(ctx.db, input.eventID, async () => {
+        if (event.capacity != null) {
+          const count = await ctx.db.eventSignup.count({
+            where: { eventID: input.eventID },
+          });
+          // Already-signed-up callers pass (idempotent); genuinely-full block.
+          if (count >= event.capacity) {
+            const already = await ctx.db.eventSignup.findUnique({
+              where: {
+                eventID_userID: { eventID: input.eventID, userID },
+              },
+              select: { eventID: true },
+            });
+            if (!already) {
+              throw new TRPCError({ code: "CONFLICT", message: "EVENT_FULL" });
+            }
+            return { signedUp: true as const };
+          }
+        }
+        try {
+          await ctx.db.eventSignup.create({
+            data: { eventID: input.eventID, userID, createdAt: new Date() },
+          });
+        } catch (err) {
+          // Unique index is the double-submit backstop — idempotent success.
+          if (
+            !(
+              typeof err === "object" &&
+              err !== null &&
+              (err as { code?: string }).code === "P2002"
+            )
+          ) {
+            throw err;
+          }
+        }
+        return { signedUp: true as const };
+      });
+    }),
+
+  cancelSignup: identifiedProcedure
+    .input(eventIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      await ctx.db.eventSignup.deleteMany({
+        where: { eventID: input.eventID, userID },
+      });
+      return { signedUp: false as const };
+    }),
+
+  listMySignups: identifiedProcedure.query(async ({ ctx }) => {
+    await assertEventsEnabled(ctx.db);
+    const userID = ctx.session.user.userID;
+    const mine = await ctx.db.eventSignup.findMany({
+      where: { userID },
+      select: { eventID: true },
+    });
+    const eventIDs = mine.map((m) => m.eventID);
+    if (eventIDs.length === 0) return { events: [] };
+
+    const events = await ctx.db.event.findMany({
+      where: { eventID: { in: eventIDs }, status: "published" },
+      orderBy: { startTime: "asc" },
+    });
+    const [names, counts] = await Promise.all([
+      attachCcaNames(
+        ctx.db,
+        events.map((e) => e.ccaID),
+      ),
+      signupCounts(
+        ctx.db,
+        events.map((e) => e.eventID),
+      ),
+    ]);
+    return {
+      events: events.map((e) => ({
+        ...toPublicCard(e),
+        ccaName: names.get(e.ccaID) ?? null,
+        signupCount: counts.get(e.eventID) ?? 0,
+        mySignup: true,
+      })),
+    };
+  }),
+});

--- a/src/server/api/services/events.ts
+++ b/src/server/api/services/events.ts
@@ -1,0 +1,155 @@
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Events feature server helpers: the kill switch, the eventID allocator, and the
+ * per-event signup lock. Modelled on services/booking.ts (nextBookingId /
+ * withFacilityLock) and services/ccaScope.ts (isCcaManagementEnabled).
+ *
+ * Requires `prisma db push` so the unique indexes on `EventLock.key`,
+ * `Counter.key` and `Event.eventID` exist — those indexes are what make the
+ * lock, the counter and the id allocation safe.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* The Events kill switch                                                       */
+/* -------------------------------------------------------------------------- */
+
+const EVENTS_FLAG_KEY = "events.enabled";
+const FLAG_TTL_MS = 15_000;
+
+let flagCache: { at: number; on: boolean } | null = null;
+
+/**
+ * Same reasoning as isCcaManagementEnabled (ccaScope.ts): this gates a NEW
+ * SURFACE that did not exist yesterday, so "behave as yesterday" means DISABLED.
+ * The absence of the row returns false, and an unreachable flag returns false:
+ * the entire Events feature is inert until someone deliberately writes
+ * `events.enabled = "on"`. Fails CLOSED, and a failed read is NOT cached so the
+ * next request retries rather than pinning "disabled" on a transient hiccup.
+ */
+export async function areEventsEnabled(db: PrismaClient): Promise<boolean> {
+  if (flagCache && Date.now() - flagCache.at < FLAG_TTL_MS) {
+    return flagCache.on;
+  }
+  try {
+    const row = await db.systemFlag.findUnique({
+      where: { key: EVENTS_FLAG_KEY },
+    });
+    const on = row?.value === "on";
+    flagCache = { at: Date.now(), on };
+    return on;
+  } catch {
+    return false;
+  }
+}
+
+/** Test/ops seam: drop the per-lambda cache so the next read hits the row. */
+export function resetEventsFlagCache(): void {
+  flagCache = null;
+}
+
+/**
+ * Assert the switch is on. Called at the top of EVERY event procedure — the
+ * page-level checks are cosmetic, this one is the boundary.
+ */
+export async function assertEventsEnabled(db: PrismaClient): Promise<void> {
+  if (!(await areEventsEnabled(db))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "EVENTS_DISABLED",
+    });
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* eventID allocation                                                          */
+/* -------------------------------------------------------------------------- */
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "P2002"
+  );
+}
+
+/**
+ * Allocate the next eventID atomically from the shared Counter collection
+ * (key "eventID"). Mirrors nextBookingId. The Event collection starts empty, so
+ * the lazy seed reads the current max (0 on first run).
+ */
+export async function nextEventId(db: PrismaClient): Promise<number> {
+  const existing = await db.counter.findUnique({ where: { key: "eventID" } });
+  if (!existing) {
+    const last = await db.event.findFirst({
+      orderBy: { eventID: "desc" },
+      select: { eventID: true },
+    });
+    try {
+      await db.counter.create({
+        data: { key: "eventID", seq: last?.eventID ?? 0 },
+      });
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+    }
+  }
+  const updated = await db.counter.update({
+    where: { key: "eventID" },
+    data: { seq: { increment: 1 } },
+  });
+  return updated.seq;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Per-event signup lock                                                       */
+/* -------------------------------------------------------------------------- */
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_ATTEMPTS = 50;
+const LOCK_RETRY_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` while holding a per-event advisory lock so the capacity count and the
+ * subsequent signup create cannot interleave and overbook. Same shape and
+ * crashed-request reclaim strategy as withFacilityLock.
+ */
+export async function withEventLock<T>(
+  db: PrismaClient,
+  eventID: number,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `event:${eventID}`;
+  let acquired = false;
+
+  for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
+    try {
+      await db.eventLock.create({ data: { key } });
+      acquired = true;
+      break;
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+      await db.eventLock.deleteMany({
+        where: { key, createdAt: { lt: new Date(Date.now() - LOCK_STALE_MS) } },
+      });
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+
+  if (!acquired) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "This event is busy right now — please try again.",
+    });
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await db.eventLock.deleteMany({ where: { key } });
+  }
+}

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -138,6 +138,15 @@ export const AUDIT_ACTIONS = [
   "ccaInterviewSlot.edit",
   "ccaInterviewSlot.cancel",
   "ccaInterviewNote.add",
+  // Events feature. approve/reject are written by JCRC (reviewEvents); publish,
+  // cancel and attendees.export are written by the owning head (assertHeadsCca).
+  // attendees.export records a PII export (matric/block/telegram) and its
+  // audit row carries the exported attendee count in `reason`.
+  "event.approve",
+  "event.reject",
+  "event.publish",
+  "event.cancel",
+  "event.attendees.export",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
@@ -792,6 +801,13 @@ export type Capabilities = {
   viewSystemHealth: boolean;
   viewSystemHealthDetail: boolean;
   manageEnforcementFlag: boolean;
+  /**
+   * May review submitted events and approve/reject them (the /admin/events
+   * tab). Manager-level (admin + jcrc), matching the JCRC review role. Heads
+   * reach their OWN events surface via reachCcaDashboard + per-event
+   * assertHeadsCca, not this.
+   */
+  reviewEvents: boolean;
 };
 
 export function computeCapabilities(roles: readonly string[]): Capabilities {
@@ -821,5 +837,6 @@ export function computeCapabilities(roles: readonly string[]): Capabilities {
     viewSystemHealth: manager,
     viewSystemHealthDetail: admin,
     manageEnforcementFlag: admin,
+    reviewEvents: manager,
   };
 }


### PR DESCRIPTION
## What

Adds an **Events** feature end to end.

**Lifecycle:** a CCA head applies (name, description, date/time, location, capacity, proposal PDF) → JCRC approves/rejects with a reason → the head adds a banner, photo gallery and public description, then **publishes** → residents see a Luma-style timeline at `/events` and sign up (matric required) → the head monitors signups, sees light analytics, and downloads an **audited** attendee CSV (matric / block / telegram). Cancel and edit supported.

## Surfaces

- **Resident:** `/events` timeline (Upcoming / My events / Past) + `/events/[eventID]` detail with photo gallery and matric-gated signup. Header gets an Events link.
- **CCA head:** new **Events** section in the portal — propose, attach the proposal PDF, submit; after approval add banner/photos/public description and publish; a monitor page with analytics, attendee table, CSV download, edit and cancel.
- **JCRC/Admin:** new **Events** review tab — queue of submitted events, view the proposal PDF, approve / reject with reason.

## How it follows house invariants

- New **unvalidated** collections `Event` / `EventSignup` / `EventLock`, plus an additive nullable `RoleAuditLog.targetEventID` — no `$jsonSchema`-guarded collection is touched.
- Everything keyed on the **canonical userID**; all new scalars nullable (I-2).
- Per-event authorization via **`assertHeadsCca`** (never a `cca_head` role check); new **`reviewEvents`** capability (= manager) for JCRC.
- `eventID` from the `Counter`; capacity serialized under a `withEventLock` advisory lock; **fail-closed `events.enabled`** kill switch gates the whole surface.
- Blob uploads reuse the existing CCA store under an `event/` path prefix — new `/api/event/upload` token route, no `next.config` change.
- Signup reuses the existing `matricProcedure` gate so the attendee list is always complete.

## Deploy / enable

1. `npx prisma db push` (creates the 3 collections + indexes) — **already run against the DB**.
2. `node scripts/remediation/set-events-flag.mjs on --commit` to flip `events.enabled` — **already set to `on`**. The feature stays inert until this branch is deployed.

## Verification

`tsc` and `next lint` clean; production `next build` passes with all new routes. Not yet click-through-tested with real head/JCRC/resident logins.

> ⚠️ Note for reviewers: `prisma db push` for this change reconciled away an out-of-band `email_unique_ci` index on `User.email`; it was restored immediately (collation en/strength 2). Consider declaring that index in a follow-up so future pushes don't drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)