### PR TITLE
Events: validate facility availability before submit

### DIFF
--- a/src/app/cca/_components/EventManage.tsx
+++ b/src/app/cca/_components/EventManage.tsx
@@ -425,6 +425,8 @@ function mapError(e: unknown): string {
   if (incomplete) return incomplete;
   if (message === "END_BEFORE_START")
     return "The end time must be after the start time.";
+  if (message === "FACILITY_UNAVAILABLE")
+    return "That facility is already booked for this time. Pick another time or facility before submitting.";
   if (message === "NOT_A_HEAD_OF_THIS_CCA")
     return "You're no longer a head of this CCA.";
   if (message === "EVENTS_DISABLED") return "Events aren't switched on yet.";

--- a/src/app/cca/_components/EventProposalFields.tsx
+++ b/src/app/cca/_components/EventProposalFields.tsx
@@ -6,6 +6,7 @@ import {
   EVENT_DESCRIPTION_MAX,
   EVENT_LOCATION_MAX,
 } from "~/lib/schemas/event";
+import { localInputToEpoch } from "~/app/events/_lib/format";
 
 /**
  * The proposal fields a head fills in at application time. A controlled block
@@ -76,6 +77,24 @@ export default function EventProposalFields({
   });
   const facilities = facilitiesQuery.data ?? [];
   const facilityChosen = isFacilitySelected(value);
+
+  // Live availability: only meaningful once a facility AND a valid time range
+  // are set. Advisory — the real gates are submit + approval.
+  const startEpoch = localInputToEpoch(value.startLocal);
+  const endEpoch = localInputToEpoch(value.endLocal);
+  const canCheckAvail =
+    facilityChosen &&
+    startEpoch != null &&
+    endEpoch != null &&
+    endEpoch > startEpoch;
+  const availability = api.event.facilityAvailability.useQuery(
+    {
+      facilityID: facilityChosen ? Number(value.facilitySelection) : 0,
+      startTime: startEpoch ?? 0,
+      endTime: endEpoch ?? 0,
+    },
+    { enabled: canCheckAvail, retry: false },
+  );
 
   return (
     <div className="space-y-4">
@@ -179,6 +198,25 @@ export default function EventProposalFields({
               approves — remember to set an end time.
             </p>
           )}
+          {facilityChosen && !canCheckAvail && (
+            <p className="text-xs text-gray-500">
+              Set start and end times to check if it&rsquo;s free.
+            </p>
+          )}
+          {canCheckAvail &&
+            (availability.data ? (
+              availability.data.available ? (
+                <p className="text-xs font-medium text-emerald-700">
+                  ✓ Free for the selected time.
+                </p>
+              ) : (
+                <p className="text-xs font-medium text-red-600">
+                  Already booked for this time — pick another time or facility.
+                </p>
+              )
+            ) : (
+              <p className="text-xs text-gray-500">Checking availability…</p>
+            ))}
         </div>
         <div className="space-y-1.5">
           <label className="block text-sm font-medium text-gray-700">

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { del } from "@vercel/blob";
 import type { PrismaClient } from "@prisma/client";
@@ -228,6 +229,26 @@ async function resolveFacility(
   return { facilityID, name: f.facilityName };
 }
 
+/**
+ * How many existing bookings overlap [startTime, endTime) on a facility. Uses
+ * the SAME half-open overlap predicate as createBooking's conflict check, so the
+ * pre-submit validation, the submit gate and the approval-time booking all agree
+ * on what "already booked" means.
+ */
+async function countFacilityConflicts(
+  db: PrismaClient,
+  facilityID: number,
+  startTime: number,
+  endTime: number,
+): Promise<number> {
+  return db.bookings.count({
+    where: {
+      facilityID,
+      AND: [{ endTime: { gt: startTime } }, { startTime: { lt: endTime } }],
+    },
+  });
+}
+
 /* -------------------------------------------------------------------------- */
 /* Router                                                                      */
 /* -------------------------------------------------------------------------- */
@@ -359,6 +380,34 @@ export const eventRouter = createTRPCRouter({
       return { ok: true };
     }),
 
+  /**
+   * Is a facility free for a time window? Drives the live "available / already
+   * booked" hint in the proposal form. Advisory only — availability can change
+   * before approval, so the real guards are submitForReview and decide. Any
+   * signed-in head may check; it exposes only a boolean + count, not who booked.
+   */
+  facilityAvailability: identifiedProcedure
+    .input(
+      z.object({
+        facilityID: z.number().int().positive(),
+        startTime: z.number().int().positive(),
+        endTime: z.number().int().positive(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      if (input.endTime <= input.startTime) {
+        return { available: false, conflicts: 0, badTime: true as const };
+      }
+      const conflicts = await countFacilityConflicts(
+        ctx.db,
+        input.facilityID,
+        input.startTime,
+        input.endTime,
+      );
+      return { available: conflicts === 0, conflicts, badTime: false as const };
+    }),
+
   submitForReview: identifiedProcedure
     .input(eventIdInput)
     .mutation(async ({ ctx, input }) => {
@@ -390,6 +439,29 @@ export const eventRouter = createTRPCRouter({
           code: "BAD_REQUEST",
           message: `INCOMPLETE:${missing.join(",")}`,
         });
+      }
+
+      // Validate facility availability at submit time — refuse to propose an
+      // event for a facility that is already booked for that window. This is an
+      // early gate, not a guarantee: the slot can still be taken before approval
+      // (decide handles that best-effort), but it stops the common case up front.
+      if (
+        event.facilityID != null &&
+        event.startTime != null &&
+        event.endTime != null
+      ) {
+        const conflicts = await countFacilityConflicts(
+          ctx.db,
+          event.facilityID,
+          event.startTime,
+          event.endTime,
+        );
+        if (conflicts > 0) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "FACILITY_UNAVAILABLE",
+          });
+        }
       }
 
       await ctx.db.event.update({
@@ -828,17 +900,13 @@ export const eventRouter = createTRPCRouter({
         const endTime = event.endTime;
         try {
           const result = await withFacilityLock(ctx.db, facilityID, async () => {
-            const conflicts = await ctx.db.bookings.findMany({
-              where: {
-                facilityID,
-                AND: [
-                  { endTime: { gt: startTime } },
-                  { startTime: { lt: endTime } },
-                ],
-              },
-              select: { id: true },
-            });
-            if (conflicts.length > 0) return { booked: false as const };
+            const conflicts = await countFacilityConflicts(
+              ctx.db,
+              facilityID,
+              startTime,
+              endTime,
+            );
+            if (conflicts > 0) return { booked: false as const };
             const bookingID = await nextBookingId(ctx.db);
             await ctx.db.bookings.create({
               data: {


### PR DESCRIPTION
> **Stacked on #74** (`event-facility-booking`). This targets that branch, so the diff is just the availability check. Merge #74 first, then this.

## What

Validates that a chosen facility is actually free for the event's time — so a head finds out *before* submitting, not when JCRC tries to approve.

## Changes

- **`event.facilityAvailability`** query → a live hint in the proposal form: once a facility and a valid start/end are set, it shows **"✓ Free for the selected time"** or **"Already booked — pick another time or facility."**
- **`submitForReview`** now refuses with `CONFLICT: FACILITY_UNAVAILABLE` when the facility already has an overlapping booking, so an obviously-conflicting event can't be proposed. (Still not a guarantee — the slot can change before approval, which `decide()` already handles best-effort.)
- All three paths — live check, submit gate, approval booking — share one `countFacilityConflicts` helper using the same half-open overlap predicate as `createBooking`, so they can't disagree on "already booked."

`tsc`, `eslint` (only the pre-existing `||`-fallback warning), and `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)