### PR TITLE
Fix: bug-report footer overlaid the sign-up link on mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,12 +19,19 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className={`${GeistSans.variable}`}>
-      <body className="min-h-screen bg-gray-100">
+      <body className="flex min-h-screen flex-col bg-gray-100">
         <SessionProviderWrapper>
-          <TRPCReactProvider>
-            <MatricGate>{children}</MatricGate>
-          </TRPCReactProvider>
-          <footer className="fixed bottom-0 w-full bg-emerald-800 py-4 text-center text-sm text-white">
+          {/* flex-1 so the footer sits BELOW the content and is pushed to the
+              bottom of the viewport on short pages. It used to be `fixed`, which
+              overlaid the bottom of every page — on mobile that covered the
+              sign-up / log-in link at the foot of the auth card. In normal flow
+              it stays visible without ever blocking anything. */}
+          <main className="flex-1">
+            <TRPCReactProvider>
+              <MatricGate>{children}</MatricGate>
+            </TRPCReactProvider>
+          </main>
+          <footer className="bg-emerald-800 py-4 text-center text-sm text-white">
             Thanks for using the RH App! Feel free to report bugs or suggest
             features via form:
             <a


### PR DESCRIPTION
## Problem

The global "Thanks for using the RH App… report bugs" footer was `position: fixed`, so it overlaid the bottom of every page. On mobile this covered the **sign-up / log-in link** at the foot of the auth card, making it untappable.

## Fix

Kept the footer (and its bug-report link) but moved it into **normal document flow** instead of overlaying:

- `body` is now a flex column (`flex min-h-screen flex-col`).
- Page content sits in a `flex-1` `<main>`, so the footer is pushed to the bottom of the viewport on short pages and follows the content on tall ones.
- Footer loses `fixed bottom-0` — it can no longer sit on top of anything.

No page loses the footer, and nothing is hidden behind it anymore.

## Verification

- `tsc --noEmit` — clean · `eslint` — clean
- Rendered `/signup`: footer is now `bg-emerald-800 …` with **no `fixed`**, `body` is `flex min-h-screen flex-col`, and content is wrapped in `<main class="flex-1">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)