### PR TITLE
Profile gate: judge the display name by shape, not by identity

### DIFF
--- a/src/app/_components/EditProfileModal.tsx
+++ b/src/app/_components/EditProfileModal.tsx
@@ -50,9 +50,6 @@ interface EditProfileModalProps {
   forced?: boolean;
   /** In forced mode, the fields that must be filled/valid before Save. */
   requiredFields?: ProfileField[];
-  /** Identity, so the display-name rule (not your NUSNET id/email/matric) can
-   *  be mirrored client-side exactly as the server enforces it. */
-  identity?: { userID: string | null; email: string | null; matric: string };
   /** Called after a successful save INSTEAD of onClose when forced — the parent
    *  refreshes the session so the gate re-evaluates and unmounts this itself. */
   onSaved?: () => void | Promise<void>;
@@ -77,7 +74,6 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
   onSuccess,
   forced = false,
   requiredFields = [],
-  identity,
   onSaved,
 }) => {
   const requires = (f: ProfileField) => forced && requiredFields.includes(f);
@@ -143,20 +139,12 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
           : "Enter it in the format A0234567X — a letter, seven digits and a letter.";
     }
 
-    // Strict display-name rule (mirrors the server): not blank, and not just
-    // your NUSNET id / email / matric. Checked whenever identity is known, so a
-    // normal edit gets the same friendly inline error as the forced flow rather
-    // than a raw server rejection.
-    if (
-      identity &&
-      !isDisplayNameValid(displayName, {
-        userID: identity.userID,
-        email: identity.email,
-        matric: nextMatric || identity.matric,
-      })
-    ) {
-      errs.displayName ??=
-        "Enter your real name — not your NUSNET ID or email.";
+    // Strict display-name rule (mirrors the server): not blank, and not an
+    // E-format NUSNET id. A check on the SHAPE of what was typed, so it needs no
+    // identity — see profileCompleteness.ts. Applied on a normal edit too, so it
+    // surfaces as this friendly inline error rather than a raw server rejection.
+    if (!isDisplayNameValid(displayName)) {
+      errs.displayName ??= "Enter your real name — not your NUSNET ID.";
     }
 
     // Forced-mode presence requirements: these fields are optional on a normal

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -100,13 +100,6 @@ const ProfilePage: React.FC = () => {
             matric: user.matric ?? "",
           }}
           onSuccess={handleEditSuccess}
-          // Passed in BOTH modes so a normal edit gets the same friendly
-          // "not your NUSNET id" inline error the forced flow does.
-          identity={{
-            userID: user.userID ?? null,
-            email: user.email ?? null,
-            matric: user.matric ?? "",
-          }}
           forced={forcedIncomplete}
           requiredFields={forcedIncomplete ? missingFields : undefined}
           // Forced completion refreshes the session so MatricGate re-evaluates

--- a/src/lib/profileCompleteness.ts
+++ b/src/lib/profileCompleteness.ts
@@ -29,46 +29,34 @@ export const PROFILE_FIELD_LABEL: Record<ProfileField, string> = {
   matric: "your matriculation number",
 };
 
-const norm = (s: string) => s.trim().toLowerCase();
-
-/** The local-part of an @-address, lowercased; "" if it is not an address. */
-function emailLocalPart(email: string | null | undefined): string {
-  if (!email) return "";
-  const at = email.indexOf("@");
-  return norm(at === -1 ? email : email.slice(0, at));
-}
+/**
+ * The ONE shape a display name may not take: an E-format NUSNET id.
+ *
+ * Narrow ON PURPOSE. The first version of this rule gated on the user's own
+ * identifiers rather than on the SHAPE of what they typed — it refused any name
+ * that contained their userID. That is right for an opaque id and UNSATISFIABLE
+ * for a name-derived one: "KE BANGYAN" over userID "BANGYAN" was refused every
+ * time it was typed, so that resident could not get through the gate at all, and
+ * 52 accounts here have digit-free, name-derived userIDs of the same shape. The
+ * rule is now purely about the string. "E1234567" is not a name; what else a
+ * resident calls themselves is their business.
+ *
+ * UNANCHORED, so the "id with a bit tacked on" placeholder ("E1234567 Tan") is
+ * refused too. Tested against the lowercased name, hence the lowercase `e`.
+ */
+const E_FORMAT_ID = /e\d{7}/;
 
 /**
- * A display name is "proper" when it is present and is NOT just the user's own
- * identifiers. Blank, too short, equal to or containing their NUSNET id, or
- * equal to their email local-part or matric all count as improper — those are
- * exactly the auto-filled / placeholder names we are stamping out (a lot of
- * accounts currently have their NUSNET id as their name).
+ * A display name is "proper" when it is present and is not an E-format NUSNET
+ * id. That is the whole rule — nothing about the account's own identity is
+ * consulted; see E_FORMAT_ID for why.
  */
 export function isDisplayNameValid(
   displayName: string | null | undefined,
-  identity: {
-    userID?: string | null;
-    email?: string | null;
-    matric?: string | null;
-  },
 ): boolean {
   const name = (displayName ?? "").trim();
   if (name.length < 2) return false;
-  const n = norm(name);
-
-  const uid = identity.userID ? norm(identity.userID) : "";
-  // Equal to OR containing the NUSNET id: "E1234567" and "E1234567 Tan" are both
-  // rejected — the second is the "id with a bit tacked on" placeholder.
-  if (uid && (n === uid || n.includes(uid))) return false;
-
-  const local = emailLocalPart(identity.email);
-  if (local && n === local) return false;
-
-  const matric = identity.matric ? norm(identity.matric) : "";
-  if (matric && n === matric) return false;
-
-  return true;
+  return !E_FORMAT_ID.test(name.toLowerCase());
 }
 
 export type ProfileSnapshot = {
@@ -82,19 +70,9 @@ export type ProfileSnapshot = {
  * The required fields this user has NOT satisfied. Empty => their profile is
  * complete and proper, and the gate lets them through.
  */
-export function computeProfileGaps(
-  profile: ProfileSnapshot,
-  identity: { userID?: string | null; email?: string | null },
-): ProfileField[] {
+export function computeProfileGaps(profile: ProfileSnapshot): ProfileField[] {
   const gaps: ProfileField[] = [];
-  if (
-    !isDisplayNameValid(profile.displayName, {
-      ...identity,
-      matric: profile.matric,
-    })
-  ) {
-    gaps.push("displayName");
-  }
+  if (!isDisplayNameValid(profile.displayName)) gaps.push("displayName");
   if (!(profile.telegramHandle ?? "").trim()) gaps.push("telegramHandle");
   if (profile.block == null) gaps.push("block");
   if (!(profile.matric ?? "").trim()) gaps.push("matric");

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -381,31 +381,21 @@ export const userRouter = createTRPCRouter({
     .input(updateProfileInput)
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const userID = ctx.session.user.userID; // canonical E-format key (I-1)
 
       // Strict profile gate (server side): a proper display name is enforced on
       // EVERY save, not just the forced completion flow — otherwise a user could
       // "fix" the gate by setting their name back to their NUSNET id and loop.
       // Uses the SAME rule the client mirrors and the session callback gates on.
-      // Skipped for an empty identity (routed to /onboarding/ineligible anyway).
-      if (userID) {
-        const matricRow = await ctx.db.userMatric.findUnique({
-          where: { userID },
-          select: { matric: true },
+      //
+      // No identity read any more: the rule is a check on the SHAPE of the name
+      // (an E-format id), not a comparison against this account's own userID /
+      // email / matric. See profileCompleteness.ts — the comparison version was
+      // unsatisfiable for name-derived NUSNET ids.
+      if (!isDisplayNameValid(input.displayName)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Enter your real name — not your NUSNET ID.",
         });
-        if (
-          !isDisplayNameValid(input.displayName, {
-            userID,
-            email: ctx.session.user.email,
-            matric: matricRow?.matric ?? null,
-          })
-        ) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message:
-              "Enter your real name — not your NUSNET ID, email or matric number.",
-          });
-        }
       }
 
       const updatedUser = await ctx.db.user.update({

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -515,15 +515,12 @@ export const authOptions = {
         // full set, which routes to /profile where the user can fix it (never a
         // hard lockout). A transient fault therefore over-prompts, not
         // over-admits.
-        const profileGaps = computeProfileGaps(
-          {
-            displayName: userDoc?.displayName ?? null,
-            telegramHandle: userDoc?.telegramHandle ?? null,
-            block: userDoc?.block ?? null,
-            matric: record?.matric ?? null,
-          },
-          { userID, email: token.email },
-        );
+        const profileGaps = computeProfileGaps({
+          displayName: userDoc?.displayName ?? null,
+          telegramHandle: userDoc?.telegramHandle ?? null,
+          block: userDoc?.block ?? null,
+          matric: record?.matric ?? null,
+        });
         session.user.profileMissingFields = profileGaps;
         session.user.profileIncomplete = profileGaps.length > 0;
 


### PR DESCRIPTION
## The bug

The strict profile gate refused any display name that **contained** the account's own NUSNET id. That is correct for an opaque id — it catches the `"E1234567 Tan"` placeholder — and unsatisfiable for a name-derived one.

`bangyan@u.nus.edu` has canonical userID `BANGYAN`, so `"KE BANGYAN"` contains their id by definition. Every real name they typed was rejected, with no way through the gate and no way into the app:

> Enter your real name — not your NUSNET ID or email.

52 accounts in production have digit-free, name-derived userIDs of the same shape (`G.S_SAMUEL`, `MINSHEN.CHIA`, `HANNAH.LIN`, …), so this was a live lockout waiting on whichever of them typed a name containing their id.

## The fix

`isDisplayNameValid` now tests only **what was typed**, not who typed it: present, and not an E-format NUSNET id. The regex is unanchored, so `"E1234567 Tan"` still fails.

Because the rule no longer consults identity, this also removes:

- the `identity` parameter from `isDisplayNameValid` and `computeProfileGaps`
- the `identity` prop from `EditProfileModal` (and its wiring in `/profile`)
- a `UserMatric` read in `updateUserData` that existed only to feed the old comparison

Error copy is now "Enter your real name — not your NUSNET ID." in all three enforcement points (session callback, tRPC mutation, client mirror), which stay a single shared rule.

## Verification

- `tsc --noEmit` clean, `next lint` clean on all changed files
- Measured against production (1256 users): **26** gated on display name before, **24** after. All 24 remaining are genuinely blank or one-character names — exactly what the gate is for.
- No data migration: `computeProfileGaps` runs live in the session callback, so affected users are through on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tYGVvASfVrPZQfK4eJsaw
