### PR TITLE
Strict profile gate: require complete, proper details before app access

### DIFF
--- a/src/app/_components/EditProfileModal.tsx
+++ b/src/app/_components/EditProfileModal.tsx
@@ -18,6 +18,11 @@ import {
   MATRIC_RE,
   updateProfileInput,
 } from "~/lib/schemas/profile";
+import {
+  isDisplayNameValid,
+  PROFILE_FIELD_LABEL,
+  type ProfileField,
+} from "~/lib/profileCompleteness";
 
 interface EditProfileModalProps {
   isOpen: boolean;
@@ -36,6 +41,21 @@ interface EditProfileModalProps {
   /** Given the message to surface, so the toast reflects what ACTUALLY saved
    *  rather than a fixed "Profile updated" that lies on a partial save. */
   onSuccess: (message: string) => void;
+  /**
+   * FORCED (profile-completion) mode. When true the dialog cannot be dismissed
+   * — no Close button, Escape and overlay-click are ignored — and the copy
+   * switches to "complete your profile to continue". Used by the strict profile
+   * gate on /profile.
+   */
+  forced?: boolean;
+  /** In forced mode, the fields that must be filled/valid before Save. */
+  requiredFields?: ProfileField[];
+  /** Identity, so the display-name rule (not your NUSNET id/email/matric) can
+   *  be mirrored client-side exactly as the server enforces it. */
+  identity?: { userID: string | null; email: string | null; matric: string };
+  /** Called after a successful save INSTEAD of onClose when forced — the parent
+   *  refreshes the session so the gate re-evaluates and unmounts this itself. */
+  onSaved?: () => void | Promise<void>;
 }
 
 /** The stored form of a typed matric. Matches the server's own transform
@@ -55,7 +75,12 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
   onClose,
   initialData,
   onSuccess,
+  forced = false,
+  requiredFields = [],
+  identity,
+  onSaved,
 }) => {
+  const requires = (f: ProfileField) => forced && requiredFields.includes(f);
   const [displayName, setDisplayName] = useState<string>(
     initialData.displayName,
   );
@@ -118,6 +143,31 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
           : "Enter it in the format A0234567X — a letter, seven digits and a letter.";
     }
 
+    // Strict display-name rule (mirrors the server): not blank, and not just
+    // your NUSNET id / email / matric. Checked whenever identity is known, so a
+    // normal edit gets the same friendly inline error as the forced flow rather
+    // than a raw server rejection.
+    if (
+      identity &&
+      !isDisplayNameValid(displayName, {
+        userID: identity.userID,
+        email: identity.email,
+        matric: nextMatric || identity.matric,
+      })
+    ) {
+      errs.displayName ??=
+        "Enter your real name — not your NUSNET ID or email.";
+    }
+
+    // Forced-mode presence requirements: these fields are optional on a normal
+    // edit but mandatory when completing a profile.
+    if (requires("telegramHandle") && telegramHandle.trim() === "") {
+      errs.telegramHandle ??= "Enter your Telegram handle to continue.";
+    }
+    if (requires("matric") && nextMatric === "") {
+      errs.matric ??= "Enter your matriculation number to continue.";
+    }
+
     if (Object.keys(errs).length > 0) {
       setFieldErrors(errs);
       return;
@@ -160,12 +210,19 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
       );
       void utils.user.getCurrentUserData.invalidate();
 
-      onSuccess(
-        matricSaved
-          ? "Profile and matriculation number updated"
-          : "Profile updated successfully",
-      );
-      onClose();
+      if (forced) {
+        // The parent refreshes the session; the gate re-evaluates and unmounts
+        // this dialog itself once the profile is complete. Do NOT onClose here —
+        // a still-incomplete save (shouldn't happen, but safe) must keep it up.
+        await onSaved?.();
+      } else {
+        onSuccess(
+          matricSaved
+            ? "Profile and matriculation number updated"
+            : "Profile updated successfully",
+        );
+        onClose();
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : "Something went wrong.";
       // If matric went through and the profile write then failed, say so. The
@@ -192,18 +249,44 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
       onOpenChange={(open) => {
         // Radix gives us Escape, an overlay click, focus trapping, role="dialog"
         // and aria-modal for free. Do not hand-roll them again.
+        if (forced) return; // FORCED: non-dismissable — no close path at all.
         if (!open && !isPending) onClose();
       }}
     >
-      <DialogContent className="max-h-[90vh] overflow-y-auto bg-white sm:max-w-lg">
+      <DialogContent
+        // Forced mode: block every dismissal route Radix offers and hide the
+        // built-in close "X" (a direct-child absolute button) so there is no way
+        // out but completing the form.
+        onEscapeKeyDown={(e) => forced && e.preventDefault()}
+        onPointerDownOutside={(e) => forced && e.preventDefault()}
+        onInteractOutside={(e) => forced && e.preventDefault()}
+        className={`max-h-[90vh] overflow-y-auto bg-white sm:max-w-lg${
+          forced ? " [&>button.absolute]:hidden" : ""
+        }`}
+      >
         <DialogHeader>
           <DialogTitle className="text-2xl font-bold text-gray-800">
-            Edit Profile
+            {forced ? "Complete your profile" : "Edit Profile"}
           </DialogTitle>
           <DialogDescription className="text-sm text-gray-500">
-            Your email and roles cannot be changed here.
+            {forced
+              ? "Fill in the details below to continue using the RHApp."
+              : "Your email and roles cannot be changed here."}
           </DialogDescription>
         </DialogHeader>
+
+        {forced && requiredFields.length > 0 && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            Please add{" "}
+            {requiredFields.map((f, i) => (
+              <span key={f}>
+                {i > 0 && (i === requiredFields.length - 1 ? " and " : ", ")}
+                {PROFILE_FIELD_LABEL[f]}
+              </span>
+            ))}
+            .
+          </div>
+        )}
 
         {formError && (
           <div
@@ -260,7 +343,8 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
               />
             </div>
             <p className="mt-1 text-xs text-gray-500">
-              5–32 characters: letters, digits or _. Leave blank to remove it.
+              5–32 characters: letters, digits or _.
+              {requires("telegramHandle") ? "" : " Leave blank to remove it."}
             </p>
             {fieldErrors.telegramHandle && (
               <p className="mt-1 text-sm text-red-600">
@@ -349,14 +433,17 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
         </div>
 
         <DialogFooter className="mt-6 gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isPending}
-            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-          >
-            Close
-          </button>
+          {/* No Close in forced mode: the only way out is completing the form. */}
+          {!forced && (
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Close
+            </button>
+          )}
           <button
             type="button"
             onClick={() => void handleSubmit()}
@@ -365,7 +452,11 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
             disabled={isPending}
             className="rounded-md bg-emerald-600 px-4 py-2 text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {isPending ? "Saving…" : "Save Changes"}
+            {isPending
+              ? "Saving…"
+              : forced
+                ? "Save and continue"
+                : "Save Changes"}
           </button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/_components/MatricGate.tsx
+++ b/src/app/_components/MatricGate.tsx
@@ -111,14 +111,33 @@ export default function MatricGate({
     session?.user?.matricRequired === true &&
     session?.user?.hasMatric === false;
 
+  // STRICT PROFILE GATE (always on). The user's own details are missing or
+  // improper (blank/NUSNET-id name, no Telegram, no block, no matric). Send
+  // them to /profile, which shows a non-dismissable completion dialog. This
+  // sits ABOVE the matric branch on purpose: the profile gate already includes
+  // matric, so /profile is the single surface to fix everything, and a user is
+  // never bounced /onboarding/matric -> /profile for two different prompts.
+  const needsProfileDetails =
+    authed &&
+    !ineligible &&
+    !needsProfileCompletion &&
+    session?.user?.profileIncomplete === true;
+
   const redirectTo = ineligible
     ? "/onboarding/ineligible"
     : needsProfileCompletion
       ? "/onboarding/complete-profile"
-      : needsMatric
-        ? "/onboarding/matric"
-        : null;
-  const blocked = redirectTo !== null && !isAllowed(pathname);
+      : needsProfileDetails
+        ? "/profile"
+        : needsMatric
+          ? "/onboarding/matric"
+          : null;
+  // `pathname !== redirectTo` so the DESTINATION renders instead of blanking:
+  // /profile is not on the allow-list (it must stay gated for a COMPLETE user
+  // who is merely browsing), but the incomplete user we just sent there has to
+  // be able to see it and its dialog.
+  const blocked =
+    redirectTo !== null && !isAllowed(pathname) && pathname !== redirectTo;
 
   useEffect(() => {
     if (blocked && redirectTo) {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
+import type { ProfileField } from "~/lib/profileCompleteness";
 import {
   User,
   Mail,
@@ -34,6 +35,14 @@ const ProfilePage: React.FC = () => {
   const [openEditProfileModal, setOpenEditProfileModal] =
     useState<boolean>(false);
   const [showMatric, setShowMatric] = useState<boolean>(false);
+
+  const { data: session, update: updateSession } = useSession();
+  // STRICT PROFILE GATE. MatricGate has already routed an incomplete session
+  // here; this drives the non-dismissable completion dialog below. Read from
+  // the session (the gate's own source of truth) so the two never disagree.
+  const forcedIncomplete = session?.user?.profileIncomplete === true;
+  const missingFields = (session?.user?.profileMissingFields ??
+    []) as ProfileField[];
 
   const {
     data: user,
@@ -76,10 +85,10 @@ const ProfilePage: React.FC = () => {
           open. Without this the modal keeps abandoned edits from a previous
           cancel and presents them as the current profile. The `key` additionally
           remounts it if the underlying profile changes beneath an open modal. */}
-      {user && openEditProfileModal && (
+      {user && (openEditProfileModal || forcedIncomplete) && (
         <EditProfileModal
           key={user.id}
-          isOpen={openEditProfileModal}
+          isOpen={openEditProfileModal || forcedIncomplete}
           onClose={() => setOpenEditProfileModal(false)}
           initialData={{
             displayName: user.displayName ?? "",
@@ -91,6 +100,21 @@ const ProfilePage: React.FC = () => {
             matric: user.matric ?? "",
           }}
           onSuccess={handleEditSuccess}
+          // Passed in BOTH modes so a normal edit gets the same friendly
+          // "not your NUSNET id" inline error the forced flow does.
+          identity={{
+            userID: user.userID ?? null,
+            email: user.email ?? null,
+            matric: user.matric ?? "",
+          }}
+          forced={forcedIncomplete}
+          requiredFields={forcedIncomplete ? missingFields : undefined}
+          // Forced completion refreshes the session so MatricGate re-evaluates
+          // and this dialog unmounts itself once the profile is complete.
+          onSaved={async () => {
+            await updateSession();
+            await refetch();
+          }}
         />
       )}
 

--- a/src/lib/profileCompleteness.ts
+++ b/src/lib/profileCompleteness.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared profile-completeness rules — the ONE definition of "this user's
+ * details are filled in and not misused". Used by BOTH the session callback
+ * (server, to raise the gate flag) and the forced completion dialog (client, to
+ * mirror it), so the two can never disagree about who is gated.
+ *
+ * No server imports, so it is safe to value-import into a `"use client"`
+ * component (same rule as src/lib/schemas/profile.ts).
+ *
+ * The mandatory set is a product decision: a real display name, a Telegram
+ * handle, a block, and a matriculation number. Bio stays optional.
+ */
+
+export type ProfileField = "displayName" | "telegramHandle" | "block" | "matric";
+
+/** The fields a user must have before they may use the app. */
+export const REQUIRED_PROFILE_FIELDS: ProfileField[] = [
+  "displayName",
+  "telegramHandle",
+  "block",
+  "matric",
+];
+
+/** Human copy for each field, used in the completion dialog's checklist. */
+export const PROFILE_FIELD_LABEL: Record<ProfileField, string> = {
+  displayName: "a proper display name (not your NUSNET ID)",
+  telegramHandle: "your Telegram handle",
+  block: "your block",
+  matric: "your matriculation number",
+};
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+/** The local-part of an @-address, lowercased; "" if it is not an address. */
+function emailLocalPart(email: string | null | undefined): string {
+  if (!email) return "";
+  const at = email.indexOf("@");
+  return norm(at === -1 ? email : email.slice(0, at));
+}
+
+/**
+ * A display name is "proper" when it is present and is NOT just the user's own
+ * identifiers. Blank, too short, equal to or containing their NUSNET id, or
+ * equal to their email local-part or matric all count as improper — those are
+ * exactly the auto-filled / placeholder names we are stamping out (a lot of
+ * accounts currently have their NUSNET id as their name).
+ */
+export function isDisplayNameValid(
+  displayName: string | null | undefined,
+  identity: {
+    userID?: string | null;
+    email?: string | null;
+    matric?: string | null;
+  },
+): boolean {
+  const name = (displayName ?? "").trim();
+  if (name.length < 2) return false;
+  const n = norm(name);
+
+  const uid = identity.userID ? norm(identity.userID) : "";
+  // Equal to OR containing the NUSNET id: "E1234567" and "E1234567 Tan" are both
+  // rejected — the second is the "id with a bit tacked on" placeholder.
+  if (uid && (n === uid || n.includes(uid))) return false;
+
+  const local = emailLocalPart(identity.email);
+  if (local && n === local) return false;
+
+  const matric = identity.matric ? norm(identity.matric) : "";
+  if (matric && n === matric) return false;
+
+  return true;
+}
+
+export type ProfileSnapshot = {
+  displayName: string | null | undefined;
+  telegramHandle: string | null | undefined;
+  block: number | null | undefined;
+  matric: string | null | undefined;
+};
+
+/**
+ * The required fields this user has NOT satisfied. Empty => their profile is
+ * complete and proper, and the gate lets them through.
+ */
+export function computeProfileGaps(
+  profile: ProfileSnapshot,
+  identity: { userID?: string | null; email?: string | null },
+): ProfileField[] {
+  const gaps: ProfileField[] = [];
+  if (
+    !isDisplayNameValid(profile.displayName, {
+      ...identity,
+      matric: profile.matric,
+    })
+  ) {
+    gaps.push("displayName");
+  }
+  if (!(profile.telegramHandle ?? "").trim()) gaps.push("telegramHandle");
+  if (profile.block == null) gaps.push("block");
+  if (!(profile.matric ?? "").trim()) gaps.push("matric");
+  return gaps;
+}

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -10,6 +10,7 @@ import {
 } from "~/lib/schemas/profile";
 import type { PrismaClient } from "@prisma/client";
 import { getUserRoles } from "../services/access";
+import { isDisplayNameValid } from "~/lib/profileCompleteness";
 
 // Matric number: "A" + 7 digits + an uppercase letter, e.g. A0234567X. The
 // regex itself now lives in ~/lib/schemas/profile beside the other shared
@@ -380,6 +381,32 @@ export const userRouter = createTRPCRouter({
     .input(updateProfileInput)
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+      const userID = ctx.session.user.userID; // canonical E-format key (I-1)
+
+      // Strict profile gate (server side): a proper display name is enforced on
+      // EVERY save, not just the forced completion flow — otherwise a user could
+      // "fix" the gate by setting their name back to their NUSNET id and loop.
+      // Uses the SAME rule the client mirrors and the session callback gates on.
+      // Skipped for an empty identity (routed to /onboarding/ineligible anyway).
+      if (userID) {
+        const matricRow = await ctx.db.userMatric.findUnique({
+          where: { userID },
+          select: { matric: true },
+        });
+        if (
+          !isDisplayNameValid(input.displayName, {
+            userID,
+            email: ctx.session.user.email,
+            matric: matricRow?.matric ?? null,
+          })
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Enter your real name — not your NUSNET ID, email or matric number.",
+          });
+        }
+      }
 
       const updatedUser = await ctx.db.user.update({
         where: { id: userId },

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { env } from "~/env";
 import { db } from "~/server/db";
 import { verifyPassword } from "~/lib/password";
+import { computeProfileGaps } from "~/lib/profileCompleteness";
 import type { CanonicalUserID } from "~/lib/identity";
 import {
   canonicalUserID,
@@ -142,6 +143,20 @@ declare module "next-auth" {
        * Already-resolved rows read as `[]` — see the session callback.
        */
       profileNeedsFields: string[];
+      /**
+       * STRICT PROFILE GATE. `profileIncomplete` is true when the user's own
+       * details are missing or improper — a blank / NUSNET-id display name, no
+       * Telegram handle, no block, or no matric — per
+       * `src/lib/profileCompleteness.ts`. Evaluated for EVERY identified session
+       * with no kill switch: the product decision is to enforce this for
+       * everyone, immediately. The client `MatricGate` routes such a session to
+       * `/profile` and shows a non-dismissable completion dialog;
+       * `profileMissingFields` names the offending fields. A LIVE read (I-4):
+       * the moment the user fills the fields and the session refreshes, this
+       * clears — nothing is baked into the 30-day JWT.
+       */
+      profileIncomplete: boolean;
+      profileMissingFields: string[];
       /**
        * D-7. False only for a pre-cutover JWT on an ineligible address, or a
        * blank/malformed stored email. RENDER-ONLY — protectedProcedure
@@ -424,6 +439,12 @@ export const authOptions = {
           // there is nothing to look up on this branch, and looking it up with
           // "" would be the ""-keyed-row hazard of I-8d one collection over.
           session.user.profileNeedsFields = [];
+          // Non-blocking on this branch: an empty identity is routed to the
+          // ineligibility page before the profile gate is ever consulted, and
+          // "not incomplete" is the only correct value with no canonical id to
+          // key a profile read on.
+          session.user.profileIncomplete = false;
+          session.user.profileMissingFields = [];
           session.user.roles = [];
           session.user.isAdmin = false;
           return session;
@@ -453,13 +474,24 @@ export const authOptions = {
         // user. The two lookups beside it predate that rule; a NEW promise here
         // must not widen the blast radius, so a ProfileCompletion fault degrades
         // to "not flagged" (no prompt) rather than to "logged out".
-        const [record, roleRow, matricRequired, completionRow] =
+        const [record, roleRow, matricRequired, completionRow, userDoc] =
           await Promise.all([
             db.userMatric.findUnique({ where: { userID } }),
             db.userRole.findUnique({ where: { userID } }),
             isMatricRequired(db),
             db.profileCompletion
               .findUnique({ where: { userID } })
+              .catch(() => null),
+            // The live profile fields the strict gate checks. Read by primary
+            // key (session.user.id is the User _id) with an EXPLICIT select — a
+            // bare read throws on a passwordHash-less Google row (I-2), and the
+            // `.catch` upholds rule 1 (this callback must never throw): a fault
+            // degrades to "no profile data" -> not gated, never logged out.
+            db.user
+              .findUnique({
+                where: { id: session.user.id },
+                select: { displayName: true, telegramHandle: true, block: true },
+              })
               .catch(() => null),
           ]);
 
@@ -474,6 +506,26 @@ export const authOptions = {
           completionRow && completionRow.resolvedAt == null
             ? (completionRow.needsFields ?? [])
             : [];
+
+        // STRICT PROFILE GATE. Computed live from the profile fields + matric
+        // above, using the SAME rules the client dialog mirrors, so the two
+        // never disagree about who is gated. `userDoc` may be null if the read
+        // faulted — treat that as "no data to prove completeness", i.e. gated,
+        // EXCEPT it degrades safely: computeProfileGaps on all-null returns the
+        // full set, which routes to /profile where the user can fix it (never a
+        // hard lockout). A transient fault therefore over-prompts, not
+        // over-admits.
+        const profileGaps = computeProfileGaps(
+          {
+            displayName: userDoc?.displayName ?? null,
+            telegramHandle: userDoc?.telegramHandle ?? null,
+            block: userDoc?.block ?? null,
+            matric: record?.matric ?? null,
+          },
+          { userID, email: token.email },
+        );
+        session.user.profileMissingFields = profileGaps;
+        session.user.profileIncomplete = profileGaps.length > 0;
 
         // Legacy-tolerant read for the D-6 dual-write window. Removing this
         // fallback belongs to doc 06 — dropping it early silently demotes any


### PR DESCRIPTION
## What

Enforces that every signed-in user has **complete, proper profile details** before they can use the app. If details are missing or improper, they're sent to **/profile** and shown a **non-dismissable completion dialog** — the rest of the app is blocked until they fill it in.

### Required (per your call)
- **Display name** — non-empty, and **not** just their NUSNET id / email / matric (a lot of accounts currently have their NUSNET id as their name).
- **Telegram handle**
- **Block**
- **Matriculation number**

Bio stays optional. **Always on** — no kill switch (enforce immediately). Sends them to the **profile page + forced dialog**.

## How

- **`src/lib/profileCompleteness.ts`** — one shared rule set (`isDisplayNameValid`, `computeProfileGaps`) used by both the server gate and the client dialog, so they can't drift.
- **`auth.ts`** — the session callback computes `profileIncomplete` / `profileMissingFields` live from the user's profile + matric. The extra read is a primary-key `findUnique` with an explicit select (I-2), joined into the existing `Promise.all`; its `.catch` degrades to "prompt", never "log out".
- **`MatricGate`** — a new branch redirects an incomplete session to `/profile`; `/profile` itself renders (instead of blanking) so its dialog can show.
- **`EditProfileModal`** — a `forced` mode: non-dismissable (no close X, Escape or overlay-click), required-field validation, and a "Save and continue" button. On save it refreshes the session so the gate re-evaluates and the dialog unmounts itself.
- **`updateUserData`** — rejects an improper display name on **every** save (server is authoritative), so the gate can't be bypassed by re-saving a bad name, and normal edits get the same friendly inline error.

## Verification

- `tsc --noEmit` — clean · `eslint` — clean
- Unit-tested the rules: valid name passes; blank / one-char / equals-NUSNET / contains-NUSNET / equals-email-localpart / equals-matric all correctly rejected; gap computation correct.
- `/login`, `/profile`, `/` all compile and render (200), no runtime errors.

## Note on rollout

This is **on immediately** as requested. Because it evaluates every identified session, the first time each user signs in after deploy, anyone with a blank/NUSNET-id name (or missing Telegram/block/matric) is gated until they fix it — including admins/JCRC, who can still complete their own profile to get in. If you'd rather stage it, it's easy to put behind a kill switch later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)