### PR TITLE
CCA members: full member details on click + Export to Excel

### DIFF
--- a/src/app/_components/RosterPanel.tsx
+++ b/src/app/_components/RosterPanel.tsx
@@ -13,12 +13,15 @@ import {
   AlertDialogTitle,
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
+import { Download } from "lucide-react";
 import type { RosterEntry } from "~/server/api/services/ccaRoster";
 import RosterTable, {
   rosterEntryKey,
   type RosterSelection,
+  type MemberDetail,
 } from "./RosterTable";
 import RosterDriftNote from "./RosterDriftNote";
+import { downloadXlsx } from "~/lib/xlsx";
 
 /** How a roster entry maps to a removeMembers target. */
 function removalTarget(entry: RosterEntry) {
@@ -51,10 +54,18 @@ export default function RosterPanel({
    * only decides whether the checkboxes are drawn.
    */
   manageMembers = false,
+  /**
+   * Enables the click-to-expand member details and the "Export to Excel"
+   * button by fetching cca.memberDirectory (the roster plus each member's full
+   * profile). Set ONLY by a head's own member list; the read-only /admin/ccas
+   * viewer leaves it off, so it makes no extra query and nothing is expandable.
+   */
+  enableDirectory = false,
 }: {
   ccaID: number;
   hideHeader?: boolean;
   manageMembers?: boolean;
+  enableDirectory?: boolean;
 }) {
   const utils = api.useUtils();
   // Selected members, by rosterEntryKey. Confirmation opens a dialog separately.
@@ -74,9 +85,61 @@ export default function RosterPanel({
     onSuccess: async () => {
       setConfirming(false);
       setSelected(new Set());
-      await utils.cca.getRoster.invalidate({ ccaID });
+      await Promise.all([
+        utils.cca.getRoster.invalidate({ ccaID }),
+        utils.cca.memberDirectory.invalidate({ ccaID }),
+      ]);
     },
   });
+
+  // Full per-member details, fetched only when the head's member list asks for
+  // them. Drives the expandable rows and the Excel export.
+  const directory = api.cca.memberDirectory.useQuery(
+    { ccaID },
+    { enabled: enableDirectory, retry: false },
+  );
+
+  // rosterEntryKey -> detail, so a table row can look up its own person.
+  const details = useMemo(() => {
+    const map = new Map<string, MemberDetail>();
+    for (const e of directory.data?.entries ?? []) map.set(e.rowKey, e);
+    return map;
+  }, [directory.data]);
+
+  function exportExcel() {
+    const dir = directory.data;
+    if (!dir) return;
+    const header = [
+      "Name",
+      "Email",
+      "Role",
+      "User ID",
+      "Matric",
+      "Block",
+      "Telegram",
+      "Bio",
+      "Membership records",
+      "Notes",
+    ];
+    const rows = dir.entries.map((e) => [
+      e.name ?? (e.resolved ? "" : "Unmatched record"),
+      e.email ?? "",
+      e.role,
+      e.userID ?? "",
+      e.matric ?? "",
+      e.block != null ? String(e.block) : "",
+      e.telegramHandle ? `@${e.telegramHandle}` : "",
+      e.bio ?? "",
+      String(e.membershipRecords),
+      e.note ?? "",
+    ]);
+    const slug =
+      (dir.cca.ccaName ?? `cca-${ccaID}`)
+        .replace(/[^a-z0-9]+/gi, "-")
+        .replace(/^-+|-+$/g, "")
+        .toLowerCase() || `cca-${ccaID}`;
+    downloadXlsx(`${slug}-members`, "Members", [header, ...rows]);
+  }
 
   // Memoised so the `?? []` fallback doesn't mint a new array every render and
   // churn the selection memo below. react-query's `data` is reference-stable
@@ -174,6 +237,25 @@ export default function RosterPanel({
 
   return (
     <div className="space-y-6">
+      {enableDirectory && (
+        <div className="flex items-center justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={exportExcel}
+            disabled={
+              directory.isPending ||
+              !!directory.error ||
+              (directory.data?.entries.length ?? 0) === 0
+            }
+            title="Download every member and their details as an Excel file"
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Export to Excel
+          </Button>
+        </div>
+      )}
+
       {!hideHeader && (
         <header>
           <h1 className="text-2xl font-semibold text-gray-900">
@@ -206,6 +288,7 @@ export default function RosterPanel({
         title="Heads"
         entries={heads}
         emptyCopy="Nobody is currently listed as a head of this CCA."
+        details={enableDirectory ? details : undefined}
       />
 
       {/* The bulk action bar. Reserves no space when nothing is selected, so it
@@ -241,6 +324,7 @@ export default function RosterPanel({
         entries={members}
         emptyCopy="No members are listed for this CCA yet."
         selection={selection}
+        details={enableDirectory ? details : undefined}
       />
 
       <AlertDialog

--- a/src/app/_components/RosterTable.tsx
+++ b/src/app/_components/RosterTable.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { Fragment, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
 import {
   Table,
   TableBody,
@@ -45,6 +48,26 @@ export type RosterSelection = {
   disabled: boolean;
 };
 
+/**
+ * Full profile detail for one member, keyed by rosterEntryKey. Supplied only on
+ * the head's own member list (via cca.memberDirectory); when absent the rows
+ * are not expandable and the table behaves exactly as before.
+ */
+export type MemberDetail = {
+  resolved: boolean;
+  role: "Head" | "Member";
+  name: string | null;
+  email: string | null;
+  userID: string | null;
+  matric: string | null;
+  block: number | null;
+  telegramHandle: string | null;
+  bio: string | null;
+  membershipRecords: number;
+  joinedAt: string | null;
+  note: string | null;
+};
+
 /** Head vs member, labelled on BOTH states — see the note in CcaBadges. */
 function RoleLabel({ isHead }: { isHead: boolean }) {
   return isHead ? (
@@ -85,7 +108,8 @@ function SelectCell({
 }) {
   const checked = selection.selectedKeys.has(rosterEntryKey(entry));
   return (
-    <TableCell className="w-0 pr-0">
+    // stopPropagation so ticking the box never also expands the row.
+    <TableCell className="w-0 pr-0" onClick={(e) => e.stopPropagation()}>
       <Checkbox
         checked={checked}
         disabled={selection.disabled}
@@ -100,26 +124,106 @@ function SelectCell({
   );
 }
 
+function Field({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+        {label}
+      </dt>
+      <dd
+        className="truncate text-sm text-gray-800"
+        title={value ?? undefined}
+      >
+        {value ?? <span className="text-gray-300">—</span>}
+      </dd>
+    </div>
+  );
+}
+
+/** The expanded detail panel shown under a member row when it is opened. */
+function DetailRow({
+  detail,
+  colSpan,
+}: {
+  detail: MemberDetail;
+  colSpan: number;
+}) {
+  const telegram = detail.telegramHandle ? `@${detail.telegramHandle}` : null;
+  const headSince =
+    detail.role === "Head" && detail.joinedAt
+      ? new Date(detail.joinedAt).toLocaleDateString("en-SG", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        })
+      : null;
+
+  const fields: { label: string; value: string | null }[] = [
+    { label: "Matric", value: detail.matric },
+    { label: "Block", value: detail.block != null ? String(detail.block) : null },
+    { label: "Email", value: detail.email },
+    { label: "Telegram", value: telegram },
+    { label: "User ID", value: detail.userID },
+    { label: "Membership records", value: String(detail.membershipRecords) },
+    ...(headSince ? [{ label: "Head since", value: headSince }] : []),
+  ];
+
+  return (
+    <TableRow className="bg-gray-50 hover:bg-gray-50">
+      <TableCell colSpan={colSpan} className="py-4">
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2.5 sm:grid-cols-3">
+          {fields.map((f) => (
+            <Field key={f.label} label={f.label} value={f.value} />
+          ))}
+        </dl>
+        {detail.bio?.trim() && (
+          <div className="mt-3">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-gray-400">
+              About
+            </p>
+            <p className="mt-0.5 whitespace-pre-line text-sm text-gray-700">
+              {detail.bio}
+            </p>
+          </div>
+        )}
+        {detail.note && (
+          <p className="mt-3 text-sm text-amber-700">{detail.note}</p>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
 function EntryRow({
   entry,
   selection,
+  detail,
+  expanded,
+  onToggleExpand,
+  colSpan,
 }: {
   entry: RosterEntry;
   selection?: RosterSelection;
+  /** When present, the row is expandable and reveals full member details. */
+  detail?: MemberDetail;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  colSpan: number;
 }) {
   const duplicate = entry.userCcaRowCount > 1;
   const selected =
     selection?.selectedKeys.has(rosterEntryKey(entry)) ?? false;
+  const expandable = detail != null;
 
   if (entry.kind === "unresolved") {
-    const { label, detail } = unresolvedCopy(entry);
+    const { label, detail: tip } = unresolvedCopy(entry);
     return (
       <TableRow
         className={selected ? "bg-amber-100" : "border-amber-200 bg-amber-50"}
       >
         {selection && <SelectCell entry={entry} selection={selection} />}
         <TableCell className="font-medium text-amber-900">
-          <span title={detail}>{label}</span>
+          <span title={tip}>{label}</span>
           {duplicate && (
             <span className="ml-2 text-xs font-normal text-amber-700">
               · {entry.userCcaRowCount} membership records
@@ -135,26 +239,48 @@ function EntryRow({
   }
 
   return (
-    <TableRow className={selected ? "bg-emerald-50" : undefined}>
-      {selection && <SelectCell entry={entry} selection={selection} />}
-      <TableCell className="font-medium text-gray-900">
-        {entry.displayName ?? (
-          <span className="text-gray-500">No name on file</span>
-        )}
-        {duplicate && (
-          <span
-            className="ml-2 text-xs font-normal text-amber-700"
-            title="This person has more than one membership record for this CCA. Harmless, but worth cleaning up."
-          >
-            · {entry.userCcaRowCount} membership records
+    <Fragment>
+      <TableRow
+        className={[
+          selected ? "bg-emerald-50" : undefined,
+          expandable ? "cursor-pointer" : undefined,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onClick={expandable ? onToggleExpand : undefined}
+        aria-expanded={expandable ? expanded : undefined}
+      >
+        {selection && <SelectCell entry={entry} selection={selection} />}
+        <TableCell className="font-medium text-gray-900">
+          <span className="inline-flex items-center gap-1.5">
+            {expandable &&
+              (expanded ? (
+                <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+              ) : (
+                <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" />
+              ))}
+            {entry.displayName ?? (
+              <span className="text-gray-500">No name on file</span>
+            )}
           </span>
-        )}
-      </TableCell>
-      <TableCell className="text-gray-600">{entry.email}</TableCell>
-      <TableCell className="text-right">
-        <RoleLabel isHead={entry.isHead} />
-      </TableCell>
-    </TableRow>
+          {duplicate && (
+            <span
+              className="ml-2 text-xs font-normal text-amber-700"
+              title="This person has more than one membership record for this CCA. Harmless, but worth cleaning up."
+            >
+              · {entry.userCcaRowCount} membership records
+            </span>
+          )}
+        </TableCell>
+        <TableCell className="text-gray-600">{entry.email}</TableCell>
+        <TableCell className="text-right">
+          <RoleLabel isHead={entry.isHead} />
+        </TableCell>
+      </TableRow>
+      {expandable && expanded && (
+        <DetailRow detail={detail} colSpan={colSpan} />
+      )}
+    </Fragment>
   );
 }
 
@@ -170,12 +296,33 @@ export default function RosterTable({
    * assertHeadsCca; this only decides whether to draw the checkboxes.
    */
   selection,
+  /**
+   * Per-member full details, keyed by rosterEntryKey. Supplied only on a head's
+   * own member list; when present, resolved rows become expandable to reveal
+   * matric, block, telegram, etc. Absent on the read-only viewer, so nothing
+   * there is clickable.
+   */
+  details,
 }: {
   title: string;
   entries: RosterEntry[];
   emptyCopy: string;
   selection?: RosterSelection;
+  details?: Map<string, MemberDetail>;
 }) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpand = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  // Name + Email + Role, plus the select column when present. The expanded
+  // detail row spans all of them.
+  const colSpan = (selection ? 1 : 0) + 3;
+
   return (
     <section>
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
@@ -210,13 +357,22 @@ export default function RosterTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {entries.map((e) => (
-                <EntryRow
-                  key={rosterEntryKey(e)}
-                  entry={e}
-                  selection={selection}
-                />
-              ))}
+              {entries.map((e) => {
+                const key = rosterEntryKey(e);
+                const detail =
+                  e.kind === "resolved" ? details?.get(key) : undefined;
+                return (
+                  <EntryRow
+                    key={key}
+                    entry={e}
+                    selection={selection}
+                    detail={detail}
+                    expanded={expanded.has(key)}
+                    onToggleExpand={() => toggleExpand(key)}
+                    colSpan={colSpan}
+                  />
+                );
+              })}
             </TableBody>
           </Table>
         </div>

--- a/src/app/cca/[ccaID]/members/page.tsx
+++ b/src/app/cca/[ccaID]/members/page.tsx
@@ -21,5 +21,7 @@ export default function CcaMembersPage({
   const ccaID = parseCcaID(params.ccaID);
   if (ccaID === null) notFound();
 
-  return <RosterPanel ccaID={ccaID} hideHeader manageMembers />;
+  return (
+    <RosterPanel ccaID={ccaID} hideHeader manageMembers enableDirectory />
+  );
 }

--- a/src/lib/xlsx.ts
+++ b/src/lib/xlsx.ts
@@ -1,0 +1,230 @@
+/**
+ * Minimal, dependency-free .xlsx writer — enough to export a single sheet of
+ * text cells that Excel (and Numbers / Google Sheets) opens as a real
+ * spreadsheet, with no "format/extension mismatch" warning and no npm
+ * dependency added to a repo we're keeping lean.
+ *
+ * An .xlsx is a ZIP of a few XML parts (OOXML / SpreadsheetML). We emit the
+ * minimal valid set and store the entries UNCOMPRESSED (ZIP method 0), so the
+ * only binary machinery needed is a CRC-32 and the ZIP record layout — no
+ * DEFLATE. Member exports are at most a couple of hundred rows, so the size
+ * cost of not compressing is negligible.
+ *
+ * Every cell is written as an inline string (`t="inlineStr"`). That is
+ * deliberate: values like a matric number ("A0234567X") or a block ("12") must
+ * stay text, never be coerced to a number or a date by Excel's type guessing.
+ *
+ * Client-only (uses TextEncoder / Blob / document) — import from client
+ * components. It never touches the server.
+ */
+
+/* --------------------------------- CRC-32 -------------------------------- */
+
+const CRC_TABLE: Uint32Array = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let c = 0xffffffff;
+  for (const b of bytes) {
+    c = (CRC_TABLE[(c ^ b) & 0xff]! ^ (c >>> 8)) >>> 0;
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+/* ------------------------------ XML building ----------------------------- */
+
+/** Escape text for an XML text node, dropping characters XML cannot carry. */
+function xmlEsc(s: string): string {
+  return s
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** 0 -> "A", 25 -> "Z", 26 -> "AA" … */
+function colRef(index: number): string {
+  let s = "";
+  let n = index + 1;
+  while (n > 0) {
+    const m = (n - 1) % 26;
+    s = String.fromCharCode(65 + m) + s;
+    n = Math.floor((n - 1) / 26);
+  }
+  return s;
+}
+
+function sheetXml(rows: string[][]): string {
+  const body = rows
+    .map((row, r) => {
+      const cells = row
+        .map((value, c) => {
+          const ref = `${colRef(c)}${r + 1}`;
+          return `<c r="${ref}" t="inlineStr"><is><t xml:space="preserve">${xmlEsc(
+            value ?? "",
+          )}</t></is></c>`;
+        })
+        .join("");
+      return `<row r="${r + 1}">${cells}</row>`;
+    })
+    .join("");
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    `<sheetData>${body}</sheetData></worksheet>`
+  );
+}
+
+function workbookXml(sheetName: string): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+    `<sheets><sheet name="${xmlEsc(sheetName)}" sheetId="1" r:id="rId1"/></sheets>` +
+    "</workbook>"
+  );
+}
+
+const CONTENT_TYPES =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+  '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+  "</Types>";
+
+const ROOT_RELS =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+  "</Relationships>";
+
+const WORKBOOK_RELS =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+  "</Relationships>";
+
+/* -------------------------------- ZIP (stored) --------------------------- */
+
+const te = new TextEncoder();
+
+function u16(n: number): number[] {
+  return [n & 0xff, (n >>> 8) & 0xff];
+}
+function u32(n: number): number[] {
+  return [n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff, (n >>> 24) & 0xff];
+}
+
+export function buildXlsx(sheetName: string, rows: string[][]): Uint8Array {
+  const parts: { name: string; text: string }[] = [
+    { name: "[Content_Types].xml", text: CONTENT_TYPES },
+    { name: "_rels/.rels", text: ROOT_RELS },
+    { name: "xl/workbook.xml", text: workbookXml(sheetName) },
+    { name: "xl/_rels/workbook.xml.rels", text: WORKBOOK_RELS },
+    { name: "xl/worksheets/sheet1.xml", text: sheetXml(rows) },
+  ];
+
+  const entries = parts.map((p) => {
+    const data = te.encode(p.text);
+    return { nameBytes: te.encode(p.name), data, crc: crc32(data) };
+  });
+
+  const local: number[] = [];
+  const central: number[] = [];
+  const offsets: number[] = [];
+
+  for (const e of entries) {
+    offsets.push(local.length);
+    local.push(
+      ...u32(0x04034b50), // local file header signature
+      ...u16(20), // version needed
+      ...u16(0), // flags
+      ...u16(0), // method 0 = stored
+      ...u16(0), // mod time
+      ...u16(0), // mod date
+      ...u32(e.crc),
+      ...u32(e.data.length), // compressed size
+      ...u32(e.data.length), // uncompressed size
+      ...u16(e.nameBytes.length),
+      ...u16(0), // extra length
+      ...e.nameBytes,
+      ...e.data,
+    );
+  }
+
+  entries.forEach((e, i) => {
+    central.push(
+      ...u32(0x02014b50), // central directory header signature
+      ...u16(20), // version made by
+      ...u16(20), // version needed
+      ...u16(0), // flags
+      ...u16(0), // method
+      ...u16(0), // mod time
+      ...u16(0), // mod date
+      ...u32(e.crc),
+      ...u32(e.data.length),
+      ...u32(e.data.length),
+      ...u16(e.nameBytes.length),
+      ...u16(0), // extra length
+      ...u16(0), // comment length
+      ...u16(0), // disk number start
+      ...u16(0), // internal attrs
+      ...u32(0), // external attrs
+      ...u32(offsets[i]!),
+      ...e.nameBytes,
+    );
+  });
+
+  const eocd: number[] = [
+    ...u32(0x06054b50), // end of central directory signature
+    ...u16(0), // disk number
+    ...u16(0), // disk with central dir
+    ...u16(entries.length),
+    ...u16(entries.length),
+    ...u32(central.length),
+    ...u32(local.length), // offset of central directory
+    ...u16(0), // comment length
+  ];
+
+  return Uint8Array.from([...local, ...central, ...eocd]);
+}
+
+/* --------------------------------- Public -------------------------------- */
+
+/** Excel sheet names cap at 31 chars and forbid a handful of characters. */
+function safeSheetName(name: string): string {
+  const cleaned = name.replace(/[\\/?*[\]:]/g, " ").trim().slice(0, 31);
+  return cleaned.length > 0 ? cleaned : "Sheet1";
+}
+
+/**
+ * Build a single-sheet .xlsx from `rows` (first row is treated as headers by
+ * the reader, but we do not style it) and trigger a browser download.
+ */
+export function downloadXlsx(
+  filename: string,
+  sheetName: string,
+  rows: string[][],
+): void {
+  const bytes = buildXlsx(safeSheetName(sheetName), rows);
+  const blob = new Blob([bytes], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".xlsx") ? filename : `${filename}.xlsx`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -157,6 +157,130 @@ export const ccaRouter = createTRPCRouter({
     }),
 
   /**
+   * The roster PLUS each resolved person's profile details (matric, block,
+   * telegram, bio) and the keys that resolved to them. Powers the
+   * click-to-expand member details and the "Export to Excel" download on a
+   * head's member list.
+   *
+   * Head-only and per-CCA (assertHeadsCca), and it exposes EXACTLY the detail
+   * set the Applications tab already shows a head (matric/telegram/bio), so it
+   * opens no new sensitivity boundary. Profile fields are read by the EXACT
+   * User.id resolveRoster already matched — no email guessing here — and
+   * selected EXPLICITLY: never a bare User read (passwordHash must not leave the
+   * server, and a passwordHash-less Google-adapter row throws on a full read,
+   * I-2). Matric lives in UserMatric keyed by canonical userID, so every key a
+   * member might be filed under is tried.
+   *
+   * Entries include heads as well as members (with a `role`), so the export is
+   * the whole roster; the members and heads tables map back to it by `rowKey`.
+   */
+  memberDirectory: identifiedProcedure
+    .input(z.object({ ccaID: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const scope = await assertHeadsCca(
+        ctx.db,
+        { userID, roles },
+        input.ccaID,
+      );
+
+      const roster = await resolveRoster(ctx.db, input.ccaID);
+      const entries = [...roster.heads, ...roster.members];
+
+      const userIds: string[] = [];
+      const matricKeys = new Set<string>();
+      for (const e of entries) {
+        if (e.kind !== "resolved") continue;
+        userIds.push(e.userId);
+        for (const k of e.membershipKeys) matricKeys.add(k);
+        if (e.storedUserID) matricKeys.add(e.storedUserID);
+        const cid = canonicalUserID(e.email);
+        if (cid) matricKeys.add(cid);
+      }
+
+      const [profiles, matrics] = await Promise.all([
+        userIds.length === 0
+          ? Promise.resolve(
+              [] as {
+                id: string;
+                telegramHandle: string | null;
+                block: number | null;
+                bio: string | null;
+              }[],
+            )
+          : ctx.db.user.findMany({
+              where: { id: { in: userIds } },
+              select: {
+                id: true,
+                telegramHandle: true,
+                block: true,
+                bio: true,
+              },
+            }),
+        matricKeys.size === 0
+          ? Promise.resolve([] as { userID: string; matric: string }[])
+          : ctx.db.userMatric.findMany({
+              where: { userID: { in: [...matricKeys] } },
+              select: { userID: true, matric: true },
+            }),
+      ]);
+
+      const profileById = new Map(profiles.map((p) => [p.id, p]));
+      const matricByKey = new Map(matrics.map((m) => [m.userID, m.matric]));
+
+      const directory = entries.map((e) => {
+        const role: "Head" | "Member" = e.isHead ? "Head" : "Member";
+        if (e.kind !== "resolved") {
+          return {
+            rowKey: `k:${e.key}`,
+            resolved: false,
+            role,
+            name: null,
+            email: null,
+            userID: e.key,
+            matric: null,
+            block: null,
+            telegramHandle: null,
+            bio: null,
+            membershipRecords: e.userCcaRowCount,
+            joinedAt: e.grantedAt ? e.grantedAt.toISOString() : null,
+            note:
+              e.reason === "AMBIGUOUS_KEY"
+                ? "Ambiguous record — more than one account claims this membership."
+                : "Unmatched record — no account matches this membership key.",
+          };
+        }
+        const prof = profileById.get(e.userId);
+        let matric: string | null = null;
+        const cid = canonicalUserID(e.email);
+        for (const k of [...e.membershipKeys, e.storedUserID, cid]) {
+          if (k && matricByKey.has(k)) {
+            matric = matricByKey.get(k) ?? null;
+            if (matric) break;
+          }
+        }
+        return {
+          rowKey: `u:${e.userId}`,
+          resolved: true,
+          role,
+          name: e.displayName,
+          email: e.email,
+          userID: e.storedUserID,
+          matric,
+          block: prof?.block ?? null,
+          telegramHandle: prof?.telegramHandle ?? null,
+          bio: prof?.bio ?? null,
+          membershipRecords: e.userCcaRowCount,
+          joinedAt: e.grantedAt ? e.grantedAt.toISOString() : null,
+          note: null,
+        };
+      });
+
+      return { cca: roster.cca, via: scope.via, entries: directory };
+    }),
+
+  /**
    * The CCA's editable profile. Separate from getRoster because the details
    * page needs none of the roster's expensive resolution, and the overview
    * needs the roster without waiting on this.


### PR DESCRIPTION
## What

Two improvements to a CCA head's **member list** (`/cca/[ccaID]/members`):

1. **Click a member to see all their info.** A member row now expands to a details panel showing **matric, block, email, Telegram, user ID, membership records** and **bio** (plus "head since" for heads).
2. **Export to Excel.** A button downloads the whole roster (heads + members, with a Role column) as a real **`.xlsx`** file.

## How

- New head-guarded **`cca.memberDirectory`** procedure enriches the roster with each resolved person's profile. It reuses the **exact resolution the Applications tab already uses** (`resolveApplicants`-style), so it exposes nothing a head couldn't already see — **no new sensitivity boundary**. Profile fields are read by the exact `User.id` the roster matched (no email guessing) and selected explicitly (never a bare `User` read — I-2).
- **`RosterTable`** gains an optional `details` map: resolved rows become expandable. Absent on the read-only `/admin/ccas` viewer, so nothing there is clickable.
- **`src/lib/xlsx.ts`** — a small, **dependency-free** OOXML + stored-ZIP writer (CRC-32 + minimal workbook parts). No npm package added. Cells are inline strings so a matric like `A0234567X` stays text.

## Verification

- `tsc --noEmit` — clean · `eslint` — clean
- The `.xlsx` output validated against a ZIP/XML parser: valid archive, well-formed OOXML, and values round-trip correctly including `<`, `&`, `"`, unicode names, empty cells and preserved newlines.
- `/cca/[ccaID]/members` compiles with no errors and correctly redirects an unauthenticated request to login.

## Notes / choices (easy to change)

- **Export scope:** the full roster (heads + members). Can be made members-only.
- **Audit:** the export is un-audited, matching how the Applications tab treats viewing details. Could add an audit row like the Events attendee export if a paper trail is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)