### PR TITLE
Events: facility-backed locations + auto-booking on approval

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -609,7 +609,14 @@ model Event {
   /// UNIX epoch seconds, UTC (like Bookings). start required to submit.
   startTime         Int?
   endTime           Int?
+  /// Display label for the location. When facilityID is set this is the
+  /// denormalized facility name (so every display path renders without a join);
+  /// when facilityID is null it is the head's free-text "Other" location.
   location          String?
+  /// The chosen facility, or null for a free-text "Other" location. When set AND
+  /// endTime is present, approval auto-creates a Bookings row for it (see
+  /// event.decide). NOT a foreign key — Bookings/Facilities key on facilityID.
+  facilityID        Int?
   /// null = unlimited. Enforced under EventLock at signup time.
   capacity          Int?
 
@@ -618,6 +625,14 @@ model Event {
   decidedAt         DateTime?
   decidedBy         String?
   decisionReason    String?
+  /// The bookingID of the auto-created facility booking, set on approval when a
+  /// facility was chosen and the slot was free. Null when Other, or when the
+  /// slot was already taken (see autoBookFailed). Deleted with the event.
+  bookingID         Int?
+  /// True when a facility was chosen but the slot was already booked at approval
+  /// time, so no booking was made — surfaced to the head to book manually. The
+  /// event is still approved (approval is never blocked on a booking clash).
+  autoBookFailed    Boolean?
 
   // Public content — added by the head only after approval, shown to residents.
   publicDescription String?

--- a/src/app/admin/_components/events/EventReviewDetail.tsx
+++ b/src/app/admin/_components/events/EventReviewDetail.tsx
@@ -142,6 +142,13 @@ export default function EventReviewDetail({ eventID }: { eventID: number }) {
         </div>
       ) : (
         <div className="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-100">
+          {event.facilityID != null && (
+            <p className="mb-3 rounded-md bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+              Approving will automatically book{" "}
+              <span className="font-medium">{event.location ?? "the facility"}</span>{" "}
+              for this event&rsquo;s time, under the CCA head.
+            </p>
+          )}
           <label className="block text-sm font-medium text-gray-700">
             Reason{" "}
             <span className="text-gray-400">(required to reject)</span>

--- a/src/app/cca/_components/EventCreateForm.tsx
+++ b/src/app/cca/_components/EventCreateForm.tsx
@@ -9,6 +9,7 @@ import { createDraftInput } from "~/lib/schemas/event";
 import { localInputToEpoch } from "~/app/events/_lib/format";
 import EventProposalFields, {
   EMPTY_PROPOSAL,
+  facilityPayload,
   type ProposalValue,
 } from "./EventProposalFields";
 
@@ -37,13 +38,15 @@ export default function EventCreateForm({ ccaID }: { ccaID: number }) {
     // time, and empty strings would fail the min-length rules.
     const start = localInputToEpoch(value.startLocal);
     const end = localInputToEpoch(value.endLocal);
+    const fp = facilityPayload(value);
     const payload = {
       ccaID,
       title: value.title.trim() || undefined,
       description: value.description.trim() || undefined,
       startTime: start ?? undefined,
       endTime: end ?? undefined,
-      location: value.location.trim() || undefined,
+      location: fp.location,
+      facilityID: fp.facilityID,
       capacity: value.capacity.trim() ? Number(value.capacity) : undefined,
     };
     const parsed = createDraftInput.safeParse(payload);

--- a/src/app/cca/_components/EventManage.tsx
+++ b/src/app/cca/_components/EventManage.tsx
@@ -18,6 +18,7 @@ import {
   localInputToEpoch,
 } from "~/app/events/_lib/format";
 import EventProposalFields, {
+  facilityPayload,
   type ProposalValue,
 } from "./EventProposalFields";
 import EventFileField from "./EventFileField";
@@ -32,6 +33,7 @@ const FIELD_LABELS: Record<string, string> = {
   title: "event name",
   description: "description",
   startTime: "start time",
+  endTime: "end time",
   location: "location",
   proposalUrl: "proposal PDF",
   banner: "banner image",
@@ -58,7 +60,14 @@ function ProposalEditor({ event }: { event: HeadEvent }) {
     description: event.description ?? "",
     startLocal: epochToLocalInput(event.startTime),
     endLocal: epochToLocalInput(event.endTime),
-    location: event.location ?? "",
+    // Facility → its id; free-text location → "other"; nothing → unset.
+    facilitySelection:
+      event.facilityID != null
+        ? String(event.facilityID)
+        : event.location
+          ? "other"
+          : "",
+    location: event.facilityID != null ? "" : (event.location ?? ""),
     capacity: event.capacity != null ? String(event.capacity) : "",
   });
   const [proposalUrl, setProposalUrl] = useState<string | null>(
@@ -71,13 +80,15 @@ function ProposalEditor({ event }: { event: HeadEvent }) {
   const submit = api.event.submitForReview.useMutation();
 
   function buildPatch() {
+    const fp = facilityPayload(value);
     return {
       eventID: event.eventID,
       title: value.title.trim() || undefined,
       description: value.description.trim() || undefined,
       startTime: localInputToEpoch(value.startLocal) ?? undefined,
       endTime: value.endLocal ? localInputToEpoch(value.endLocal) : null,
-      location: value.location.trim() || undefined,
+      location: fp.location,
+      facilityID: fp.facilityID,
       capacity: value.capacity.trim() ? Number(value.capacity) : null,
       proposalUrl,
     };
@@ -380,6 +391,34 @@ function CancelEventButton({ event }: { event: HeadEvent }) {
 /* Orchestrator                                                                */
 /* -------------------------------------------------------------------------- */
 
+/* -------------------------------------------------------------------------- */
+/* Auto-booking status                                                         */
+/* -------------------------------------------------------------------------- */
+
+function AutoBookingNotice({ event }: { event: HeadEvent }) {
+  // Only relevant when a facility (not free-text) was chosen.
+  if (event.facilityID == null) return null;
+  if (event.bookingID != null) {
+    return (
+      <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+        <span className="font-medium">Facility booked automatically</span>
+        {event.location ? ` — ${event.location}` : ""}. It appears in the
+        bookings calendar under your name.
+      </div>
+    );
+  }
+  if (event.autoBookFailed) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        <span className="font-medium">Facility not booked.</span>{" "}
+        {event.location ?? "The facility"} was already booked for this time, so
+        no automatic booking was made — please book it manually.
+      </div>
+    );
+  }
+  return null;
+}
+
 function mapError(e: unknown): string {
   const message = e instanceof Error ? e.message : "";
   const incomplete = incompleteMessage(message);
@@ -496,6 +535,7 @@ export default function EventManage({
             Approved. Add a banner, photos and a public description, then publish
             to put it on the residents’ timeline.
           </div>
+          <AutoBookingNotice event={event} />
           <PublicEditor event={event} mode="publish" />
           <div className="border-t border-gray-100 pt-4">
             <CancelEventButton event={event} />
@@ -506,6 +546,7 @@ export default function EventManage({
       {/* PUBLISHED — monitor + edit. */}
       {status === "published" && (
         <div className="space-y-8">
+          <AutoBookingNotice event={event} />
           <section>
             <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
               Signups

--- a/src/app/cca/_components/EventProposalFields.tsx
+++ b/src/app/cca/_components/EventProposalFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { api } from "~/trpc/react";
 import {
   EVENT_TITLE_MAX,
   EVENT_DESCRIPTION_MAX,
@@ -17,6 +18,9 @@ export type ProposalValue = {
   description: string;
   startLocal: string;
   endLocal: string;
+  /** "" = unset, "other" = free-text, otherwise a facilityID as a string. */
+  facilitySelection: string;
+  /** Free-text location, used only when facilitySelection === "other". */
   location: string;
   capacity: string;
 };
@@ -26,9 +30,34 @@ export const EMPTY_PROPOSAL: ProposalValue = {
   description: "",
   startLocal: "",
   endLocal: "",
+  facilitySelection: "",
   location: "",
   capacity: "",
 };
+
+/** Is the current selection a real facility (not unset / not "Other")? */
+export function isFacilitySelected(v: ProposalValue): boolean {
+  return v.facilitySelection !== "" && v.facilitySelection !== "other";
+}
+
+/**
+ * Map the location selection to the { facilityID, location } the draft mutations
+ * expect. A facility sends its id (the server denormalizes the name into
+ * `location`); "Other" sends free text and a null facilityID; unset sends
+ * neither (undefined = leave unchanged on a patch).
+ */
+export function facilityPayload(v: ProposalValue): {
+  facilityID: number | null | undefined;
+  location: string | undefined;
+} {
+  if (v.facilitySelection === "") {
+    return { facilityID: undefined, location: undefined };
+  }
+  if (v.facilitySelection === "other") {
+    return { facilityID: null, location: v.location.trim() || undefined };
+  }
+  return { facilityID: Number(v.facilitySelection), location: undefined };
+}
 
 export default function EventProposalFields({
   value,
@@ -41,6 +70,12 @@ export default function EventProposalFields({
 }) {
   const field =
     "mt-1 w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:bg-gray-50";
+
+  const facilitiesQuery = api.bookings.getAllFacilities.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const facilities = facilitiesQuery.data ?? [];
+  const facilityChosen = isFacilitySelected(value);
 
   return (
     <div className="space-y-4">
@@ -113,15 +148,37 @@ export default function EventProposalFields({
           <label className="block text-sm font-medium text-gray-700">
             Location
           </label>
-          <input
-            type="text"
-            value={value.location}
-            maxLength={EVENT_LOCATION_MAX}
+          <select
+            value={value.facilitySelection}
             disabled={disabled}
-            onChange={(e) => onChange({ location: e.target.value })}
+            onChange={(e) => onChange({ facilitySelection: e.target.value })}
             className={field}
-            placeholder="e.g. Raffles Hall Dining Hall"
-          />
+          >
+            <option value="">Select a location…</option>
+            {facilities.map((f) => (
+              <option key={f.facilityID} value={String(f.facilityID)}>
+                {f.facilityName}
+              </option>
+            ))}
+            <option value="other">Other (type it in)</option>
+          </select>
+          {value.facilitySelection === "other" && (
+            <input
+              type="text"
+              value={value.location}
+              maxLength={EVENT_LOCATION_MAX}
+              disabled={disabled}
+              onChange={(e) => onChange({ location: e.target.value })}
+              className={field}
+              placeholder="e.g. Raffles Hall Dining Hall"
+            />
+          )}
+          {facilityChosen && (
+            <p className="text-xs text-emerald-700">
+              A booking for this facility is created automatically once JCRC
+              approves — remember to set an end time.
+            </p>
+          )}
         </div>
         <div className="space-y-1.5">
           <label className="block text-sm font-medium text-gray-700">

--- a/src/lib/schemas/event.ts
+++ b/src/lib/schemas/event.ts
@@ -206,7 +206,11 @@ export const createDraftInput = z
     description: descriptionField.optional(),
     startTime: epochSecondsField.optional(),
     endTime: epochSecondsField.optional(),
+    // Location is EITHER a facility (facilityID set → server denormalizes the
+    // name into `location`) OR free text (`location`, facilityID null). null
+    // facilityID clears a previous facility choice.
     location: locationField.optional(),
+    facilityID: z.number().int().positive().nullable().optional(),
     capacity: capacityField.nullable().optional(),
   })
   .superRefine(refineTimes);
@@ -225,6 +229,7 @@ export const updateDraftInput = z
     startTime: epochSecondsField.optional(),
     endTime: epochSecondsField.nullable().optional(),
     location: locationField.optional(),
+    facilityID: z.number().int().positive().nullable().optional(),
     capacity: capacityField.nullable().optional(),
     proposalUrl: z.string().url().nullable().optional(),
   })

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -18,6 +18,7 @@ import {
   nextEventId,
   withEventLock,
 } from "~/server/api/services/events";
+import { nextBookingId, withFacilityLock } from "~/server/api/services/booking";
 import { canonicalUserID } from "~/lib/identity";
 import {
   createDraftInput,
@@ -207,6 +208,26 @@ async function attachCcaNames(
   return byID;
 }
 
+/**
+ * Resolve a chosen facility to its id + name. The name is denormalized into
+ * Event.location so every display path (timeline, detail, CSV) renders the
+ * location without a join; the id drives the auto-booking on approval. Throws
+ * if the facility does not exist.
+ */
+async function resolveFacility(
+  db: PrismaClient,
+  facilityID: number,
+): Promise<{ facilityID: number; name: string }> {
+  const f = await db.facilities.findUnique({
+    where: { facilityID },
+    select: { facilityName: true },
+  });
+  if (!f) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "NO_SUCH_FACILITY" });
+  }
+  return { facilityID, name: f.facilityName };
+}
+
 /* -------------------------------------------------------------------------- */
 /* Router                                                                      */
 /* -------------------------------------------------------------------------- */
@@ -230,6 +251,16 @@ export const eventRouter = createTRPCRouter({
       });
       if (!cca) throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
 
+      // A facility choice denormalizes its name into `location`; otherwise the
+      // free-text location is used as-is.
+      let location: string | null = input.location ?? null;
+      let facilityID: number | null = null;
+      if (input.facilityID != null) {
+        const f = await resolveFacility(ctx.db, input.facilityID);
+        facilityID = f.facilityID;
+        location = f.name;
+      }
+
       const eventID = await nextEventId(ctx.db);
       await ctx.db.event.create({
         data: {
@@ -240,7 +271,8 @@ export const eventRouter = createTRPCRouter({
           description: input.description ?? null,
           startTime: input.startTime ?? null,
           endTime: input.endTime ?? null,
-          location: input.location ?? null,
+          location,
+          facilityID,
           capacity: input.capacity ?? null,
           status: "draft",
           createdAt: new Date(),
@@ -289,6 +321,20 @@ export const eventRouter = createTRPCRouter({
       if (input.capacity !== undefined) data.capacity = input.capacity;
       if (input.proposalUrl !== undefined) data.proposalUrl = input.proposalUrl;
 
+      // Facility ↔ location. A number selects a facility (denormalize its name,
+      // overriding any location text sent above); explicit null switches to
+      // "Other" (keep/clear the free text); undefined leaves both untouched.
+      if (input.facilityID !== undefined) {
+        if (input.facilityID === null) {
+          data.facilityID = null;
+          data.location = input.location ?? null;
+        } else {
+          const f = await resolveFacility(ctx.db, input.facilityID);
+          data.facilityID = f.facilityID;
+          data.location = f.name;
+        }
+      }
+
       await ctx.db.event.update({ where: { eventID: input.eventID }, data });
 
       // Clean up a replaced proposal PDF (non-fatal, mirrors updateProfile).
@@ -334,6 +380,11 @@ export const eventRouter = createTRPCRouter({
       if (event.startTime == null) missing.push("startTime");
       if (!event.location?.trim()) missing.push("location");
       if (!event.proposalUrl) missing.push("proposalUrl");
+      // A facility can only be auto-booked with a definite end time, so require
+      // it when a facility was chosen (free-text locations don't need one).
+      if (event.facilityID != null && event.endTime == null) {
+        missing.push("endTime");
+      }
       if (missing.length > 0) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -479,10 +530,31 @@ export const eventRouter = createTRPCRouter({
         where: { eventID: input.eventID },
         data: {
           status: "canceled",
+          bookingID: null,
           updatedAt: new Date(),
           updatedBy: userID,
         },
       });
+
+      // Free the facility: delete the auto-created booking so the slot reopens.
+      // Non-fatal — a missing booking (already deleted) is fine.
+      if (event.bookingID != null) {
+        try {
+          await ctx.db.bookings.deleteMany({
+            where: { bookingID: event.bookingID },
+          });
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              evt: "event_booking_delete_failed",
+              eventID: event.eventID,
+              bookingID: event.bookingID,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      }
+
       await writeAudit(ctx.db, {
         actorUserID: userID,
         actorRoles: roles,
@@ -736,15 +808,100 @@ export const eventRouter = createTRPCRouter({
           decisionReason: input.reason ?? null,
         },
       });
+
+      // On approval, if a facility was chosen, auto-create a Booking under the
+      // event's head for that facility at the event's time. BEST-EFFORT: a clash
+      // (the slot was taken between submit and approval) FLAGS the event instead
+      // of blocking approval or double-booking. Reuses the same
+      // withFacilityLock + conflict check + nextBookingId as createBooking. The
+      // facility ROLE gate is intentionally skipped — JCRC approving the event IS
+      // the authorization — but the physical time-conflict check is kept.
+      let autoBook: "booked" | "conflict" | "none" = "none";
+      if (
+        input.decision === "approve" &&
+        event.facilityID != null &&
+        event.startTime != null &&
+        event.endTime != null
+      ) {
+        const facilityID = event.facilityID;
+        const startTime = event.startTime;
+        const endTime = event.endTime;
+        try {
+          const result = await withFacilityLock(ctx.db, facilityID, async () => {
+            const conflicts = await ctx.db.bookings.findMany({
+              where: {
+                facilityID,
+                AND: [
+                  { endTime: { gt: startTime } },
+                  { startTime: { lt: endTime } },
+                ],
+              },
+              select: { id: true },
+            });
+            if (conflicts.length > 0) return { booked: false as const };
+            const bookingID = await nextBookingId(ctx.db);
+            await ctx.db.bookings.create({
+              data: {
+                bookingID,
+                ccaID: event.ccaID,
+                facilityID,
+                startTime,
+                endTime,
+                userID: event.createdBy,
+                eventName: event.title ?? `Event #${event.eventID}`,
+                description: `Auto-booked for event #${event.eventID}`,
+              },
+            });
+            return { booked: true as const, bookingID };
+          });
+          if (result.booked) {
+            autoBook = "booked";
+            await ctx.db.event.update({
+              where: { eventID: input.eventID },
+              data: { bookingID: result.bookingID, autoBookFailed: false },
+            });
+          } else {
+            autoBook = "conflict";
+            await ctx.db.event.update({
+              where: { eventID: input.eventID },
+              data: { autoBookFailed: true },
+            });
+          }
+        } catch (err) {
+          // NEVER fail the approval on a booking error — flag it for the head to
+          // book manually.
+          autoBook = "conflict";
+          console.error(
+            JSON.stringify({
+              evt: "event_autobook_failed",
+              eventID: event.eventID,
+              facilityID,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+          await ctx.db.event
+            .update({
+              where: { eventID: input.eventID },
+              data: { autoBookFailed: true },
+            })
+            .catch(() => undefined);
+        }
+      }
+
       await writeAudit(ctx.db, {
         actorUserID: userID,
         actorRoles: roles,
         targetCcaID: event.ccaID,
         targetEventID: event.eventID,
         action: input.decision === "approve" ? "event.approve" : "event.reject",
-        reason: input.reason ?? undefined,
+        reason:
+          autoBook === "booked"
+            ? `${input.reason ? input.reason + "; " : ""}auto-booked facility #${event.facilityID}`
+            : autoBook === "conflict"
+              ? `${input.reason ? input.reason + "; " : ""}facility #${event.facilityID} clash — not booked`
+              : (input.reason ?? undefined),
       });
-      return { status: nextStatus as "approved" | "rejected" };
+      return { status: nextStatus as "approved" | "rejected", autoBook };
     }),
 
   /* ------------------------------ RESIDENT ------------------------------- */


### PR DESCRIPTION
## What

The event **location** becomes a picker: choose a **facility** from the list, or **"Other"** and type it in. When a facility is chosen, **approving** the event **automatically creates a Booking** under the event's head, for that facility at the event's time.

## Behaviour

- **Auto-book on approval** (`event.decide`) reuses the exact `withFacilityLock` + conflict check + `nextBookingId` path as `createBooking`. Owner = the event's head (`createdBy`), tagged with the event name.
- **Best-effort, never double-books:** if the slot was taken between submit and approval, the event still approves but the booking is skipped and the event is flagged (`autoBookFailed`) for the head to book manually. The facility *role* gate is skipped (JCRC approval is the authorization); the physical time-conflict check is kept.
- **Cancel frees the slot:** cancelling an event deletes its auto-created booking.
- **End time required** when a facility is chosen (a booking needs a definite end).

## Data

Additive nullable fields on `Event`: `facilityID`, `bookingID`, `autoBookFailed`. **No `db push` needed** — `Event` is unvalidated, so Mongo accepts the new fields on write; only `prisma generate` (client types). A facility choice **denormalizes its name into `location`**, so the timeline, detail page and CSV render unchanged.

## UI

- Proposal form: facility `<select>` (from `bookings.getAllFacilities`) + "Other" free-text, with a hint that approval will book it.
- Head manage page: "Facility booked automatically" / "facility was already booked — book manually".
- JCRC reviewer: a note that approving will auto-book the facility.

`tsc`, `eslint` (only pre-existing `||`-fallback warnings) and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)