### PR TITLE
CCA interviews: 'Clear free slots' bulk action for heads

### DIFF
--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -75,6 +75,16 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
     [list.data],
   );
 
+  // Free = unbooked. Only these are ever bulk-cleared; booked slots stay.
+  const freeCount = useMemo(
+    () => (list.data?.slots ?? []).filter((s) => s.bookedByUserID === null).length,
+    [list.data],
+  );
+
+  const clear = api.ccaApplicationsHead.clearFreeSlots.useMutation({
+    onSuccess: () => utils.ccaApplicationsHead.listSlots.invalidate({ ccaID }),
+  });
+
   return (
     <div className="space-y-6">
       <SlotGenerator
@@ -84,7 +94,38 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
       />
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold text-gray-900">Schedule</h2>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-gray-900">Schedule</h2>
+          {freeCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={clear.isPending}
+              onClick={() => {
+                if (
+                  window.confirm(
+                    `Clear all ${freeCount} free (unbooked) slot${
+                      freeCount === 1 ? "" : "s"
+                    }? Booked slots are kept.`,
+                  )
+                ) {
+                  clear.mutate({ ccaID });
+                }
+              }}
+              className="text-red-600 hover:bg-red-50 hover:text-red-700"
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" />
+              {clear.isPending ? "Clearing…" : "Clear free slots"}
+            </Button>
+          )}
+        </div>
+        {clear.error && (
+          <p className="mb-2 text-sm text-red-600">
+            {clear.error.message === "NOT_A_HEAD_OF_THIS_CCA"
+              ? "You can only clear slots for CCAs you head."
+              : "Those couldn’t be cleared. Try again."}
+          </p>
+        )}
         {list.isPending ? (
           <div className="h-32 animate-pulse rounded-lg bg-gray-200" />
         ) : list.error ? (

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -564,6 +564,60 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       });
     }),
 
+  /**
+   * Clear every FREE (unbooked, non-canceled) slot for a CCA in one go — the
+   * bulk counterpart to cancelSlot, so a head doesn't delete a whole day one
+   * card at a time.
+   *
+   * BOOKED slots are DELIBERATELY untouched: cancelling one reverts an
+   * applicant to reschedule, which must stay a per-slot, confirmed action
+   * (cancelSlot), never a side effect of "clear". So this only ever removes
+   * slots nobody has claimed. Idempotent — clearing when there are none is a
+   * no-op that returns 0.
+   */
+  clearFreeSlots: identifiedProcedure
+    .input(ccaTargetInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertApplicationsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+
+      return withCcaLock(ctx.db, input.ccaID, async () => {
+        // Filter in JS, NOT the query: `{ canceledAt: null }` / `{ bookedByUserID
+        // : null }` miss absent-field slots on Prisma+Mongo (see listSlots), which
+        // would leave old free slots behind. Fetch, then filter both in memory.
+        const all = await ctx.db.ccaInterviewSlot.findMany({
+          where: { ccaID: input.ccaID },
+          select: { slotID: true, canceledAt: true, bookedByUserID: true },
+        });
+        const freeIDs = all
+          .filter((s) => s.canceledAt === null && s.bookedByUserID === null)
+          .map((s) => s.slotID);
+
+        if (freeIDs.length === 0) {
+          return { ccaID: input.ccaID, cleared: 0 };
+        }
+
+        // Mark them canceled by slotID list (not a null-filter), so absent-field
+        // rows are included. Nothing to revert — these were unbooked.
+        await ctx.db.ccaInterviewSlot.updateMany({
+          where: { slotID: { in: freeIDs } },
+          data: { canceledAt: new Date() },
+        });
+
+        await writeAudit(ctx.db, {
+          actorUserID: userID,
+          actorRoles: roles,
+          targetCcaID: input.ccaID,
+          action: "ccaInterviewSlot.clear",
+          reason: `${scope.via}: cleared ${freeIDs.length} free slot(s)`,
+        });
+
+        return { ccaID: input.ccaID, cleared: freeIDs.length };
+      });
+    }),
+
   /** Append an interview note to an application. */
   addNote: identifiedProcedure
     .input(addNoteInput)

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -137,6 +137,10 @@ export const AUDIT_ACTIONS = [
   "ccaInterviewSlot.open",
   "ccaInterviewSlot.edit",
   "ccaInterviewSlot.cancel",
+  // Bulk-cancel of every FREE (unbooked) slot at once. Booked slots are never
+  // touched by this — they still go through ccaInterviewSlot.cancel one at a
+  // time, which reverts the applicant. The audit row carries the cleared count.
+  "ccaInterviewSlot.clear",
   "ccaInterviewNote.add",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];


### PR DESCRIPTION
## What

Adds a one-click **Clear free slots** action to the CCA head interview scheduler, so a head can wipe a whole batch of unbooked slots instead of deleting them card by card.

## Behaviour

- New `ccaApplicationsHead.clearFreeSlots` mutation cancels **every unbooked, non-canceled slot** for the CCA at once.
- **Booked slots are deliberately untouched.** Cancelling a booked slot reverts its applicant to reschedule, so that stays the existing per-slot, confirmed `cancelSlot` action — never a side effect of a bulk clear.
- Object-scoped via `assertHeadsCca`, serialized under `withCcaLock`, and audited as a new `ccaInterviewSlot.clear` action carrying the cleared count.
- The button sits in the Schedule header, appears only when free slots exist, shows the count, and confirms before clearing.
- Free/canceled slots are filtered in JS (not a Mongo `null` filter), matching the existing `listSlots` note about absent-field slots.

## Notes

`tsc` clean. (ESLint can't run inside the nested worktree — duplicate `@next/next` plugin — so I relied on `tsc` there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)