### PR TITLE
Group interview slots: a slot can seat N applicants

### DIFF
--- a/docs/plans/cca/01-group-interview-slots.md
+++ b/docs/plans/cca/01-group-interview-slots.md
@@ -1,0 +1,361 @@
+# 01 — Group interview slots (capacity > 1)
+
+**Ask:** a CCA head can decide that a given interview slot takes _N_ people instead of
+one, N chosen by them.
+
+**Status:** proposal. Nothing below is implemented.
+
+---
+
+## 0. Ground truth, verified against the repo
+
+### 0.1 The slot is a single-seat row
+
+`prisma/schema.prisma:532` — `CcaInterviewSlot` carries the claim as three scalars on
+the slot itself:
+
+```prisma
+bookedByUserID      String?
+bookedApplicationID Int?
+bookedAt            DateTime?
+```
+
+"Free" is spelled `bookedByUserID === null` in nine places. There is no seat entity and
+no count anywhere — occupancy is boolean by construction.
+
+### 0.2 The claim is already mirrored on the application
+
+`CcaApplication.interviewSlotID` (`prisma/schema.prisma:494`) points back at the slot,
+and **every writer maintains both sides inside one `withCcaLock` section**:
+
+| Site | Slot side | Application side |
+|---|---|---|
+| `ccaApplications.bookSlot` (`ccaApplications.ts:568`) | sets all three | `interviewSlotID = S`, status `interview_scheduled` |
+| `ccaApplications.cancelSlot` (`:647`) | `releaseSlotIfMine` (`:71`) | `interviewSlotID = null`, status `submitted` |
+| `ccaApplications.withdraw` (`:690`) | `releaseSlotIfMine` | `interviewSlotID = null`, status `withdrawn` |
+| head `cancelSlot` (`ccaApplicationsHead.ts:520`) | `canceledAt` + clears claim | conditional revert to `submitted` |
+| head `decide` → reject (`:823`) | clears claim **iff the slot is still future** | pointer deliberately **left** |
+| head `decide` → accept (`:750`) | untouched | untouched |
+
+So the system already has two sources of truth for "who holds this slot", kept in step by
+the per-CCA advisory lock. That is the thing to collapse, not to duplicate.
+
+### 0.3 What serializes a booking today
+
+`withCcaLock` (`services/ccaApplications.ts:138`) — a `BookingLock` document per
+`ccaApp:{ccaID}`, 30s staleness reclaim, the same mechanism `withFacilityLock` uses for
+room bookings. Every check-then-write in this workflow already runs inside it: two
+residents claiming a slot, the one-open-application check, two heads deciding at once.
+
+### 0.4 The null-vs-absent trap, restated
+
+`listSlots` (`ccaApplicationsHead.ts:303`), `openSlots` (`:365`), `clearFreeSlots`
+(`:607`) and `availableSlots` (`ccaApplications.ts:536`) all carry the same comment:
+**`{ canceledAt: null }` matches a stored null but NOT an absent field**, so freshly
+written rows must set every optional scalar EXPLICITLY and every "is it null" test is
+done in JS. Any new optional field inherits this rule.
+
+### 0.5 Everything that reads the claim
+
+Nine server sites (above, plus `listSlots`, `clearFreeSlots`, `getCca.openSlotCount`
+`ccaApplications.ts:265`, `availableSlots` `:551`) and four client ones:
+`InterviewSlots.tsx` (`freeCount:79`, `ScheduleView:452`, `SlotCard:539`),
+`CcaApplyPanel.tsx` (`SlotPicker`), `InterviewSessions.tsx` (run-sheet, reads the
+application's slot, not the claim), `MyApplicationsList.tsx` (own slot time only).
+
+---
+
+## 1. The design question
+
+Occupancy has to become a **number compared against a capacity**. Three ways to hold it.
+
+### Option A — seats as extra slot rows
+
+Capacity 3 = open three identical rows. No schema change.
+
+**Rejected.** `openSlots` refuses identical times as `DUPLICATE_SLOT` (`:384`) and
+overlapping times as `SLOT_OVERLAP` — those guards are precisely what stops a head
+double-opening a day, and relaxing them for this is how that protection dies. The head's
+schedule would render N identical cards, "edit seat 2 of 3" is meaningless, and lowering
+capacity means picking which rows to cancel. The zero-schema-change benefit is spent
+entirely on UI grouping that has to be written anyway.
+
+### Option B — a `CcaInterviewBooking` collection (one row per seat)
+
+`capacity Int?` on the slot, seat claims in their own collection with
+`@@unique([slotID, userID])` and `@@unique([applicationID])`.
+
+**Viable, and the strongest concurrency story:** with a unique index the database itself
+refuses a double claim, rather than the advisory lock. Cost: a new collection, a real
+backfill of every existing booked slot, and a third representation of "who holds this
+slot" living beside `CcaApplication.interviewSlotID` — a new drift pair of exactly the
+kind CH-1 documents.
+
+### Option C — capacity on the slot, occupancy DERIVED from the applications ✅
+
+```
+occupancy(S) = |{ CcaApplication : interviewSlotID === S }|
+```
+
+Add `capacity Int?` to the slot; **delete `bookedByUserID`, `bookedApplicationID`,
+`bookedAt`**. The application's pointer becomes the single source of truth for a claim.
+
+**This is the recommendation.** Why:
+
+1. **It removes a source of truth instead of adding one.** The mirror in §0.2 collapses
+   to one side. No new drift pair, no backfill of claim data — the data already exists on
+   the application side and is already maintained under the lock.
+2. **"One application, at most one seat" becomes structural.** The pointer is a single
+   scalar, so an application cannot hold two seats and cannot be counted twice — the
+   property Option B needs a unique index to buy. Re-booking the same slot is idempotent
+   for free.
+3. **Every missed reader is a compile error.** Deleting the three scalars from the Prisma
+   model means any code still asking `slot.bookedByUserID` fails `tsc`, instead of
+   silently reading "free" on a full slot. That is the mitigation this codebase's own
+   sentinel-bug-class doc argues for: make the absent value visible to the type system.
+4. **Capacity 1 is byte-for-byte today's behaviour**, so the rollout is inert until a
+   head types a bigger number.
+
+**What Option C gives up:** over-booking is prevented by `withCcaLock`, not by a unique
+index. That is the same guarantee the current single-seat claim, the one-open-application
+check, and the two-heads-deciding check already rely on. If that is judged insufficient,
+Option B is the upgrade path and the seat rows can be introduced later without changing
+the capacity field or any UI.
+
+---
+
+## 2. The model
+
+```prisma
+model CcaInterviewSlot {
+  id        String    @id @default(auto()) @map("_id") @db.ObjectId
+  slotID    Int       @unique(map: "slotID")
+  ccaID     Int
+  startTime Int?
+  endTime   Int?
+  location  String?
+  createdBy String?
+  /// How many applicants may claim this slot. ABSENT/null means 1 — every row
+  /// written before group slots existed. Normalise through slotCapacity() and
+  /// NEVER inline `?? 1`, so the legacy default lives in exactly one place.
+  capacity  Int?
+  canceledAt DateTime?
+  createdAt  DateTime? @default(now())
+
+  @@index([ccaID, startTime, endTime], map: "cca_time")
+}
+```
+
+Removed: `bookedByUserID`, `bookedApplicationID`, `bookedAt`, `@@index([bookedByUserID])`.
+
+On `CcaApplication`, add `@@index([interviewSlotID], map: "slot")` — occupancy is now a
+query on this field.
+
+**Prisma db push drops non-schema indexes.** List indexes on both collections before and
+after the push and restore anything not declared (this has bitten `email_unique_ci`
+before).
+
+---
+
+## 3. Server rules
+
+One helper module owns the arithmetic — `services/ccaApplications.ts`:
+
+```ts
+export const SLOT_CAPACITY_DEFAULT = 1;
+export const SLOT_CAPACITY_MAX = 20;
+
+/** Absent/null/0/negative all mean one seat. The ONLY place this default lives. */
+export function slotCapacity(c: number | null | undefined): number
+
+/** slotID -> seats taken, for one CCA. Projects interviewSlotID ONLY — this is
+ *  called on a resident path and must never read another applicant's row. */
+export async function occupancyBySlot(db, ccaID): Promise<Map<number, number>>
+```
+
+| Rule | Behaviour |
+|---|---|
+| **Claim** | inside `withCcaLock`: `occupancy(S) >= capacity(S)` → `SLOT_FULL`. `SLOT_TAKEN` is retired. |
+| **Re-claim same slot** | idempotent; the pointer already equals S, occupancy unchanged. |
+| **Release** | `interviewSlotID = null` on the application. `releaseSlotIfMine` disappears — there is no slot-side state left to release. |
+| **Free (for `clearFreeSlots`)** | `occupancy === 0`. A partially-filled slot is NOT free and is never bulk-cleared. |
+| **Edit time/location** | refused while `occupancy > 0` (today: refused while booked). Unchanged in spirit. |
+| **Edit capacity** | allowed at any time, including on an occupied slot. **Raising** re-opens the slot immediately. **Lowering below current occupancy** → `CAPACITY_BELOW_OCCUPANCY`, refused: nobody is evicted by an edit. |
+| **Head cancels a slot** | reverts **every** occupant to `submitted` (today: one), in one locked section, one audit row with a `batchId`. Confirm copy must name the count. |
+| **Reject one occupant** | frees that seat only — null that application's pointer when the slot is still future, which is exactly today's rule expressed on the pointer instead of the slot. |
+| **Accept** | leaves the pointer, as today: an accepted applicant's interview stays on the record. |
+| **Overlap between slots** | unchanged. A group slot is still one room at one time. |
+| **`MAX_SLOTS_PER_OPEN`** | unchanged at 50 slots. Seats cost no rows, so 50 × 20 is fine. |
+
+### Privacy
+
+A resident sees **counts only** — "3 of 5 seats left" — never who else booked. The head
+sees the roster. `occupancyBySlot` projects `interviewSlotID` and nothing else, so no
+applicant PII is even loaded on the resident path.
+
+---
+
+## 4. Schema (zod) changes — `src/lib/schemas/ccaApplication.ts`
+
+```ts
+export const SLOT_CAPACITY_MAX = 20;
+const capacity = z.number().int().min(1).max(SLOT_CAPACITY_MAX);
+
+slotDraftSchema: + capacity.default(1)          // applies to the whole generated batch
+editSlotInput:   + capacity.optional()          // omitted = leave unchanged
+```
+
+The SECURITY note at the top of that file still holds: `capacity` is a head-only field
+and must never appear on a resident input.
+
+New error vocabulary: `SLOT_FULL` (replaces `SLOT_TAKEN`), `CAPACITY_BELOW_OCCUPANCY`.
+Both need copy in `InterviewSlots.tsx` and `CcaApplyPanel.tsx`.
+
+---
+
+## 5. UI
+
+**Head — slot generator (`InterviewSlots.tsx:147`).** One new control beside "Minutes per
+interview": **"People per slot"**, default 1, presets 1 / 2 / 3 / 4 / 6 + custom. Applies
+to every slot in the generated batch. Preview chips gain "×N" when N > 1.
+
+**Head — slot card (`:539`).** Occupancy replaces the boolean:
+`2/4 booked`, names listed (truncate past three, "+2 more"). Fill state becomes
+three-way — white empty, amber partial, solid green full — so a half-empty group session
+is visible at a glance. Day-tab counts become seats, not slots.
+
+**Head — run-sheet (`InterviewSessions.tsx`).** Group applicants who share a slot under
+one session header — `10:00–10:30 · 4 applicants` — instead of four sibling rows. This is
+where a group interview actually gets run, and it is the main reason not to model seats as
+separate rows (Option A would fragment exactly this view).
+
+**Resident — slot picker (`CcaApplyPanel.tsx`).** Each open slot shows seats left; a slot
+with capacity > 1 is labelled **"Group interview · up to N people"**. Full slots are
+filtered out exactly as taken slots are today.
+
+> Turning up to a 1:1 and finding three other people is a bad surprise. The label is not
+> decoration — it is the reason to show capacity to residents at all.
+
+**Resident — `MyApplicationsList.tsx`.** No change; it shows the caller's own slot time.
+
+---
+
+## 6. Migration — `scripts/remediation/backfill-slot-capacity.mjs`
+
+Dry-run by default, `--commit` to write, full pre-image backup first, verify at the end —
+the house pattern (`reconcile-ccas.mjs`).
+
+1. **Gate on agreement.** For every slot with `bookedByUserID` set, assert the matching
+   application has `interviewSlotID === slotID`. Any disagreement is pre-existing drift:
+   print it and **abort**. Deriving occupancy from a pointer that is already wrong would
+   bake the error in.
+2. **Write `capacity: 1` EXPLICITLY** on every existing slot — not absent (§0.4).
+3. **Reconcile the reject case.** Null `interviewSlotID` on any application in a terminal
+   status whose slot no longer names it (`bookedApplicationID !== applicationID`). This is
+   the one place today's semantics live on the slot and not on the pointer; without it a
+   rejected applicant would keep occupying a future seat.
+4. **`$unset`** `bookedByUserID`, `bookedApplicationID`, `bookedAt`.
+5. **Verify:** no slot has occupancy > capacity; per-slot occupancy after == booked count
+   before; counts and the backup file are printed.
+
+Reversible: the backup holds every pre-image, and the three scalars are re-derivable from
+the application pointers.
+
+**Verification script** — extend the `verify-cca-roster.mjs` pattern with
+`verify-interview-slots.mjs`: occupancy ≤ capacity everywhere, no application pointing at
+a canceled or non-existent slot, no slot with capacity < 1.
+
+---
+
+## 7. Rollout
+
+No new kill switch. The whole surface is already behind `cca.applications.enabled`
+(`services/ccaApplications.ts:18`), and **capacity 1 is exactly today's behaviour**, so
+the feature is inert until a head types a number greater than 1.
+
+**The migration needs a quiesce window — this is not a zero-downtime change.** The flag
+is currently ON and residents are using the feature. `backfill-slot-capacity.mjs`
+snapshots both collections and then, in step 4, deletes the field that says which
+applicant a slot last belonged to. A head who REJECTS an applicant holding a future slot
+inside that window creates a reject-orphan the run cannot see — and once the field is
+gone, a re-run cannot classify it either, so the seat is held by a rejected application
+permanently while every check reports healthy. `--commit` therefore REFUSES to run while
+the flag is on (`--allow-live` overrides, and prints what it is risking).
+
+Order:
+
+```
+node scripts/remediation/set-cca-flag.mjs applications off --commit   # quiesce
+node scripts/remediation/backfill-slot-capacity.mjs                   # dry run, read the plan
+node scripts/remediation/backfill-slot-capacity.mjs --commit          # migrate
+npx prisma db push                                                    # then diff the index lists
+node scripts/remediation/verify-interview-slots.mjs                   # must PASS
+# deploy the new code
+node scripts/remediation/set-cca-flag.mjs applications on --commit    # <-- DO NOT FORGET
+```
+
+The last line is the one that gets missed. The switch is default-closed, so leaving it off
+locks every resident out of `/ccas` with no error anywhere. The window itself is seconds —
+34 slots and 63 applications — so quiescing costs almost nothing and buys the one failure
+mode of this migration that is both permanent and invisible.
+
+Then: heads opt in per slot.
+
+---
+
+## 8. Files this touches
+
+| File | Change |
+|---|---|
+| `prisma/schema.prisma` | `capacity`, drop three scalars + one index, add `interviewSlotID` index |
+| `src/lib/schemas/ccaApplication.ts` | capacity bounds, `slotDraftSchema`, `editSlotInput` |
+| `src/server/api/services/ccaApplications.ts` | `slotCapacity`, `occupancyBySlot`, constants |
+| `src/server/api/routers/ccaApplications.ts` | `bookSlot` (`SLOT_FULL`), `availableSlots`, `getCca.openSlotCount` → seats, `cancelSlot`, `withdraw`, delete `releaseSlotIfMine` |
+| `src/server/api/routers/ccaApplicationsHead.ts` | `openSlots`, `updateSlot`, `cancelSlot` (multi-revert), `clearFreeSlots`, `listSlots` (roster), `decide` |
+| `src/app/cca/_components/InterviewSlots.tsx` | capacity control, occupancy card, edit form |
+| `src/app/cca/_components/InterviewSessions.tsx` | group the run-sheet by slot |
+| `src/app/ccas/_components/CcaApplyPanel.tsx` | seats left, group label |
+| `scripts/remediation/backfill-slot-capacity.mjs` | new |
+| `scripts/remediation/verify-interview-slots.mjs` | new |
+
+Rough size: ~1 focused day, the migration and the run-sheet grouping being the two parts
+worth reviewing closely.
+
+---
+
+## 9. Edge cases the implementation must answer
+
+1. Legacy slot, `capacity` absent → 1, via `slotCapacity()` only.
+2. Two residents race for the last seat → `withCcaLock` serializes; the loser gets
+   `SLOT_FULL`, not a silent over-book.
+3. Head lowers capacity 4 → 2 on a slot holding 3 → refused, message names the occupancy.
+4. Head raises capacity on a full slot → bookable again immediately, no other write.
+5. Resident re-books the slot they already hold → no-op, occupancy unchanged (structural).
+6. Head cancels a group slot holding 4 → 4 reverts to `submitted`, one audit row, one
+   confirm dialog that says "4 applicants".
+7. One occupant rejected while the slot is future → that seat frees, the other three are
+   untouched.
+8. An occupant marked `interviewed` → pointer and seat both stay; the slot is history.
+9. Slot in the past → never bookable (`endTime > now`), unchanged.
+10. Capacity 1 throughout → the diff must be behaviourally invisible.
+
+---
+
+## 10. Decisions
+
+Settled with the owner, 2026-08-02:
+
+1. **Data model — Option C.** Capacity on the slot, occupancy derived from
+   `CcaApplication.interviewSlotID`, the three booking scalars deleted. Over-booking is
+   prevented by `withCcaLock`, the same guarantee the rest of this workflow trusts.
+   Option B (seat rows + unique index) remains the upgrade path if that is ever judged
+   insufficient — it changes neither the capacity field nor any UI.
+2. **Residents see seats left, plus an explicit group label** — "Group interview · up to
+   4 people — 3 seats left". Counts only; never who else booked.
+
+Assumed unless the owner says otherwise:
+
+3. **Max capacity 20.** Big enough for a mass audition, small enough that a typo is
+   caught.
+4. **Capacity is set per generated batch**, then editable per slot (subject to the
+   never-evict rule in §3).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -517,6 +517,17 @@ model CcaApplication {
   @@index([userID], map: "applicant")
   /// The duplicate-open-application check (one non-terminal row per person+CCA).
   @@index([ccaID, userID], map: "cca_applicant")
+  /// Everyone holding a seat on one slot. Serves the ONE query that filters on
+  /// this field alone: head `cancelSlot`'s updateMany, which reverts every
+  /// occupant of a slot it is about to cancel.
+  ///
+  /// It does NOT serve occupancyBySlot(), despite that being the field's main
+  /// reader — that function filters on `ccaID` (already covered by the ccaID
+  /// prefix of cca_status/cca_applicant) and reads interviewSlotID out of every
+  /// application for the CCA, counting in memory. That is a whole-CCA read on
+  /// every book, capacity edit and resident slot list; fine at ~63 applications
+  /// repo-wide, and the thing to revisit before it is thousands per CCA.
+  @@index([interviewSlotID], map: "slot")
 }
 
 /// An interview slot a CCA head opens from their availability; a resident then
@@ -524,27 +535,36 @@ model CcaApplication {
 /// UNIX epoch SECONDS (Int), not DateTime, and overlap is a range query, not a
 /// DB constraint (Mongo cannot express an overlapping-range unique index).
 ///
-/// A slot's lifecycle: created with bookedByUserID = null (open) → a resident's
-/// bookSlot sets bookedByUserID + bookedApplicationID under an advisory lock
-/// (withCcaLock) so two residents cannot claim the same slot. canceledAt marks
-/// a slot the head withdrew; a booked slot is reverted (application → submitted)
-/// before it is canceled, never hard-deleted out from under a resident.
+/// A slot's lifecycle: created open → residents claim seats under the per-CCA
+/// advisory lock (withCcaLock) so two of them cannot take the last seat.
+/// canceledAt marks a slot the head withdrew; every occupant is reverted
+/// (application → submitted) before it is canceled, never hard-deleted out from
+/// under a resident.
+///
+/// THERE IS NO CLAIM ON THIS ROW. `bookedByUserID`/`bookedApplicationID`/
+/// `bookedAt` were DELETED with group slots: occupancy is DERIVED as
+/// `count(CcaApplication where interviewSlotID == slotID)`, so the applicant's
+/// pointer is the single source of truth and the two sides cannot drift. They
+/// were removed rather than left unused precisely so that any reader still
+/// asking "is this slot booked?" fails to compile instead of silently reading
+/// "free" on a full slot.
 model CcaInterviewSlot {
-  id                  String    @id @default(auto()) @map("_id") @db.ObjectId
-  slotID              Int       @unique(map: "slotID")
-  ccaID               Int
-  startTime           Int?
-  endTime             Int?
-  location            String?
-  createdBy           String?
-  bookedByUserID      String?
-  bookedApplicationID Int?
-  bookedAt            DateTime?
-  canceledAt          DateTime?
-  createdAt           DateTime? @default(now())
+  id         String    @id @default(auto()) @map("_id") @db.ObjectId
+  slotID     Int       @unique(map: "slotID")
+  ccaID      Int
+  startTime  Int?
+  endTime    Int?
+  location   String?
+  createdBy  String?
+  /// How many applicants may claim this slot. ABSENT/null means 1 — every row
+  /// written before group slots existed. Normalise through slotCapacity()
+  /// (services/ccaApplications.ts) and NEVER inline `?? 1`, so the legacy
+  /// default lives in exactly one place.
+  capacity   Int?
+  canceledAt DateTime?
+  createdAt  DateTime? @default(now())
 
   @@index([ccaID, startTime, endTime], map: "cca_time")
-  @@index([bookedByUserID], map: "booked_by")
 }
 
 /// Append-only interview notes a head records against an application — multiple

--- a/scripts/remediation/backfill-slot-capacity.mjs
+++ b/scripts/remediation/backfill-slot-capacity.mjs
@@ -1,0 +1,666 @@
+/**
+ * Group interview slots (docs/plans/cca/01), the data half.
+ *
+ *   node scripts/remediation/backfill-slot-capacity.mjs            # dry run
+ *   node scripts/remediation/backfill-slot-capacity.mjs --commit   # apply
+ *
+ * QUIESCE FIRST. `--commit` REFUSES to run while `cca.applications.enabled` is
+ * "on" (--allow-live overrides, loudly). See "THE LIVE-SURFACE WINDOW" below —
+ * this is not caution, it is the one failure mode of this migration that is
+ * both permanent and invisible. The dry run is unaffected by the switch.
+ *
+ *   node scripts/remediation/set-cca-flag.mjs applications off --commit
+ *   node scripts/remediation/backfill-slot-capacity.mjs --commit
+ *   node scripts/remediation/set-cca-flag.mjs applications on  --commit   # <-- DO NOT FORGET
+ *
+ * WHAT CHANGES. `CcaInterviewSlot` stops carrying the claim. Occupancy becomes
+ * DERIVED — `count(CcaApplication where interviewSlotID == slotID)` — so the
+ * three claim scalars go and a `capacity` is written in their place:
+ *
+ *   1. GATE on agreement between the two sides. Refuse to start otherwise.
+ *   2. SET capacity: 1 explicitly on every slot that has none.
+ *   3. RECONCILE the reject case: null the pointer on a TERMINAL application
+ *      that still names a LIVE FUTURE slot which no longer names it back.
+ *   4. $unset bookedByUserID / bookedApplicationID / bookedAt.
+ *
+ * IDEMPOTENT — RUNNING `--commit` TWICE LEAVES THE DATABASE BYTE-IDENTICAL
+ * AFTER THE FIRST RUN. This is a correctness requirement, not a nicety, and it
+ * is enforced in two places rather than assumed:
+ *
+ *   (a) THE MIGRATED-STATE DETECTOR. If no slot carries any of the three claim
+ *       fields AND every slot has a capacity, the script prints "already
+ *       migrated" and returns before writing anything — no backup, no update,
+ *       no $unset.
+ *   (b) THE PER-SLOT MARKER GUARD. Step 3's classification asks "does this
+ *       slot's bookedApplicationID still name this application?" — and step 4
+ *       DELETES bookedApplicationID. On a second run every slot would answer
+ *       "no", so every terminal application holding a pointer would look like a
+ *       reject-orphan and have its pointer wiped. (Production application #2 is
+ *       `accepted` with interviewSlotID 2: a naive re-run would silently erase
+ *       the record of that interview and print "Done.") So a slot that carries
+ *       NO claim field at all can never produce a reject-orphan: the absence of
+ *       a claim only MEANS anything while the pre-migration marker is present.
+ *
+ * "CARRIES A CLAIM FIELD" MEANS $exists, NOT non-null. The old openSlots wrote
+ * all three as EXPLICIT NULLS, so 31 of the 34 production slots carry them
+ * while only 1 holds a real claim. Reading presence as non-null under-reports
+ * step 4 by 30 documents and, worse, would make the marker guard above mistake
+ * a pre-migration database for a migrated one.
+ *
+ * THE LIVE-SURFACE WINDOW, and why quiescing is structural rather than advice.
+ * Both collections are snapshotted once at the start. If a head REJECTS an
+ * applicant who holds a future slot after that snapshot but before step 4
+ * finishes, the resulting reject-orphan is not in this run's plan — and step 4
+ * then strips the claim marker off that slot, so the marker guard in (b) makes
+ * a RE-RUN classify it `unclassifiable` and leave it alone too. The seat is
+ * held by a rejected application permanently: verify-interview-slots.mjs
+ * passes, availableSlots reports seatsLeft 0, clearFreeSlots sees the slot as
+ * occupied, and no surface anywhere says why. The marker guard is still the
+ * right trade — never-erase beats always-release — but it converts a
+ * recoverable miss into an unrecoverable one, so the window is closed at the
+ * source instead. As a backstop the VERIFY block below names any
+ * rejected/withdrawn application left pointing at a live future slot; both of
+ * those paths null the pointer in normal operation, so a survivor is exactly
+ * this leak and can be released by hand.
+ *
+ * ORDER MATTERS. The gate and step 3 both read the claim scalars, so they must
+ * run before the $unset that destroys them — `bookedApplicationID` is the ONLY
+ * record of which applicant the slot last belonged to, and it is exactly what
+ * distinguishes "rejected, seat already freed" from "still holds a seat". Once
+ * it is gone that distinction is unrecoverable, which is why a failed step 2 or
+ * 3 aborts BEFORE step 4 rather than falling through to it.
+ *
+ * WHY STEP 1 IS A HARD GATE. After this migration the application's pointer is
+ * the ONLY source of truth. If a slot and its application already disagree
+ * today, deriving occupancy from the pointer does not resolve the disagreement,
+ * it silently picks a winner — and the losing side is deleted in step 4. So a
+ * single mismatch aborts the whole run: the drift has to be understood and
+ * fixed by hand first. Measured 2026-08-02 against production: 0 mismatches.
+ *
+ * WHY capacity IS WRITTEN AND NOT LEFT ABSENT. Prisma+Mongo's `{ capacity:
+ * null }` matches a stored null but NOT an absent field, so a filter on it
+ * would silently skip every legacy row. slotCapacity() normalises absent/null
+ * to 1 in the app so nothing BREAKS if this step is skipped — but "the code
+ * rescues it" is not a reason to leave a whole collection in the shape that
+ * needs rescuing. Same rule as canceledAt (§0.4 of the plan).
+ *
+ * $runCommandRaw does NOT throw on a per-write failure — every reply is read
+ * through inspectWriteReply, and a non-empty writeErrors stops the run.
+ *
+ * REVERSIBLE. The backup holds every pre-image, and the three scalars are
+ * re-derivable from the application pointers in any case.
+ */
+import { PrismaClient } from "@prisma/client";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  abort,
+  banner,
+  fileStamp,
+  findAll,
+  inspectWriteReply,
+  isCommit,
+  numify,
+} from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+/** Override for the quiesce gate. Deliberately spelled out rather than a bare
+ *  --force: the operator should have to type what they are allowing. */
+const ALLOW_LIVE = process.argv.includes("--allow-live");
+const raw = (cmd) => db.$runCommandRaw(cmd);
+
+/** The kill switch that gates the whole applications surface
+ *  (services/ccaApplications.ts). "on" means residents are booking right now. */
+const APPLICATIONS_FLAG_KEY = "cca.applications.enabled";
+
+/** Same read as set-cca-flag.mjs — an absent row means "off" (default-closed). */
+async function readApplicationsFlag() {
+  const r = await raw({
+    find: "SystemFlag",
+    filter: { key: APPLICATIONS_FLAG_KEY },
+    limit: 1,
+  });
+  return r?.cursor?.firstBatch?.[0]?.value ?? null;
+}
+
+/** Mirrors src/lib/schemas/ccaApplication.ts. Kept as literals, not imported:
+ *  this file is plain .mjs and the schema module is TypeScript. */
+const SLOT_CAPACITY_DEFAULT = 1;
+const SLOT_CAPACITY_MAX = 20;
+
+/** Mirrors TERMINAL_STATUSES in the same module. */
+const TERMINAL = new Set(["accepted", "rejected", "withdrawn"]);
+
+/**
+ * `interviewed` is NEITHER terminal NOR a live booking, and both scripts need
+ * that third category.
+ *
+ * It is not terminal: the application is still open awaiting accept/reject, so
+ * isTerminalStatus() returns false and it still blocks a duplicate apply. It is
+ * not a live claim either: the interview has HAPPENED, and the head's
+ * cancelSlot deliberately reverts only `interview_scheduled` — so marking
+ * someone interviewed and then cancelling their slot leaves them pointing at a
+ * canceled slot, from two ordinary head actions and no bug. Treating that as
+ * drift would abort this migration on data the app legitimately produces;
+ * treating it as a reject-orphan would erase the record of an interview that
+ * took place. So: HISTORICAL. Counted, left exactly where it is, never
+ * released.
+ */
+const HISTORICAL = new Set([...TERMINAL, "interviewed"]);
+
+/** The three fields step 4 removes. Their PRESENCE is the pre-migration marker. */
+const CLAIM_FIELDS = ["bookedByUserID", "bookedApplicationID", "bookedAt"];
+
+/** Extended-JSON int or absent -> a JS number or null. Never 0-for-absent:
+ *  a slotID of 0 and "no slot" must not collapse into the same value. */
+function intOrNull(v) {
+  if (v == null) return null;
+  const n = numify(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** $exists semantics. An explicit null IS present — see the header. */
+const present = (d, k) =>
+  Object.prototype.hasOwnProperty.call(d, k) && d[k] !== undefined;
+/** Present AND non-null: an actual value. */
+const has = (v) => v !== undefined && v !== null;
+
+async function main() {
+  banner("backfill-slot-capacity.mjs", COMMIT);
+
+  /* --- THE QUIESCE GATE --------------------------------------------------- */
+  // Read (and print) the switch on every run, so a dry run tells the operator
+  // what they will have to do before committing. Enforced only under --commit:
+  // reading is harmless with residents booking, writing is not.
+  const flag = await readApplicationsFlag();
+  const live = flag === "on";
+  console.log(
+    `${APPLICATIONS_FLAG_KEY}: ${JSON.stringify(flag)}${live ? "  <- LIVE" : "  (surface inert)"}\n`,
+  );
+
+  if (COMMIT && live && !ALLOW_LIVE) {
+    console.error(
+      `The applications surface is LIVE. Residents can book and heads can reject\n` +
+        `while this migration runs, and one specific interleaving is unrecoverable:\n` +
+        `a reject landing after the snapshot leaves a seat held by a rejected\n` +
+        `application FOREVER, with the verifier passing and nothing surfacing it.\n` +
+        `(Full explanation: "THE LIVE-SURFACE WINDOW" in this file's header.)\n\n` +
+        `Quiesce, migrate, un-quiesce:\n` +
+        `  node scripts/remediation/set-cca-flag.mjs applications off --commit\n` +
+        `  node scripts/remediation/backfill-slot-capacity.mjs --commit\n` +
+        `  node scripts/remediation/set-cca-flag.mjs applications on  --commit   <-- DO NOT FORGET\n\n` +
+        `The last line is the one that gets missed. The surface is default-closed,\n` +
+        `so forgetting it leaves every resident locked out of /ccas silently.\n\n` +
+        `If the owner accepts the risk, re-run with --allow-live.`,
+    );
+    return abort(`refusing to write while ${APPLICATIONS_FLAG_KEY} is "on".`);
+  }
+  if (COMMIT && live && ALLOW_LIVE) {
+    console.log(
+      `*** --allow-live: WRITING AGAINST A LIVE APPLICATIONS SURFACE ***\n` +
+        `    Risk accepted: a head rejecting an applicant who holds a future slot,\n` +
+        `    between the snapshot below and the end of step 4, permanently strands\n` +
+        `    that seat. It cannot be detected by re-running this script and cannot\n` +
+        `    be fixed by it either — the marker it would need is gone.\n` +
+        `    The VERIFY block at the end names any rejected/withdrawn application\n` +
+        `    still pointing at a live future slot; that list IS the leak. Check it,\n` +
+        `    and cross-check AuditLog for ccaApplication.reject rows written during\n` +
+        `    this run.\n`,
+    );
+  }
+
+  const slotDocs = await findAll(db, "CcaInterviewSlot");
+  const appDocs = await findAll(db, "CcaApplication");
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  const slots = slotDocs.map((d) => ({
+    slotID: intOrNull(d.slotID),
+    ccaID: intOrNull(d.ccaID),
+    endTime: intOrNull(d.endTime),
+    capacity: intOrNull(d.capacity),
+    capacityUsable: has(d.capacity),
+    canceled: has(d.canceledAt),
+    bookedByUserID: has(d.bookedByUserID) ? String(d.bookedByUserID) : null,
+    bookedApplicationID: intOrNull(d.bookedApplicationID),
+    // THE PRE-MIGRATION MARKER. $exists on any of the three, so a row written
+    // with explicit nulls counts. Everything that reads "the slot does not name
+    // this application" is gated on this being true.
+    claimMarker: CLAIM_FIELDS.some((k) => present(d, k)),
+  }));
+  const apps = appDocs.map((d) => ({
+    applicationID: intOrNull(d.applicationID),
+    ccaID: intOrNull(d.ccaID),
+    status: d.status == null ? null : String(d.status),
+    interviewSlotID: intOrNull(d.interviewSlotID),
+  }));
+
+  const slotByID = new Map(slots.map((s) => [s.slotID, s]));
+  const appByID = new Map(apps.map((a) => [a.applicationID, a]));
+
+  const marked = slots.filter((s) => s.claimMarker);
+  const needCapacity = slots.filter((s) => !s.capacityUsable);
+
+  console.log(`CcaInterviewSlot: ${slots.length}`);
+  console.log(`  canceled:                ${slots.filter((s) => s.canceled).length}`);
+  console.log(`  carrying claim FIELDS:   ${marked.length}   <- what step 4 will touch`);
+  console.log(`  holding a real claim:    ${slots.filter((s) => s.bookedByUserID !== null || s.bookedApplicationID !== null).length}`);
+  console.log(`  with a usable capacity:  ${slots.length - needCapacity.length}`);
+  console.log(`CcaApplication:   ${apps.length}`);
+  console.log(`  with a slot pointer:     ${apps.filter((a) => a.interviewSlotID !== null).length}`);
+  const byStatus = new Map();
+  for (const a of apps) byStatus.set(a.status, (byStatus.get(a.status) ?? 0) + 1);
+  console.log(`  statuses:                ${JSON.stringify(Object.fromEntries(byStatus))}`);
+
+  /* --- [0] ALREADY MIGRATED? --------------------------------------------- */
+  // The idempotence guarantee, enforced rather than assumed. Nothing below this
+  // point runs — in particular no backup is written and no update is issued —
+  // so a second --commit is a genuine no-op, not a no-op-shaped set of writes.
+  if (marked.length === 0 && needCapacity.length === 0) {
+    console.log(
+      `\nALREADY MIGRATED — every slot has a capacity and none carries ` +
+        `${CLAIM_FIELDS.join("/")}. Nothing to do.`,
+    );
+    console.log(`Run verify-interview-slots.mjs to confirm the invariants hold.\n`);
+    return;
+  }
+  if (marked.length === 0) {
+    console.log(
+      `\nNOTE: no slot carries the claim fields, so step 4 has already run — but ` +
+        `${needCapacity.length} slot(s) still have no capacity. This run does STEP 2 ONLY.`,
+    );
+    console.log(
+      `      Step 3 is IMPOSSIBLE in this state and is skipped: it classifies a ` +
+        `pointer by asking whether the slot still names it, and the field that ` +
+        `answers that is already gone. Skipping is the safe direction — it can ` +
+        `only leave a pointer in place, never erase one.`,
+    );
+  } else if (marked.length < slots.length) {
+    console.log(
+      `\nNOTE: ${slots.length - marked.length} slot(s) carry NO claim field while ` +
+        `${marked.length} still do — rows predating the explicit-null writes, a ` +
+        `hand-created slot, or a partially applied earlier run. They are excluded ` +
+        `from steps 1 and 3 (see the header's marker guard); nothing about them ` +
+        `is assumed either way.`,
+    );
+  }
+
+  /* --- [1] THE GATE ------------------------------------------------------ */
+  // Both directions. A claim that names an application which does not point
+  // back, or a LIVE application pointing at a slot that does not name it, means
+  // the two sources of truth have already diverged.
+  console.log(`\n--- [1] slot <-> application agreement (blocking) ---`);
+  const drift = [];
+
+  for (const s of slots) {
+    if (s.bookedByUserID === null && s.bookedApplicationID === null) continue;
+    if (s.bookedApplicationID === null) {
+      drift.push(
+        `slot #${s.slotID}: bookedByUserID=${JSON.stringify(s.bookedByUserID)} but NO bookedApplicationID — cannot tell whose seat this is`,
+      );
+      continue;
+    }
+    const a = appByID.get(s.bookedApplicationID);
+    if (!a) {
+      drift.push(`slot #${s.slotID}: bookedApplicationID ${s.bookedApplicationID} matches no application`);
+    } else if (a.interviewSlotID !== s.slotID) {
+      drift.push(
+        `slot #${s.slotID}: claimed by application #${a.applicationID}, but that application points at ${a.interviewSlotID === null ? "NOTHING" : `#${a.interviewSlotID}`}`,
+      );
+    }
+  }
+
+  // The reverse. Only meaningful on a slot that still carries the marker: on a
+  // slot whose claim fields are gone, "does not name this application" is not
+  // information, it is this migration's own footprint.
+  const rejectOrphans = [];
+  let unclassifiable = 0;
+  let historical = 0;
+  for (const a of apps) {
+    if (a.interviewSlotID === null) continue;
+    const s = slotByID.get(a.interviewSlotID);
+    const isHistorical = HISTORICAL.has(a.status ?? "");
+    if (!s) {
+      if (isHistorical) {
+        console.log(`  warn  application #${a.applicationID} (${a.status}) points at slot #${a.interviewSlotID}, which does not exist — left alone, it can occupy nothing`);
+        historical++;
+      } else {
+        drift.push(`application #${a.applicationID} (${a.status}) points at slot #${a.interviewSlotID}, which does not exist`);
+      }
+      continue;
+    }
+    if (!s.claimMarker) {
+      unclassifiable++;
+      continue;
+    }
+    if (s.bookedApplicationID === a.applicationID) continue; // the two agree
+
+    // The slot does not name this application, and the marker says we can trust
+    // that reading.
+    if (!isHistorical) {
+      drift.push(
+        `application #${a.applicationID} (${a.status}) points at slot #${s.slotID}, which is claimed by ${s.bookedApplicationID === null ? "NOBODY" : `#${s.bookedApplicationID}`}`,
+      );
+      continue;
+    }
+    // A pointer only needs releasing if the seat it holds is one somebody else
+    // could otherwise use: a LIVE, FUTURE slot. On a canceled or past slot the
+    // pointer is the historical record of an interview that was scheduled, and
+    // erasing it would lose that — this is the same "iff the slot is still
+    // future" rule today's reject already applies, moved onto the pointer.
+    // `interviewed` is never released at all (see HISTORICAL above).
+    const releasable =
+      TERMINAL.has(a.status ?? "") &&
+      !s.canceled &&
+      s.endTime !== null &&
+      s.endTime > nowSec;
+    if (releasable) rejectOrphans.push({ ...a, slot: s });
+    else historical++;
+  }
+
+  if (drift.length) {
+    for (const d of drift) console.error(`  BLOCK  ${d}`);
+    return abort(
+      `${drift.length} slot/application disagreement(s). After this migration the ` +
+        `application pointer is the ONLY claim, so running now would pick a winner ` +
+        `silently and then delete the loser. Resolve each by hand first.`,
+    );
+  }
+  console.log(`  0 disagreement(s) — the two sides agree.`);
+  console.log(`  historical pointers left alone: ${historical}`);
+  if (unclassifiable > 0) {
+    console.log(
+      `  warn  ${unclassifiable} pointer(s) sit on slots with no claim field — ` +
+        `not classified, not touched (see the header's marker guard).`,
+    );
+  }
+
+  /* --- [2] capacity ------------------------------------------------------ */
+  const badCapacity = slots.filter(
+    (s) =>
+      s.capacityUsable &&
+      (s.capacity === null || s.capacity < 1 || s.capacity > SLOT_CAPACITY_MAX),
+  );
+  console.log(`\n--- [2] capacity: ${SLOT_CAPACITY_DEFAULT} on slots that have none ---`);
+  console.log(`  to write: ${needCapacity.length}`);
+  if (badCapacity.length) {
+    for (const s of badCapacity) {
+      console.error(`  BLOCK  slot #${s.slotID}: capacity ${JSON.stringify(s.capacity)} is outside 1..${SLOT_CAPACITY_MAX}`);
+    }
+    return abort(
+      `a slot carries a capacity no UI can produce. Someone hand-edited it; ` +
+        `fix or remove the value before this script normalises around it.`,
+    );
+  }
+
+  /* --- [3] the reject case ------------------------------------------------ */
+  console.log(`\n--- [3] terminal applications holding a live future seat their slot no longer grants ---`);
+  console.log(`  to release: ${rejectOrphans.length}`);
+  for (const a of rejectOrphans) {
+    console.log(`    application #${a.applicationID} (${a.status}) -> release slot #${a.interviewSlotID}`);
+  }
+  if (rejectOrphans.length === 0) {
+    console.log(`    (none — no rejected applicant is holding a future seat)`);
+  }
+
+  /* --- [4] the $unset ----------------------------------------------------- */
+  console.log(`\n--- [4] $unset ${CLAIM_FIELDS.join(" / ")} ---`);
+  console.log(
+    `  slots carrying at least one, by $exists — the same predicate the statement uses: ${marked.length}`,
+  );
+
+  /* --- projected occupancy ------------------------------------------------ */
+  // What the app will compute the moment the new code is deployed. Printed in
+  // the dry run because it is the only chance to see it BEFORE it is live.
+  const released = new Set(rejectOrphans.map((a) => a.applicationID));
+  const occAfter = new Map();
+  for (const a of apps) {
+    if (a.interviewSlotID === null || released.has(a.applicationID)) continue;
+    occAfter.set(a.interviewSlotID, (occAfter.get(a.interviewSlotID) ?? 0) + 1);
+  }
+  const over = [];
+  const overCanceled = [];
+  for (const s of slots) {
+    const occ = occAfter.get(s.slotID) ?? 0;
+    const cap = s.capacityUsable && s.capacity !== null ? s.capacity : SLOT_CAPACITY_DEFAULT;
+    if (occ <= cap) continue;
+    const line = `slot #${s.slotID}: ${occ} occupant(s) but capacity ${cap}`;
+    // A canceled slot's occupancy is inert — it can never be booked again — so
+    // it is reported, not refused.
+    if (s.canceled) overCanceled.push(line);
+    else over.push(line);
+  }
+  console.log(`\n--- projected occupancy after this migration ---`);
+  console.log(`  slots with someone on them: ${[...occAfter.keys()].filter((k) => slotByID.has(k)).length}`);
+  console.log(`  seats claimed:              ${[...occAfter.entries()].filter(([k]) => slotByID.has(k)).reduce((n, [, v]) => n + v, 0)}`);
+  for (const o of overCanceled) console.log(`  warn  ${o} (canceled — inert)`);
+  if (over.length) {
+    for (const o of over) console.error(`  BLOCK  ${o}`);
+    return abort(
+      `a live slot would come out OVER capacity — two applications already point ` +
+        `at a single-seat slot. That cannot happen through the UI, so it is a ` +
+        `hand-edit or a restore artefact. Fix it before migrating.`,
+    );
+  }
+  console.log(`  no live slot exceeds its capacity — good.`);
+
+  /* --- index report ------------------------------------------------------- */
+  // `prisma db push` DROPS indexes it does not know about (it has taken
+  // email_unique_ci out before). Printed here so the operator has a before
+  // picture to diff against after the push.
+  for (const coll of ["CcaInterviewSlot", "CcaApplication"]) {
+    try {
+      const idx = await raw({ listIndexes: coll });
+      const names = (idx?.cursor?.firstBatch ?? []).map((i) => i.name);
+      console.log(`  indexes on ${coll}: ${names.join(", ") || "(none)"}`);
+    } catch (e) {
+      console.log(`  indexes on ${coll}: unavailable (${String(e?.message ?? e)})`);
+    }
+  }
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --commit to apply.\n`);
+    return;
+  }
+
+  /* --- backup, BEFORE the first write ------------------------------------ */
+  const out = path.join(
+    process.cwd(),
+    "scripts",
+    "remediation",
+    "backups",
+    `backfill-slot-capacity-${fileStamp()}.json`,
+  );
+  try {
+    writeFileSync(
+      out,
+      JSON.stringify(
+        { at: new Date().toISOString(), slots: slotDocs, applications: appDocs },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    console.log(`\nBackup written: ${out}`);
+  } catch (e) {
+    return abort(
+      `could not write the backup (${String(e?.message ?? e)}). Step 4 is a $unset ` +
+        `of the only copy of the claim data — refusing to proceed without a pre-image.`,
+    );
+  }
+
+  console.log(`\n--- APPLYING ---`);
+  /**
+   * Run one statement, print it, and RETURN whether it was clean. The caller
+   * must branch on that: $runCommandRaw resolves on a per-write failure, so a
+   * `failures` counter that is only read at the end lets a broken step 2 or 3
+   * fall straight through into the irreversible $unset.
+   *
+   * A writeConcernError COUNTS AS FAILURE. inspectWriteReply returns it as its
+   * own field and never folds it into writeErrors (lib/rbac.mjs), so testing
+   * writeErrors alone accepts a write that applied on the primary but was not
+   * majority-acknowledged — i.e. one an Atlas failover may roll back. Proceeding
+   * from there into the $unset would destroy the claim scalars on the strength
+   * of a capacity write that then vanished. This is the last path from a failed
+   * write into step 4.
+   */
+  const step = async (label, cmd) => {
+    const r = inspectWriteReply(await raw(cmd), label);
+    console.log(
+      `  ${label.padEnd(34)} n=${r.n} nModified=${r.nModified} writeErrors=${r.writeErrors.length} writeConcernErrors=${r.writeConcernError.length}`,
+    );
+    if (r.writeErrors.length) {
+      console.error(`    writeErrors: ${JSON.stringify(r.writeErrors).slice(0, 400)}`);
+    }
+    if (r.writeConcernError.length) {
+      console.error(
+        `    writeConcernError: ${JSON.stringify(r.writeConcernError).slice(0, 400)}`,
+      );
+    }
+    return r.writeErrors.length === 0 && r.writeConcernError.length === 0;
+  };
+  const stoppedBeforeUnset = (which) =>
+    abort(
+      `${which} did not complete cleanly (write errors, or a write concern that ` +
+        `was not acknowledged). STOPPING BEFORE step 4 — the claim scalars are ` +
+        `untouched, so the database is still classifiable and this script can ` +
+        `simply be re-run once the cause is fixed. Backup: ${out}`,
+    );
+
+  // [2] capacity. Matched on $exists/null rather than by id list so a slot
+  // opened between the read above and this write is covered too — and NOT
+  // matched on "every slot", so a capacity a head has already set is untouched.
+  if (
+    !(await step("capacity := 1", {
+      update: "CcaInterviewSlot",
+      ordered: false,
+      updates: [
+        {
+          q: { $or: [{ capacity: { $exists: false } }, { capacity: null }] },
+          u: { $set: { capacity: SLOT_CAPACITY_DEFAULT } },
+          multi: true,
+        },
+      ],
+    }))
+  ) {
+    return stoppedBeforeUnset("step 2 (capacity)");
+  }
+
+  // [3] the reject case, one statement per application: each is a different
+  // document and the filter has to name it exactly.
+  if (rejectOrphans.length > 0) {
+    if (
+      !(await step("release terminal pointers", {
+        update: "CcaApplication",
+        ordered: false,
+        updates: rejectOrphans.map((a) => ({
+          q: { applicationID: a.applicationID, interviewSlotID: a.interviewSlotID },
+          u: { $set: { interviewSlotID: null } },
+          multi: false,
+        })),
+      }))
+    ) {
+      return stoppedBeforeUnset("step 3 (release terminal pointers)");
+    }
+  }
+
+  // [4] the claim scalars. LAST — steps 1 and 3 read them, and nothing after
+  // this point can tell a released seat from a never-claimed one.
+  const unsetOk = await step("$unset booked* scalars", {
+    update: "CcaInterviewSlot",
+    ordered: false,
+    updates: [
+      {
+        q: { $or: CLAIM_FIELDS.map((k) => ({ [k]: { $exists: true } })) },
+        u: { $unset: Object.fromEntries(CLAIM_FIELDS.map((k) => [k, ""])) },
+        multi: true,
+      },
+    ],
+  });
+
+  /* --- verify ------------------------------------------------------------- */
+  console.log(`\n=== VERIFY ===`);
+  const slotsAfter = (await findAll(db, "CcaInterviewSlot")).map((d) => ({
+    slotID: intOrNull(d.slotID),
+    capacity: intOrNull(d.capacity),
+    endTime: intOrNull(d.endTime),
+    canceled: has(d.canceledAt),
+    leftovers: CLAIM_FIELDS.some((k) => present(d, k)),
+  }));
+  const appsAfter = (await findAll(db, "CcaApplication")).map((d) => ({
+    applicationID: intOrNull(d.applicationID),
+    status: d.status == null ? null : String(d.status),
+    interviewSlotID: intOrNull(d.interviewSlotID),
+  }));
+
+  const occ = new Map();
+  for (const a of appsAfter) {
+    if (a.interviewSlotID === null) continue;
+    occ.set(a.interviewSlotID, (occ.get(a.interviewSlotID) ?? 0) + 1);
+  }
+
+  const noCapacity = slotsAfter.filter((s) => s.capacity === null || s.capacity < 1);
+  const leftovers = slotsAfter.filter((s) => s.leftovers);
+  const overAfter = slotsAfter.filter(
+    (s) => (occ.get(s.slotID) ?? 0) > (s.capacity ?? SLOT_CAPACITY_DEFAULT),
+  );
+
+  // The claim count before must equal the seat count after, on exactly the
+  // slots that were claimed. This is the check that would catch a $unset that
+  // ran before the gate, or a step-3 filter that released too much.
+  const claimedBefore = slots
+    .filter((s) => s.bookedApplicationID !== null)
+    .map((s) => s.slotID);
+  const seatsOnThose = claimedBefore.reduce((n, id) => n + (occ.get(id) ?? 0), 0);
+
+  // THE LIVE-WINDOW BACKSTOP. In normal operation `rejected` and `withdrawn`
+  // both null the pointer, so one still aimed at a live FUTURE slot after this
+  // run is a stranded seat — almost certainly a reject that landed inside the
+  // window (see the header). Reported by name because the marker that would let
+  // this script fix it is gone by now; releasing them is a one-line hand-fix.
+  const slotAfterByID = new Map(slotsAfter.map((s) => [s.slotID, s]));
+  const strandedNow = Math.floor(Date.now() / 1000);
+  const stranded = appsAfter.filter((a) => {
+    if (a.interviewSlotID === null) return false;
+    if (a.status !== "rejected" && a.status !== "withdrawn") return false;
+    const s = slotAfterByID.get(a.interviewSlotID);
+    return !!s && !s.canceled && s.endTime !== null && s.endTime > strandedNow;
+  });
+
+  console.log(`slots:                     ${slotsAfter.length}`);
+  console.log(`without a usable capacity: ${noCapacity.length} (must be 0)`);
+  console.log(`still carrying booked*:    ${leftovers.length} (must be 0)`);
+  console.log(`over capacity:             ${overAfter.length} (must be 0)`);
+  console.log(`claimed before:            ${claimedBefore.length}`);
+  console.log(`seats on those slots now:  ${seatsOnThose} (must equal claimed-before)`);
+  console.log(`stranded seats:            ${stranded.length} (must be 0)`);
+  for (const a of stranded) {
+    console.error(
+      `  STRANDED  application #${a.applicationID} (${a.status}) still holds a seat on live future slot #${a.interviewSlotID}. ` +
+        `Release it by hand: set interviewSlotID = null on that application.`,
+    );
+  }
+  if (
+    !unsetOk ||
+    noCapacity.length ||
+    leftovers.length ||
+    overAfter.length ||
+    stranded.length ||
+    seatsOnThose !== claimedBefore.length
+  ) {
+    return abort(
+      `migration did not complete cleanly — the backup holds every pre-image ` +
+        `(${out}). Do NOT deploy the new code against this state.`,
+    );
+  }
+
+  console.log(`\nDone. A re-run of this script will now report "already migrated".`);
+  console.log(`Next: prisma db push, then re-check the index list printed above.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/fix-leia-duplicate.mjs
+++ b/scripts/remediation/fix-leia-duplicate.mjs
@@ -1,0 +1,283 @@
+/**
+ * One-off: collapse a duplicate account created by a typo'd sign-up email.
+ *
+ *   node scripts/remediation/fix-leia-duplicate.mjs            # dry run
+ *   node scripts/remediation/fix-leia-duplicate.mjs --commit    # apply
+ *
+ * THE SITUATION. One person, two User rows:
+ *
+ *   A  e1514199@u.nus.edu   displayName "Ganzon Leia Plaza"   User.userID E1524199
+ *   B  e1524199@u.nus.edu   displayName "leia"                User.userID E1524199
+ *
+ * `1514199` is a typo of her NUSNET `1524199`. Session identity is derived from
+ * the EMAIL (canonicalUserID in src/server/auth.ts), never from the stored
+ * `User.userID`, so A logs in as E1514199 — an identity that owns one baseline
+ * `resident` row and nothing else — while every real thing she has (matric
+ * A0321292M, cca_head of CCAs 7 and 46, membership of 47, two bookings, an
+ * accepted application) is keyed E1524199, i.e. B.
+ *
+ * Action: give B her full name, delete A.
+ *
+ * ############################################################################
+ * # WHY THIS DOES NOT CALL deleteUserCascade().                              #
+ * #                                                                          #
+ * # A's STORED User.userID is E1524199 — B's key, not its own. deleteUser-   #
+ * # Cascade(db, userID) deletes Bookings, Posts, Order, UserCCA and Gym BY   #
+ * # THAT STRING, so calling it for A would delete B's bookings, B's          #
+ * # membership and B's data, and then `user.deleteMany({ userID })` would    #
+ * # take BOTH rows. The whole reason this account is broken — a stored key   #
+ * # that disagrees with the email — is also what makes the ordinary delete   #
+ * # helper catastrophic here.                                                #
+ * #                                                                          #
+ * # This script deletes A BY ITS ObjectId, and by nothing else. Session /    #
+ * # Account / Authenticator carry onDelete: Cascade on their User relation,  #
+ * # so those follow the row automatically.                                   #
+ * ############################################################################
+ *
+ * The gates below refuse to proceed unless the situation is still EXACTLY as
+ * described — one row per address, distinct ids, and A's own canonical key
+ * owning nothing but role rows. If she has logged in as A since this was
+ * written and acquired a matric or a booking under E1514199, that is no longer
+ * a delete, it is a merge, and this script stops rather than losing it.
+ */
+import { PrismaClient } from "@prisma/client";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { isCommit, abort, banner, fileStamp, inspectWriteReply } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+const DOOMED_EMAIL = "e1514199@u.nus.edu"; // A — the typo
+const KEEP_EMAIL = "e1524199@u.nus.edu"; // B — the real account
+const DOOMED_KEY = "E1514199"; // A's canonical key, derived from its email
+const KEEP_KEY = "E1524199"; // B's canonical key — MUST survive untouched
+const NEW_DISPLAY_NAME = "Ganzon Leia Plaza";
+
+/** Collections keyed by the canonical userID string. */
+const KEYED = [
+  "UserMatric",
+  "UserRole",
+  "UserCCA",
+  "CcaHead",
+  "CcaApplication",
+  "CcaInterviewSlot",
+  "Bookings",
+  "Posts",
+  "Order",
+  "Gym",
+  "ProfileCompletion",
+];
+/** Of those, the ones A is ALLOWED to own — a baseline role row is expected and
+ *  is deleted with it. Anything else means real data lives under A. */
+const DISPOSABLE = new Set(["UserRole"]);
+
+const FIELD = { CcaInterviewSlot: "bookedByUserID" };
+
+async function ownedBy(key) {
+  const out = new Map();
+  for (const coll of KEYED) {
+    const field = FIELD[coll] ?? "userID";
+    const r = await db.$runCommandRaw({
+      find: coll,
+      filter: { [field]: key },
+      batchSize: 200,
+      singleBatch: true,
+    });
+    const rows = r?.cursor?.firstBatch ?? [];
+    if (rows.length) out.set(coll, rows);
+  }
+  return out;
+}
+
+const brief = (m) =>
+  [...m.entries()].map(([c, r]) => `${c}=${r.length}`).join(", ") || "(nothing)";
+
+async function main() {
+  banner("fix-leia-duplicate.mjs", COMMIT);
+
+  /* --- resolve both rows, refusing anything ambiguous --------------------- */
+  const rows = await db.user.findMany({
+    where: { email: { in: [DOOMED_EMAIL, KEEP_EMAIL], mode: "insensitive" } },
+    select: {
+      id: true,
+      email: true,
+      userID: true,
+      displayName: true,
+      block: true,
+      telegramHandle: true,
+      bio: true,
+    },
+  });
+  const A = rows.filter((r) => r.email.toLowerCase() === DOOMED_EMAIL);
+  const B = rows.filter((r) => r.email.toLowerCase() === KEEP_EMAIL);
+
+  const bad = [];
+  if (A.length !== 1) bad.push(`${DOOMED_EMAIL}: ${A.length} row(s), expected exactly 1`);
+  if (B.length !== 1) bad.push(`${KEEP_EMAIL}: ${B.length} row(s), expected exactly 1`);
+  if (bad.length) {
+    for (const b of bad) console.error(`  BLOCK  ${b}`);
+    return abort("the two accounts are not in the shape this script was written against.");
+  }
+  const a = A[0];
+  const b = B[0];
+  if (a.id === b.id) return abort("both addresses resolved to the SAME row — nothing to delete.");
+
+  console.log(`A (delete)  _id=${a.id}  ${a.email}`);
+  console.log(`              displayName=${JSON.stringify(a.displayName)}  stored userID=${a.userID}`);
+  console.log(`B (keep)    _id=${b.id}  ${b.email}`);
+  console.log(`              displayName=${JSON.stringify(b.displayName)}  stored userID=${b.userID}`);
+
+  /* --- what each canonical key owns -------------------------------------- */
+  const ownedA = await ownedBy(DOOMED_KEY);
+  const ownedB = await ownedBy(KEEP_KEY);
+  console.log(`\nowned by ${DOOMED_KEY} (A's login identity): ${brief(ownedA)}`);
+  console.log(`owned by ${KEEP_KEY} (B's, must be untouched): ${brief(ownedB)}`);
+
+  const keepsRealData = [...ownedA.keys()].filter((c) => !DISPOSABLE.has(c));
+  if (keepsRealData.length) {
+    for (const c of keepsRealData) {
+      console.error(`  BLOCK  ${DOOMED_KEY} owns ${ownedA.get(c).length} ${c} row(s) — deleting A would lose it`);
+    }
+    return abort(
+      `A's identity now owns real data. That is a MERGE, not a delete — use ` +
+        `merge-by-canonical.mjs / dedupe-users.mjs instead of this script.`,
+    );
+  }
+
+  /* --- plan --------------------------------------------------------------- */
+  const roleRows = ownedA.get("UserRole") ?? [];
+  console.log(`\n--- PLAN ---`);
+  console.log(`  ~ B.displayName: ${JSON.stringify(b.displayName)} -> ${JSON.stringify(NEW_DISPLAY_NAME)}`);
+  console.log(`  - delete User _id=${a.id} (BY ObjectId — never by userID, see the header)`);
+  console.log(`  - delete ${roleRows.length} UserRole row(s) keyed ${DOOMED_KEY}: ${JSON.stringify(roleRows.map((r) => r.roles ?? r.role))}`);
+  console.log(`  = Session/Account/Authenticator for that _id follow via onDelete: Cascade`);
+  console.log(`  = everything keyed ${KEEP_KEY} is untouched: ${brief(ownedB)}`);
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --commit to apply.\n`);
+    return;
+  }
+
+  /* --- backup, before the first write ------------------------------------- */
+  // NOTE: contains A's passwordHash. scripts/remediation/backups/ is gitignored.
+  const full = await db.$runCommandRaw({
+    find: "User",
+    filter: { _id: { $oid: a.id } },
+    batchSize: 5,
+    singleBatch: true,
+  });
+  const sessions = await db.$runCommandRaw({
+    find: "Session",
+    filter: { userId: { $oid: a.id } },
+    batchSize: 50,
+    singleBatch: true,
+  });
+  const accounts = await db.$runCommandRaw({
+    find: "Account",
+    filter: { userId: { $oid: a.id } },
+    batchSize: 50,
+    singleBatch: true,
+  });
+  const out = path.join(
+    process.cwd(),
+    "scripts",
+    "remediation",
+    "backups",
+    `fix-leia-duplicate-${fileStamp()}.json`,
+  );
+  try {
+    writeFileSync(
+      out,
+      JSON.stringify(
+        {
+          at: new Date().toISOString(),
+          deletedUser: full?.cursor?.firstBatch ?? [],
+          deletedSessions: sessions?.cursor?.firstBatch ?? [],
+          deletedAccounts: accounts?.cursor?.firstBatch ?? [],
+          deletedUserRoles: roleRows,
+          keptUserBefore: b,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    console.log(`\nBackup written: ${out}`);
+  } catch (e) {
+    return abort(`could not write the backup (${String(e?.message ?? e)}). Refusing to proceed.`);
+  }
+
+  /* --- apply -------------------------------------------------------------- */
+  let failures = 0;
+  await db.user.update({
+    where: { id: b.id },
+    data: { displayName: NEW_DISPLAY_NAME },
+  });
+  console.log(`  ~ renamed B -> ${JSON.stringify(NEW_DISPLAY_NAME)}`);
+
+  if (roleRows.length) {
+    const reply = await db.$runCommandRaw({
+      delete: "UserRole",
+      deletes: [{ q: { userID: DOOMED_KEY }, limit: 0 }],
+    });
+    const r = inspectWriteReply(reply, "delete UserRole");
+    if (r.writeErrors.length || r.writeConcernError.length) {
+      failures++;
+      console.error(`  ! ${JSON.stringify([...r.writeErrors, ...r.writeConcernError]).slice(0, 200)}`);
+    } else {
+      console.log(`  - deleted ${r.n} UserRole row(s) keyed ${DOOMED_KEY}`);
+    }
+  }
+
+  // BY ObjectId. Never `deleteMany({ userID })` — see the header.
+  await db.user.delete({ where: { id: a.id } });
+  console.log(`  - deleted User _id=${a.id}`);
+
+  /* --- verify -------------------------------------------------------------- */
+  console.log(`\n=== VERIFY ===`);
+  const aGone = await db.user.findUnique({ where: { id: a.id }, select: { id: true } });
+  console.log(`  A row gone:              ${aGone === null}`);
+  if (aGone !== null) failures++;
+
+  const kept = await db.user.findUnique({
+    where: { id: b.id },
+    select: { id: true, email: true, displayName: true, userID: true, block: true, telegramHandle: true },
+  });
+  console.log(`  B row: ${JSON.stringify(kept)}`);
+  if (!kept || kept.displayName !== NEW_DISPLAY_NAME) failures++;
+
+  const ownedAfter = await ownedBy(KEEP_KEY);
+  console.log(`  owned by ${KEEP_KEY} after: ${brief(ownedAfter)}`);
+  for (const coll of new Set([...ownedB.keys(), ...ownedAfter.keys()])) {
+    const before = ownedB.get(coll)?.length ?? 0;
+    const after = ownedAfter.get(coll)?.length ?? 0;
+    if (before !== after) {
+      failures++;
+      console.error(`  ! ${coll}: ${before} -> ${after} — B LOST DATA, restore from the backup`);
+    }
+  }
+  const strayRoles = await ownedBy(DOOMED_KEY);
+  console.log(`  owned by ${DOOMED_KEY} after: ${brief(strayRoles)} (must be nothing)`);
+  if (strayRoles.size) failures++;
+
+  const leftoverSessions = await db.$runCommandRaw({
+    find: "Session",
+    filter: { userId: { $oid: a.id } },
+    batchSize: 5,
+    singleBatch: true,
+  });
+  const nS = (leftoverSessions?.cursor?.firstBatch ?? []).length;
+  console.log(`  orphaned Session rows:   ${nS} (cascade should have taken them)`);
+
+  console.log(`\nfailures: ${failures}`);
+  if (failures) return abort("did not complete cleanly — the backup holds every pre-image.");
+  console.log(`\nDone.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/remove-ccas.mjs
+++ b/scripts/remediation/remove-ccas.mjs
@@ -1,0 +1,278 @@
+/**
+ * Removes a named set of CCAs and everything scoped to them.
+ *
+ *   node scripts/remediation/remove-ccas.mjs            # dry run
+ *   node scripts/remediation/remove-ccas.mjs --commit   # apply
+ *
+ * The set is the five RHMP sub-committees below, per the owner's instruction.
+ *
+ * KEYED ON NAME, unlike reconcile-ccas.mjs. That script keyed on ccaID because
+ * names were the thing it was changing; here the names are the only handle the
+ * request gave and nothing renames anything, so the name is stable for the
+ * length of the run. It is still not TRUSTED: a name that matches zero rows, or
+ * more than one, aborts the whole run rather than guessing, and the resolved
+ * ccaIDs are printed in the dry run so they can be eyeballed before --commit.
+ *
+ * WHAT GOES, AND WHY THAT LINE.
+ * Everything scoped to the CCA goes — memberships (UserCCA and the embedded
+ * User.userCCA array), headships, profile, applications, interview slots and
+ * notes, events, posts. Leaving any of them is not "safe": an orphaned CcaHead
+ * row keeps an ex-head's `cca_head` string alive permanently, because
+ * revokeCcaHead drops the string only when remaining === 0 and that count never
+ * reaches zero while the row survives (services/cascade.ts, GUARD 2).
+ *
+ * WHAT STAYS: Bookings and BookingLogs. This is the same call reconcile-ccas.mjs
+ * made for the retired CCAs — the booking history is left in place, orphaned but
+ * intact. An orphaned booking renders without a CCA name; a deleted one is gone.
+ * Only one of those is reversible. deleteCcaCascade() DOES delete bookings by
+ * ccaID and is deliberately not used here for exactly that reason.
+ *
+ * ccaID 0 IS REFUSED. BookingModal hardcodes ccaID 0 on every booking the
+ * current UI creates, so anything that reaches bookings by ccaID 0 reaches the
+ * whole collection. Nothing here deletes bookings, but the guard stays: a CCA
+ * row holding 0 is a data problem to fix, not to delete around.
+ *
+ * EVERY deleted document is written to scripts/remediation/backups/ BEFORE the
+ * first delete, in full, so the removal is reversible by re-insert.
+ */
+import { PrismaClient } from "@prisma/client";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  isCommit,
+  abort,
+  banner,
+  fileStamp,
+  countWhere,
+  inspectWriteReply,
+  numify,
+} from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+/** Exact ccaName values. Matched literally — no trimming, no case folding: a row
+ *  that differs by so much as a trailing space is a DIFFERENT row and this
+ *  script must not decide it meant the same thing. */
+const TARGETS = [
+  "RHMP Cinematography",
+  // Lowercase "relations" is how the row is actually stored (ccaID 59). The
+  // request spelled it "Corporate Relations"; the literal match above is on the
+  // database's spelling, not the request's, and there is no second candidate.
+  "RHMP Corporate relations",
+  "RHMP Internal Relations",
+  "RHMP Post Production",
+  "RHMP Production Managers",
+];
+
+/** Collections whose rows are scoped to one CCA and are deleted with it.
+ *  Order is dependents-first; the CCA row itself is deleted last, so an
+ *  interrupted run leaves a CCA with fewer dependents (harmless, re-runnable)
+ *  rather than dependents pointing at a row that no longer exists. */
+const DEPENDENTS = [
+  "Posts",
+  "UserCCA",
+  "CcaHead",
+  "CcaProfile",
+  "CcaApplication",
+  "CcaInterviewSlot",
+  "CcaInterviewNote",
+  "Event",
+];
+
+/** Scoped to a CCA but deliberately KEPT. Reported, never touched. */
+const KEPT = ["Bookings", "BookingLogs"];
+
+/**
+ * Read a collection FULLY for the backup, and refuse a partial read.
+ *
+ * Same trap as lib/rbac.mjs findAll(): a `find` reply is capped by the server's
+ * default batch (101 documents) unless batchSize says otherwise, and a backup
+ * that silently holds a prefix of what is about to be deleted is worse than no
+ * backup — it reads as complete. Volumes here are small enough for one batch, so
+ * a non-zero cursor id is treated as a read failure rather than paged into the
+ * replica-set getMore hazard documented in that file.
+ */
+async function readAll(collection, filter) {
+  const res = await db.$runCommandRaw({
+    find: collection,
+    filter,
+    batchSize: 100000,
+    singleBatch: true,
+  });
+  if (numify(res?.ok) !== 1) {
+    // A collection that does not exist on this cluster still answers ok:1 with
+    // an empty batch, so this really is a failure, not an absence.
+    throw new Error(`find on ${collection} failed: ${String(res?.errmsg ?? "(no errmsg)")}`);
+  }
+  const rows = res?.cursor?.firstBatch ?? [];
+  const id = res?.cursor?.id;
+  if (id && String(numify(id)) !== "0" && String(id) !== "0") {
+    throw new Error(
+      `find on ${collection} exceeded one batch (${rows.length} read). Refusing ` +
+        `to back up a prefix of the documents this script is about to delete.`,
+    );
+  }
+  const expected = await countWhere(db, collection, filter);
+  if (rows.length !== expected) {
+    throw new Error(
+      `find on ${collection} read ${rows.length} document(s) but $count says ${expected}. ` +
+        `Refusing to proceed on a partial backup.`,
+    );
+  }
+  return rows;
+}
+
+async function main() {
+  banner("remove-ccas.mjs", COMMIT);
+
+  const before = await db.cCA.findMany({ orderBy: { ccaID: "asc" } });
+  console.log(`CCAs before: ${before.length}`);
+
+  /* --- resolve names -> ccaIDs, refusing anything ambiguous ---------------- */
+  const bad = [];
+  const targets = [];
+  for (const name of TARGETS) {
+    const hits = before.filter((c) => c.ccaName === name);
+    if (hits.length === 0) bad.push(`${JSON.stringify(name)}: NOT FOUND`);
+    else if (hits.length > 1)
+      bad.push(
+        `${JSON.stringify(name)}: ${hits.length} rows (ccaIDs ${hits.map((h) => h.ccaID).join(", ")}) — ` +
+          `resolve the duplicate first, this script will not pick one`,
+      );
+    else if (hits[0].ccaID === 0)
+      bad.push(`${JSON.stringify(name)}: holds the RESERVED ccaID 0 — see verify-cca-roster.mjs [10]`);
+    else targets.push(hits[0]);
+  }
+  if (bad.length) {
+    for (const b of bad) console.error(`  BLOCK  ${b}`);
+    return abort(
+      "the CCA collection does not match this removal list. Re-read it (verify-cca-roster.mjs) and re-derive the plan.",
+    );
+  }
+
+  const ids = targets.map((t) => t.ccaID);
+  const scope = { ccaID: { $in: ids } };
+
+  /* --- plan ---------------------------------------------------------------- */
+  console.log(`\n--- DELETE (${targets.length}) ---`);
+  for (const t of targets) {
+    console.log(`  - ${String(t.ccaID).padStart(3)}  ${t.ccaName.padEnd(28)} [${t.category}]`);
+  }
+
+  console.log(`\n--- dependents removed with them ---`);
+  const depCounts = {};
+  for (const coll of DEPENDENTS) {
+    depCounts[coll] = await countWhere(db, coll, scope);
+    console.log(`  ${coll.padEnd(18)} ${String(depCounts[coll]).padStart(5)}`);
+  }
+  // The embedded Int[] on User — Source A of the roster (services/ccaRoster.ts).
+  // It is NOT declared in `model User`, so it is reachable only through raw
+  // commands and is invisible to every typed read; left alone it keeps stale
+  // memberships for a CCA that no longer exists.
+  const embedded = await countWhere(db, "User", { userCCA: { $in: ids } });
+  console.log(`  ${"User.userCCA[]".padEnd(18)} ${String(embedded).padStart(5)}  (array elements pulled, User rows untouched otherwise)`);
+
+  console.log(`\n--- KEPT, left orphaned on purpose ---`);
+  for (const coll of KEPT) {
+    console.log(`  ${coll.padEnd(18)} ${String(await countWhere(db, coll, scope)).padStart(5)}`);
+  }
+
+  console.log(`\n  CCAs after: ${before.length - targets.length}`);
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing written. Check the ccaIDs above, then re-run with --commit.\n`);
+    return;
+  }
+
+  /* --- backup, in full, before the first delete ---------------------------- */
+  const snapshot = { at: new Date().toISOString(), targets, collections: {} };
+  try {
+    for (const coll of DEPENDENTS) snapshot.collections[coll] = await readAll(coll, scope);
+    // Only _id and the array are needed to undo a $pull; the rest of a User row
+    // (passwordHash, base64 profilePictureUrl) has no business in a backup file.
+    snapshot.collections["User.userCCA"] = (
+      await readAll("User", { userCCA: { $in: ids } })
+    ).map((u) => ({ _id: u._id, email: u.email, userCCA: u.userCCA }));
+  } catch (e) {
+    return abort(`could not read the documents to back up (${String(e?.message ?? e)}). Nothing was deleted.`);
+  }
+
+  const out = path.join(process.cwd(), "scripts", "remediation", "backups", `remove-ccas-${fileStamp()}.json`);
+  try {
+    writeFileSync(out, JSON.stringify(snapshot, null, 2), "utf8");
+    console.log(`\nBackup written: ${out}`);
+  } catch (e) {
+    return abort(`could not write the backup (${String(e?.message ?? e)}). Refusing to proceed without one.`);
+  }
+
+  /* --- delete -------------------------------------------------------------- */
+  let failures = 0;
+  const report = (r) => {
+    if (!r.ok || r.writeErrors.length || r.writeConcernError.length) {
+      failures++;
+      console.error(`  ! ${r.label}: ${JSON.stringify([...r.writeErrors, ...r.writeConcernError]).slice(0, 200)}`);
+      return false;
+    }
+    return true;
+  };
+
+  for (const coll of DEPENDENTS) {
+    const reply = await db.$runCommandRaw({
+      delete: coll,
+      deletes: [{ q: scope, limit: 0 }],
+    });
+    const r = inspectWriteReply(reply, `delete ${coll}`);
+    if (report(r)) console.log(`  - ${coll.padEnd(18)} deleted ${r.n}`);
+  }
+
+  {
+    const reply = await db.$runCommandRaw({
+      update: "User",
+      updates: [{ q: { userCCA: { $in: ids } }, u: { $pull: { userCCA: { $in: ids } } }, multi: true }],
+    });
+    const r = inspectWriteReply(reply, "pull User.userCCA");
+    if (report(r)) console.log(`  - ${"User.userCCA[]".padEnd(18)} updated ${r.nModified}`);
+  }
+
+  // The CCA rows last — see the note on DEPENDENTS.
+  {
+    const reply = await db.$runCommandRaw({
+      delete: "CCA",
+      deletes: [{ q: scope, limit: 0 }],
+    });
+    const r = inspectWriteReply(reply, "delete CCA");
+    if (report(r)) console.log(`  - ${"CCA".padEnd(18)} deleted ${r.n}`);
+  }
+
+  /* --- verify --------------------------------------------------------------- */
+  console.log(`\n=== VERIFY ===`);
+  const after = await db.cCA.findMany({ orderBy: { ccaID: "asc" } });
+  console.log(`CCAs after: ${after.length}`);
+  for (const t of targets) {
+    const left = after.some((c) => c.ccaID === t.ccaID);
+    console.log(`  ccaID ${String(t.ccaID).padStart(3)} ${t.ccaName.padEnd(28)} ${left ? "STILL PRESENT" : "gone"}`);
+    if (left) failures++;
+  }
+  for (const coll of [...DEPENDENTS]) {
+    const n = await countWhere(db, coll, scope);
+    console.log(`  ${coll.padEnd(18)} remaining ${n} (must be 0)`);
+    if (n) failures++;
+  }
+  const embeddedLeft = await countWhere(db, "User", { userCCA: { $in: ids } });
+  console.log(`  ${"User.userCCA[]".padEnd(18)} remaining ${embeddedLeft} (must be 0)`);
+  if (embeddedLeft) failures++;
+  for (const coll of KEPT) {
+    console.log(`  ${coll.padEnd(18)} orphaned ${await countWhere(db, coll, scope)} (kept on purpose)`);
+  }
+  console.log(`\nfailures: ${failures}`);
+  if (failures) return abort("removal did not complete cleanly — the backup holds every pre-image.");
+  console.log(`\nDone.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/verify-interview-slots.mjs
+++ b/scripts/remediation/verify-interview-slots.mjs
@@ -1,0 +1,355 @@
+/**
+ * Interview slot invariants — post-migration gate and standing drift census.
+ * READ-ONLY.
+ *
+ *   node scripts/remediation/verify-interview-slots.mjs            # all CCAs
+ *   node scripts/remediation/verify-interview-slots.mjs --cca 12   # one CCA
+ *
+ * TOUCHES THE DATABASE: reads only. No write, no index build, no delete.
+ *
+ * Group interview slots (docs/plans/cca/01) made occupancy DERIVED — the
+ * application's `interviewSlotID` is the only claim, and `capacity` on the slot
+ * is the bound. Nothing in Mongo enforces either half: there is no unique index
+ * on the pointer and no constraint tying it to a live slot, so over-booking is
+ * prevented by the advisory lock alone. This script is what notices when that
+ * assumption stops holding.
+ *
+ * RUN IT after the migration, after any hand-fix, and periodically. Check [1]
+ * is the one that matters: an over-capacity slot means a group interview will
+ * have more people in the room than the head planned for, and nothing in the UI
+ * will say so.
+ *
+ * EXIT CODES
+ *   0  invariants hold. Drift counts printed as warnings.
+ *   1  a BLOCKING invariant failed:
+ *      [1] a slot holds more applicants than its capacity
+ *      [2] a slot carries a capacity below 1 or above the schema max
+ *      [3] a LIVE application points at a canceled or non-existent slot
+ *      [5] a slot still carries the deleted booked* claim scalars
+ *      [7] a rejected/withdrawn application still holds a live future seat
+ *   2  could not connect, an unusable --cca argument (non-integer, or one that
+ *      matches no data at all), or an unexpected throw.
+ */
+import { PrismaClient } from "@prisma/client";
+import { findAll, numify } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+let failed = 0;
+const fail = (m) => {
+  console.error(`  FAIL  ${m}`);
+  failed++;
+};
+const warn = (m) => console.log(`  warn  ${m}`);
+
+/** Mirrors src/lib/schemas/ccaApplication.ts — plain .mjs cannot import it. */
+const SLOT_CAPACITY_DEFAULT = 1;
+const SLOT_CAPACITY_MAX = 20;
+const TERMINAL = new Set(["accepted", "rejected", "withdrawn"]);
+
+/**
+ * `interviewed` is NEITHER terminal NOR a live booking — see the long note in
+ * backfill-slot-capacity.mjs. Short version: the application is still open
+ * (so not terminal), but the interview has already happened and head cancelSlot
+ * only reverts `interview_scheduled` — so an interviewed applicant left
+ * pointing at a canceled slot is the record of an interview that took place,
+ * produced by two ordinary head actions. Check [3] must report it as history,
+ * not fail on it.
+ */
+const HISTORICAL = new Set([...TERMINAL, "interviewed"]);
+
+/** The three fields the migration removes. Checked by $exists, not by value. */
+const CLAIM_FIELDS = ["bookedByUserID", "bookedApplicationID", "bookedAt"];
+
+/**
+ * `--cca N`, or null for every CCA.
+ *
+ * A non-integer is REFUSED rather than coerced. `Number("all")` and
+ * `Number(undefined)` are both NaN, which is not null, so the scope filter
+ * would match zero rows and every check would pass having examined nothing —
+ * a verifier printing PASS over an empty set is worse than no verifier.
+ */
+const onlyCca = (() => {
+  const i = process.argv.indexOf("--cca");
+  if (i === -1) return null;
+  const arg = process.argv[i + 1];
+  const n = Number(arg);
+  if (arg === undefined || arg.trim?.() === "" || !Number.isInteger(n)) {
+    console.error(
+      `\n*** --cca needs an integer ccaID; got ${JSON.stringify(arg)}. ` +
+        `Refusing to run: a NaN scope silently checks nothing and prints PASS. ***\n`,
+    );
+    process.exit(2);
+  }
+  return n;
+})();
+
+function intOrNull(v) {
+  if (v == null) return null;
+  const n = numify(v);
+  return Number.isFinite(n) ? n : null;
+}
+/** Present AND non-null. */
+const has = (v) => v !== undefined && v !== null;
+/** $exists semantics. The old openSlots wrote the claim fields as EXPLICIT
+ *  NULLS, so a non-null test finds 1 of the 31 production rows that carry
+ *  them — and check [5] could then never fail on a pre-migration database. */
+const present = (d, k) =>
+  Object.prototype.hasOwnProperty.call(d, k) && d[k] !== undefined;
+
+/** THE definition of a seat count, mirrored from slotCapacity() in
+ *  src/server/api/services/ccaApplications.ts. If these two ever disagree this
+ *  script reports invariants the app does not actually hold. */
+const slotCapacity = (c) =>
+  typeof c === "number" && Number.isFinite(c) && Math.floor(c) >= 1
+    ? Math.floor(c)
+    : SLOT_CAPACITY_DEFAULT;
+
+async function main() {
+  console.log(`\n=== verify-interview-slots.mjs (READ-ONLY) ===\n`);
+
+  // Raw reads, not typed ones: the whole point of checks [2] and [5] is to see
+  // fields Prisma no longer models (booked*) and values it would happily
+  // deserialize past (a capacity of 0).
+  let slots = (await findAll(db, "CcaInterviewSlot")).map((d) => ({
+    slotID: intOrNull(d.slotID),
+    ccaID: intOrNull(d.ccaID),
+    startTime: intOrNull(d.startTime),
+    endTime: intOrNull(d.endTime),
+    rawCapacity: intOrNull(d.capacity),
+    // Non-null, not merely $exists: a stored `capacity: null` is exactly what
+    // the migration rewrites, so it belongs with "absent" and not with "set".
+    capacityUsable: has(d.capacity),
+    canceled: has(d.canceledAt),
+    leftovers: CLAIM_FIELDS.some((k) => present(d, k)),
+  }));
+  let apps = (await findAll(db, "CcaApplication")).map((d) => ({
+    applicationID: intOrNull(d.applicationID),
+    ccaID: intOrNull(d.ccaID),
+    userID: d.userID == null ? null : String(d.userID),
+    status: d.status == null ? null : String(d.status),
+    interviewSlotID: intOrNull(d.interviewSlotID),
+  }));
+
+  if (onlyCca !== null) {
+    slots = slots.filter((s) => s.ccaID === onlyCca);
+    apps = apps.filter((a) => a.ccaID === onlyCca);
+    console.log(`scoped to ccaID ${onlyCca}\n`);
+    // A ZERO-ROW SCOPE IS REFUSED, for the same reason a non-integer one is: an
+    // integer that matches nothing — `--cca 999`, or `--cca 4` fat-fingered for
+    // `--cca 49` — makes every check below pass having examined no data, and
+    // PASS over an empty set is worse than no verifier. A CCA with slots but no
+    // applications (or the reverse) is legitimate and still runs; only "neither
+    // exists" is treated as a mistyped id.
+    if (slots.length === 0 && apps.length === 0) {
+      console.error(
+        `\n*** ccaID ${onlyCca} has no interview slots AND no applications. ` +
+          `Refusing to report PASS over an empty set — check the id. ` +
+          `Run without --cca to verify every CCA. ***\n`,
+      );
+      process.exit(2);
+    }
+  }
+
+  const slotByID = new Map(slots.map((s) => [s.slotID, s]));
+  const occupants = new Map();
+  for (const a of apps) {
+    if (a.interviewSlotID === null) continue;
+    const arr = occupants.get(a.interviewSlotID) ?? [];
+    arr.push(a);
+    occupants.set(a.interviewSlotID, arr);
+  }
+
+  console.log(`slots: ${slots.length}   applications: ${apps.length}`);
+  console.log(
+    `claimed seats: ${[...occupants.values()].reduce((n, v) => n + v.length, 0)}`,
+  );
+  // Unscoped and empty is a DIFFERENT statement from a mistyped --cca: it means
+  // the feature has genuinely never been used. Said out loud rather than left
+  // to read as a clean bill of health.
+  if (onlyCca === null && slots.length === 0 && apps.length === 0) {
+    warn(
+      `there are no interview slots and no applications AT ALL. Every check ` +
+        `below passes vacuously — this is "nothing exists yet", not "everything ` +
+        `is correct".`,
+    );
+  }
+
+  /* [1] OCCUPANCY <= CAPACITY --------------------------------------------- */
+  // The invariant the advisory lock exists to keep. A breach here means either
+  // a write got in outside withCcaLock, or a capacity was lowered by hand under
+  // people who had already booked.
+  console.log(`\n[1] occupancy <= capacity (blocking)`);
+  let overCount = 0;
+  for (const s of slots) {
+    const occ = (occupants.get(s.slotID) ?? []).length;
+    const cap = slotCapacity(s.rawCapacity);
+    if (occ > cap) {
+      overCount++;
+      fail(
+        `slot #${s.slotID} (ccaID ${s.ccaID}) holds ${occ} applicant(s) but capacity is ${cap}: ` +
+          `applications ${(occupants.get(s.slotID) ?? []).map((a) => `#${a.applicationID}`).join(", ")}`,
+      );
+    }
+  }
+  console.log(`  over capacity: ${overCount}`);
+
+  /* [2] CAPACITY IS SANE --------------------------------------------------- */
+  console.log(`\n[2] capacity within 1..${SLOT_CAPACITY_MAX} (blocking)`);
+  let absent = 0;
+  let badCap = 0;
+  for (const s of slots) {
+    if (!s.capacityUsable) {
+      absent++;
+      continue;
+    }
+    if (s.rawCapacity === null || s.rawCapacity < 1 || s.rawCapacity > SLOT_CAPACITY_MAX) {
+      badCap++;
+      fail(`slot #${s.slotID}: capacity ${JSON.stringify(s.rawCapacity)} is outside 1..${SLOT_CAPACITY_MAX}`);
+    }
+  }
+  console.log(`  out of range: ${badCap}`);
+  console.log(`  absent or null: ${absent}`);
+  if (absent > 0) {
+    warn(
+      `${absent} slot(s) have no usable capacity (absent or null). slotCapacity() reads them as ` +
+        `${SLOT_CAPACITY_DEFAULT}, so nothing is broken — but backfill-slot-capacity.mjs ` +
+        `has not been run (or has not been run since these were written).`,
+    );
+  }
+
+  /* [3] POINTERS RESOLVE --------------------------------------------------- */
+  // Blocking only for a LIVE application. A HISTORICAL one (terminal, or
+  // `interviewed`) pointing at a canceled or deleted slot is the record of an
+  // interview that was scheduled and, in the interviewed case, actually
+  // happened — clearing it would erase that. See HISTORICAL above for why
+  // `interviewed` belongs here and not with the live statuses.
+  console.log(`\n[3] applications point at a live slot (blocking for live apps)`);
+  let missing = 0;
+  let atCanceled = 0;
+  let historical = 0;
+  for (const a of apps) {
+    if (a.interviewSlotID === null) continue;
+    const s = slotByID.get(a.interviewSlotID);
+    const isHistorical = HISTORICAL.has(a.status ?? "");
+    if (!s) {
+      if (isHistorical) historical++;
+      else {
+        missing++;
+        fail(`application #${a.applicationID} (${a.status}) points at slot #${a.interviewSlotID}, which does not exist`);
+      }
+      continue;
+    }
+    if (s.canceled) {
+      if (isHistorical) historical++;
+      else {
+        atCanceled++;
+        fail(
+          `application #${a.applicationID} (${a.status}) points at slot #${s.slotID}, which is CANCELED — ` +
+            `this resident thinks they have an interview that is not happening`,
+        );
+      }
+    }
+  }
+  console.log(`  live -> missing slot:  ${missing}`);
+  console.log(`  live -> canceled slot: ${atCanceled}`);
+  console.log(`  historical, left alone:${String(historical).padStart(3)}`);
+  if (historical > 0) {
+    warn(`${historical} decided/withdrawn/interviewed application(s) still name a canceled or deleted slot — kept on purpose, that is the record.`);
+  }
+
+  /* [4] STATUS AGREES WITH THE POINTER ------------------------------------- */
+  // Not blocking: neither direction breaks a booking, and both are visible in
+  // the UI. Reported because a drift here is how a resident ends up unable to
+  // book (status says scheduled) or unable to find their interview.
+  console.log(`\n[4] interview_scheduled <-> a slot pointer`);
+  const scheduledNoSlot = apps.filter(
+    (a) => a.status === "interview_scheduled" && a.interviewSlotID === null,
+  );
+  const slotNotScheduled = apps.filter(
+    (a) =>
+      a.interviewSlotID !== null &&
+      a.status !== "interview_scheduled" &&
+      !HISTORICAL.has(a.status ?? ""),
+  );
+  console.log(`  scheduled with no slot: ${scheduledNoSlot.length}`);
+  console.log(`  slot held, not scheduled/interviewed: ${slotNotScheduled.length}`);
+  if (scheduledNoSlot.length) {
+    warn(`e.g. ${scheduledNoSlot.slice(0, 5).map((a) => `#${a.applicationID}`).join(", ")} — these residents see "Waiting for interview" with nothing booked.`);
+  }
+  if (slotNotScheduled.length) {
+    warn(`e.g. ${slotNotScheduled.slice(0, 5).map((a) => `#${a.applicationID} (${a.status})`).join(", ")} — occupying a seat while not scheduled.`);
+  }
+
+  /* [5] THE DELETED CLAIM SCALARS ------------------------------------------ */
+  // `prisma db push` removes a field from PRISMA'S VIEW only; the documents keep
+  // it until backfill-slot-capacity.mjs $unsets them. A leftover is not read by
+  // anything any more, but it is a second, stale answer to "who booked this"
+  // sitting next to the real one — exactly the drift pair Option C removed.
+  //
+  // Detected by $exists, not by value: the old openSlots wrote all three as
+  // explicit nulls, so a non-null test would find 1 slot instead of 31 and this
+  // check could not fail on a pre-migration database at all.
+  console.log(`\n[5] leftover ${CLAIM_FIELDS.join(" / ")} (blocking)`);
+  const leftovers = slots.filter((s) => s.leftovers);
+  console.log(`  slots still carrying them: ${leftovers.length}`);
+  if (leftovers.length) {
+    fail(
+      `${leftovers.length} slot(s) still carry the deleted claim scalars ` +
+        `(e.g. ${leftovers.slice(0, 5).map((s) => `#${s.slotID}`).join(", ")}). ` +
+        `Run backfill-slot-capacity.mjs --commit.`,
+    );
+  }
+
+  /* [6] GROUP SLOT CENSUS --------------------------------------------------- */
+  console.log(`\n[6] group slot census`);
+  const live = slots.filter((s) => !s.canceled);
+  const group = live.filter((s) => slotCapacity(s.rawCapacity) > 1);
+  const seats = live.reduce((n, s) => n + slotCapacity(s.rawCapacity), 0);
+  const taken = live.reduce((n, s) => n + (occupants.get(s.slotID) ?? []).length, 0);
+  console.log(`  live slots:   ${live.length}`);
+  console.log(`  group slots:  ${group.length}`);
+  console.log(`  seats:        ${seats}`);
+  console.log(`  seats taken:  ${taken}`);
+  if (group.length > 0) {
+    const sizes = [...new Set(group.map((s) => slotCapacity(s.rawCapacity)))].sort((a, b) => a - b);
+    console.log(`  capacities in use: ${sizes.join(", ")}`);
+  }
+
+  /* [7] STRANDED SEATS ----------------------------------------------------- */
+  // `rejected` and `withdrawn` BOTH null the pointer in normal operation
+  // (reject does so whenever the slot is still future; withdraw always). So one
+  // of those still aimed at a live, future slot is a seat nobody can book and
+  // nobody is using — no UI shows it, availableSlots just reports one fewer
+  // seat, and clearFreeSlots treats the slot as occupied.
+  //
+  // The known way to produce it is a reject landing inside the migration's
+  // snapshot window (see "THE LIVE-SURFACE WINDOW" in backfill-slot-capacity.mjs
+  // — which is why --commit refuses to run while the surface is live). Blocking,
+  // because the fix is a one-line hand-edit and the alternative is a seat that
+  // stays lost.
+  console.log(`\n[7] stranded seats (blocking)`);
+  const nowSec = Math.floor(Date.now() / 1000);
+  const stranded = apps.filter((a) => {
+    if (a.interviewSlotID === null) return false;
+    if (a.status !== "rejected" && a.status !== "withdrawn") return false;
+    const s = slotByID.get(a.interviewSlotID);
+    return !!s && !s.canceled && s.endTime !== null && s.endTime > nowSec;
+  });
+  console.log(`  ${stranded.length}`);
+  for (const a of stranded) {
+    fail(
+      `application #${a.applicationID} (${a.status}) still holds a seat on live future slot #${a.interviewSlotID}. ` +
+        `Nobody can book it and nobody is using it — set interviewSlotID = null on that application.`,
+    );
+  }
+
+  console.log(`\n=== ${failed === 0 ? "PASS" : `FAIL (${failed} blocking)`} ===\n`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main()
+  .catch((e) => {
+    console.error(`\nUNEXPECTED: ${e?.stack ?? e}\n`);
+    process.exit(2);
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/cca/_components/InterviewSessions.tsx
+++ b/src/app/cca/_components/InterviewSessions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, MapPin, Users } from "lucide-react";
 
 import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
@@ -19,6 +19,51 @@ function dayKey(epoch: number): string {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
+/** One session: the slot, and everyone being seen in it. */
+type Session = { slot: AppRow["slot"]; rows: AppRow[] };
+
+/** Still to be run. Drives which SECTION a session lands in — see below. */
+const isPending = (s: Session) =>
+  s.rows.some((r) => r.status === "interview_scheduled");
+
+/**
+ * Group rows into sessions, preserving the caller's ordering.
+ *
+ * CALLED ONCE, OVER EVERY ROW — never per section. Sections partition by
+ * status, and a capacity-4 slot where two applicants have been marked done and
+ * two have not would otherwise be split into two sessions for the same slot,
+ * each headed "2 applicants of 4". The slot is one event; it gets one header,
+ * and the section it lands in is decided from the session as a whole
+ * (isPending: anyone still to be seen keeps the whole session in the to-do
+ * list). Per-row state — the Mark done button — stays per row.
+ *
+ * Grouped on slotID, NOT on the formatted time: two distinct slots can print
+ * the same label (different locations, or a slot canceled and reopened), and
+ * merging those into one session would put people in a room they are not in.
+ * Applications with no slot each become their own single-row session, so
+ * "No time" rows never collapse into one another.
+ */
+function groupBySlot(rows: AppRow[]): Session[] {
+  const out: Session[] = [];
+  const bySlot = new Map<number, Session>();
+  for (const r of rows) {
+    const id = r.slot?.slotID ?? null;
+    if (id === null) {
+      out.push({ slot: null, rows: [r] });
+      continue;
+    }
+    const existing = bySlot.get(id);
+    if (existing) {
+      existing.rows.push(r);
+    } else {
+      const session: Session = { slot: r.slot, rows: [r] };
+      bySlot.set(id, session);
+      out.push(session);
+    }
+  }
+  return out;
+}
+
 /**
  * The "Interviews" tab — the head's run-sheet, distinct from "Interview slots"
  * (availability). Today's interviews sit at the top, then everything else still
@@ -26,6 +71,12 @@ function dayKey(epoch: number): string {
  * done button moves it to Interviewed; accept/reject happens on the Applications
  * tab. Expanding a row shows the applicant's full details, the notes they sent,
  * and the interview notes (which can be added here, during the interview).
+ *
+ * Applicants sharing a slot are GROUPED under one session header rather than
+ * listed as siblings that happen to repeat the same time. A group interview is
+ * one thing that happens once, with four people in the room — a run-sheet that
+ * prints the 10:00 slot four times is a run-sheet you cannot follow. Mark-done
+ * stays PER APPLICANT: they are interviewed together but assessed individually.
  */
 export default function InterviewSessions({ ccaID }: { ccaID: number }) {
   const list = api.ccaApplicationsHead.listApplications.useQuery(
@@ -55,18 +106,26 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
     (b.slot?.startTime ?? Number.MAX_SAFE_INTEGER);
 
   const apps = list.data.applications;
-  const scheduled = apps
-    .filter((a) => a.status === "interview_scheduled")
+  // Sort and group ONCE across both statuses, so a part-done group slot stays a
+  // single session. Sorting first means the sessions come out time-ordered and
+  // each session's rows are in time order too (they share a time, so this just
+  // makes the order stable).
+  const runnable = apps
+    .filter(
+      (a) => a.status === "interview_scheduled" || a.status === "interviewed",
+    )
     .sort(byTime);
-  const completed = apps.filter((a) => a.status === "interviewed").sort(byTime);
+  const sessions = groupBySlot(runnable);
 
   const today = dayKey(Math.floor(Date.now() / 1000));
-  const isToday = (a: AppRow) =>
-    a.slot?.startTime != null && dayKey(a.slot.startTime) === today;
-  const todays = scheduled.filter(isToday);
-  const upcoming = scheduled.filter((a) => !isToday(a));
+  const isToday = (s: Session) =>
+    s.slot?.startTime != null && dayKey(s.slot.startTime) === today;
+  const pending = sessions.filter(isPending);
+  const todays = pending.filter(isToday);
+  const upcoming = pending.filter((s) => !isToday(s));
+  const completed = sessions.filter((s) => !isPending(s));
 
-  if (scheduled.length === 0 && completed.length === 0) {
+  if (sessions.length === 0) {
     return (
       <div className="rounded-lg border border-gray-200 bg-white px-4 py-10 text-center">
         <p className="text-sm font-medium text-gray-900">
@@ -87,9 +146,8 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
         <Section
           title="Today"
           subtitle="Interviews happening today."
-          rows={todays}
+          sessions={todays}
           ccaID={ccaID}
-          markable
           highlight
         />
       )}
@@ -97,18 +155,16 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
         <Section
           title="To be interviewed"
           subtitle="Booked — mark each done once you've met the applicant."
-          rows={upcoming}
+          sessions={upcoming}
           ccaID={ccaID}
-          markable
         />
       )}
       {completed.length > 0 && (
         <Section
           title="Already interviewed"
           subtitle="Done — review and accept or reject on the Applications tab."
-          rows={completed}
+          sessions={completed}
           ccaID={ccaID}
-          markable={false}
         />
       )}
     </div>
@@ -118,18 +174,18 @@ export default function InterviewSessions({ ccaID }: { ccaID: number }) {
 function Section({
   title,
   subtitle,
-  rows,
+  sessions,
   ccaID,
-  markable,
   highlight = false,
 }: {
   title: string;
   subtitle: string;
-  rows: AppRow[];
+  /** Already grouped by the caller — see the note on groupBySlot. */
+  sessions: Session[];
   ccaID: number;
-  markable: boolean;
   highlight?: boolean;
 }) {
+  const rowCount = sessions.reduce((n, s) => n + s.rows.length, 0);
   return (
     <section
       className={
@@ -144,16 +200,20 @@ function Section({
         >
           {title}
         </h2>
-        <span className="text-xs text-gray-400">{rows.length}</span>
+        <span className="text-xs text-gray-400">
+          {rowCount}
+          {sessions.length !== rowCount
+            ? ` · ${sessions.length} session${sessions.length === 1 ? "" : "s"}`
+            : ""}
+        </span>
       </div>
       <p className="mb-2 text-xs text-gray-500">{subtitle}</p>
-      <ul className="space-y-2">
-        {rows.map((a) => (
-          <SessionRow
-            key={a.applicationID}
+      <ul className="space-y-3">
+        {sessions.map((s, i) => (
+          <SessionGroup
+            key={s.slot?.slotID ?? `unslotted-${s.rows[0]?.applicationID ?? i}`}
             ccaID={ccaID}
-            app={a}
-            markable={markable}
+            session={s}
           />
         ))}
       </ul>
@@ -161,15 +221,82 @@ function Section({
   );
 }
 
+/**
+ * One session header with its applicants underneath.
+ *
+ * The header is shown whenever the SLOT is a group slot (capacity > 1) — not
+ * merely when more than one person has booked. A capacity-4 slot with one
+ * booking is still a group session: three more people may walk in before it
+ * runs, and rendering it as an ordinary 1:1 row would tell the head the exact
+ * opposite. That is the deliberate choice; the alternative (header only when
+ * rows > 1) makes the run-sheet silently change shape as bookings arrive.
+ *
+ * A genuine 1:1 renders WITHOUT a header — today's layout, and the
+ * overwhelmingly common case. Wrapping every single interview in a "1 applicant"
+ * banner would make every existing CCA's run-sheet noisier to buy a feature
+ * none of them use yet.
+ */
+function SessionGroup({ ccaID, session }: { ccaID: number; session: Session }) {
+  const { slot, rows } = session;
+  const capacity = slot?.capacity ?? 1;
+  const grouped = rows.length > 1 || capacity > 1;
+
+  if (!grouped) {
+    return <SessionRow ccaID={ccaID} app={rows[0]!} showTime />;
+  }
+
+  const done = rows.filter((r) => r.status === "interviewed").length;
+
+  return (
+    <li className="overflow-hidden rounded-lg border border-amber-200 bg-amber-50/40">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-amber-200 px-3 py-2">
+        <span className="text-sm font-semibold tabular-nums text-amber-900">
+          {slot ? formatSlot(slot.startTime, slot.endTime) : "No time"}
+        </span>
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-800">
+          <Users className="h-3.5 w-3.5" />
+          {rows.length} applicant{rows.length === 1 ? "" : "s"}
+          {capacity > rows.length ? ` of ${capacity}` : ""}
+        </span>
+        {done > 0 && done < rows.length && (
+          <span className="text-xs text-amber-700">{done} done</span>
+        )}
+        {slot?.location && (
+          <span className="inline-flex items-center gap-1 text-xs text-amber-800">
+            <MapPin className="h-3.5 w-3.5" />
+            {slot.location}
+          </span>
+        )}
+      </div>
+      <ul className="space-y-2 p-2">
+        {rows.map((a) => (
+          <SessionRow
+            key={a.applicationID}
+            ccaID={ccaID}
+            app={a}
+            showTime={false}
+          />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
 function SessionRow({
   ccaID,
   app,
-  markable,
+  showTime,
 }: {
   ccaID: number;
   app: AppRow;
-  markable: boolean;
+  /** False inside a grouped session — the header already says the time, and
+   *  repeating it on every row is the fragmentation the grouping removes. */
+  showTime: boolean;
 }) {
+  // PER ROW, not per section. A group session sits in "To be interviewed" while
+  // some of its applicants are already done; those rows must not offer Mark
+  // done again (the server would refuse it with NOT_INTERVIEWABLE anyway).
+  const markable = app.status === "interview_scheduled";
   const utils = api.useUtils();
   const [open, setOpen] = useState(false);
   const mark = api.ccaApplicationsHead.markInterviewed.useMutation({
@@ -190,11 +317,13 @@ function SessionRow({
           aria-expanded={open}
           className="flex min-w-0 flex-1 items-center gap-3 text-left"
         >
-          <span className="shrink-0 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium tabular-nums text-gray-700">
-            {app.slot
-              ? formatSlot(app.slot.startTime, app.slot.endTime)
-              : "No time"}
-          </span>
+          {showTime && (
+            <span className="shrink-0 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium tabular-nums text-gray-700">
+              {app.slot
+                ? formatSlot(app.slot.startTime, app.slot.endTime)
+                : "No time"}
+            </span>
+          )}
           <span className="min-w-0">
             <span className="block truncate text-sm font-medium text-gray-900">
               {name}
@@ -207,7 +336,7 @@ function SessionRow({
             }`}
           />
         </button>
-        {markable && (
+        {markable ? (
           <Button
             onClick={() =>
               mark.mutate({ ccaID, applicationID: app.applicationID })
@@ -218,6 +347,10 @@ function SessionRow({
             <Check className="h-4 w-4" />
             {mark.isPending ? "…" : "Mark done"}
           </Button>
+        ) : (
+          <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-gray-400">
+            <Check className="h-3.5 w-3.5" /> Done
+          </span>
         )}
       </div>
       {open && <SessionDetail ccaID={ccaID} app={app} />}

--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -8,6 +8,7 @@ import {
   Pencil,
   Plus,
   Trash2,
+  Users,
   X,
 } from "lucide-react";
 
@@ -17,12 +18,33 @@ import {
   editSlotInput,
   INTERVIEW_LOCATION_MAX,
   MAX_SLOTS_PER_OPEN,
+  SLOT_CAPACITY_DEFAULT,
+  SLOT_CAPACITY_MAX,
   slotDraftSchema,
 } from "~/lib/schemas/ccaApplication";
 
 type Slot = RouterOutputs["ccaApplicationsHead"]["listSlots"]["slots"][number];
 
 const DURATION_PRESETS = [10, 15, 20, 30, 45, 60];
+/** 1 is a normal interview; the rest are the group sizes heads actually ask
+ *  for. Anything else goes in the custom box. */
+const CAPACITY_PRESETS = [1, 2, 3, 4, 6];
+
+/** Seats still open on a slot. Never negative — a capacity lowered by hand
+ *  below the occupancy would otherwise render "-1 left". */
+function seatsLeft(slot: Slot): number {
+  return Math.max(0, slot.capacity - slot.occupancy);
+}
+
+/** Occupant names for a card, truncated: four rows of names in a small card is
+ *  noise, and the head opens the run-sheet to actually work through them. */
+function occupantSummary(slot: Slot): string {
+  const names = slot.occupants.map(
+    (o) => o.applicant.displayName ?? o.applicant.email ?? o.userID,
+  );
+  if (names.length <= 3) return names.join(", ");
+  return `${names.slice(0, 3).join(", ")} +${names.length - 3} more`;
+}
 
 /* ------------------------------- time helpers ------------------------------ */
 
@@ -75,9 +97,11 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
     [list.data],
   );
 
-  // Free = unbooked. Only these are ever bulk-cleared; booked slots stay.
+  // Free = NOBODY on it. A group slot with one person and three spare seats is
+  // not free and is never bulk-cleared — same rule as the server's
+  // clearFreeSlots, so this count and that mutation cannot disagree.
   const freeCount = useMemo(
-    () => (list.data?.slots ?? []).filter((s) => s.bookedByUserID === null).length,
+    () => (list.data?.slots ?? []).filter((s) => s.occupancy === 0).length,
     [list.data],
   );
 
@@ -104,9 +128,9 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
               onClick={() => {
                 if (
                   window.confirm(
-                    `Clear all ${freeCount} free (unbooked) slot${
+                    `Clear all ${freeCount} empty slot${
                       freeCount === 1 ? "" : "s"
-                    }? Booked slots are kept.`,
+                    }? Slots with anyone booked on them are kept.`,
                   )
                 ) {
                   clear.mutate({ ccaID });
@@ -115,7 +139,7 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
               className="text-red-600 hover:bg-red-50 hover:text-red-700"
             >
               <Trash2 className="mr-1.5 h-4 w-4" />
-              {clear.isPending ? "Clearing…" : "Clear free slots"}
+              {clear.isPending ? "Clearing…" : "Clear empty slots"}
             </Button>
           )}
         </div>
@@ -158,6 +182,10 @@ function SlotGenerator({
   const [to, setTo] = useState("");
   const [duration, setDuration] = useState(15);
   const [gap, setGap] = useState(0);
+  // One capacity for the whole generated batch. Per-slot changes are an edit on
+  // the card afterwards — a per-chip capacity picker in the preview would be a
+  // lot of UI for a case that barely happens.
+  const [capacity, setCapacity] = useState(SLOT_CAPACITY_DEFAULT);
   const [location, setLocation] = useState("");
   const [removed, setRemoved] = useState<Set<number>>(new Set());
   const [formError, setFormError] = useState<string | null>(null);
@@ -235,11 +263,20 @@ function SlotGenerator({
       );
       return;
     }
-    // Validate each against the shared schema before sending.
+    if (capacity < 1 || capacity > SLOT_CAPACITY_MAX) {
+      setFormError(
+        `People per slot has to be between 1 and ${SLOT_CAPACITY_MAX}.`,
+      );
+      return;
+    }
+    // Validate each against the shared schema before sending. `capacity` is
+    // sent explicitly rather than left to the schema default, so what the head
+    // sees in the preview is literally what is transmitted.
     const slots = creatable.map((c) => ({
       startTime: c.startTime,
       endTime: c.endTime,
       location: location.trim() || undefined,
+      capacity,
     }));
     for (const s of slots) {
       if (!slotDraftSchema.safeParse(s).success) {
@@ -342,7 +379,44 @@ function SlotGenerator({
             className="w-20 rounded-md border border-gray-300 px-2 py-1 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
           />
         </div>
+        <div>
+          <p className="mb-1 text-sm font-medium text-gray-700">
+            People per slot
+          </p>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {CAPACITY_PRESETS.map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setCapacity(n)}
+                className={`rounded-md px-2.5 py-1 text-sm font-medium transition-colors ${
+                  capacity === n
+                    ? "bg-emerald-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+            <input
+              type="number"
+              min={1}
+              max={SLOT_CAPACITY_MAX}
+              value={capacity}
+              onChange={(e) => setCapacity(Number(e.target.value) || 0)}
+              aria-label="Custom people per slot"
+              className="w-16 rounded-md border border-gray-300 px-2 py-1 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            />
+          </div>
+        </div>
       </div>
+
+      {capacity > 1 && (
+        <p className="mt-2 text-xs text-amber-700">
+          Group interviews — every slot takes {capacity} applicants at once, and
+          they&rsquo;ll see it labelled that way before they book.
+        </p>
+      )}
 
       {/* Preview */}
       {candidates.length > 0 && (
@@ -351,6 +425,11 @@ function SlotGenerator({
             <p className="text-sm font-medium text-gray-700">
               {creatable.length} slot{creatable.length === 1 ? "" : "s"} to
               open{" "}
+              {capacity > 1 && (
+                <span className="font-normal text-gray-500">
+                  · {creatable.length * capacity} seats
+                </span>
+              )}{" "}
               <span className="font-normal text-gray-400">
                 ({fmtTime(candidates[0]!.startTime)}–
                 {fmtTime(candidates[candidates.length - 1]!.endTime)})
@@ -396,6 +475,7 @@ function SlotGenerator({
                     }`}
                   >
                     {fmtTime(c.startTime)}
+                    {capacity > 1 && <span>×{capacity}</span>}
                     {!excluded && <Check className="h-3 w-3" />}
                   </button>
                 </li>
@@ -445,9 +525,14 @@ function fmtDayTab(epoch: number): string {
 }
 
 /**
- * A day view: pick a day, see that day's slots laid out as cards. Booked slots
- * are solid green and name who took them; free slots are plain white. This reads
- * far more like a schedule than one long flat list.
+ * A day view: pick a day, see that day's slots laid out as cards. Fill state is
+ * THREE-WAY since group slots: white empty, amber part-full, solid green full.
+ * A half-empty group session has to be visible at a glance — it is the one that
+ * still needs bookings, and a two-state card would show it as "booked" and hide
+ * exactly that.
+ *
+ * Counts here are SEATS, not slots: with capacity > 1 the number of slots on a
+ * day stops being the number of people who can be seen that day.
  */
 function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
   const days = useMemo(() => {
@@ -479,7 +564,8 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
     days.find(([k]) => k >= todayKey)?.[0] ?? days[0]?.[0] ?? null;
   const current = days.find(([k]) => k === (selected ?? defaultDay)) ?? days[0]!;
   const daySlots = current[1];
-  const booked = daySlots.filter((s) => s.bookedByUserID !== null).length;
+  const seats = daySlots.reduce((n, s) => n + s.capacity, 0);
+  const booked = daySlots.reduce((n, s) => n + s.occupancy, 0);
 
   return (
     <div className="space-y-3">
@@ -487,7 +573,8 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
       <div className="flex gap-1.5 overflow-x-auto pb-1">
         {days.map(([key, ds]) => {
           const active = key === current[0];
-          const b = ds.filter((s) => s.bookedByUserID !== null).length;
+          const dSeats = ds.reduce((n, s) => n + s.capacity, 0);
+          const b = ds.reduce((n, s) => n + s.occupancy, 0);
           return (
             <button
               key={key}
@@ -505,6 +592,7 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
               </span>
               <span className={active ? "text-emerald-600" : "text-gray-400"}>
                 {ds.length} slot{ds.length === 1 ? "" : "s"}
+                {dSeats !== ds.length ? ` · ${dSeats} seats` : ""}
                 {b > 0 ? ` · ${b} booked` : ""}
               </span>
             </button>
@@ -513,16 +601,21 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
       </div>
 
       {/* Legend */}
-      <div className="flex items-center gap-4 text-xs text-gray-500">
+      <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500">
         <span className="inline-flex items-center gap-1.5">
-          <span className="h-3 w-3 rounded bg-emerald-600" /> Booked
+          <span className="h-3 w-3 rounded bg-emerald-600" /> Full
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded border border-amber-300 bg-amber-100" />{" "}
+          Partly booked
         </span>
         <span className="inline-flex items-center gap-1.5">
           <span className="h-3 w-3 rounded border border-gray-300 bg-white" />{" "}
-          Free
+          Empty
         </span>
         <span className="ml-auto tabular-nums">
-          {daySlots.length - booked} free · {booked} booked
+          {seats - booked} seat{seats - booked === 1 ? "" : "s"} free ·{" "}
+          {booked} booked
         </span>
       </div>
 
@@ -539,7 +632,9 @@ function ScheduleView({ ccaID, slots }: { ccaID: number; slots: Slot[] }) {
 function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
   const utils = api.useUtils();
   const [editing, setEditing] = useState(false);
-  const booked = slot.bookedByUserID !== null;
+  const occupied = slot.occupancy > 0;
+  const full = seatsLeft(slot) === 0;
+  const group = slot.capacity > 1;
 
   const refresh = () => utils.ccaApplicationsHead.listSlots.invalidate({ ccaID });
   const cancel = api.ccaApplicationsHead.cancelSlot.useMutation({
@@ -562,58 +657,78 @@ function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
     );
   }
 
+  // Three-way fill. `full` (not `occupied`) drives the solid treatment so a
+  // group slot only reads as "done" once there is nothing left to sell.
+  const tone = full
+    ? "border-emerald-600 bg-emerald-600 text-white"
+    : occupied
+      ? "border-amber-300 bg-amber-50"
+      : "border-gray-200 bg-white";
+  const muted = full
+    ? "text-emerald-50"
+    : occupied
+      ? "text-amber-800"
+      : "text-gray-500";
+
   return (
-    <div
-      className={`relative rounded-lg border p-3 ${
-        booked
-          ? "border-emerald-600 bg-emerald-600 text-white"
-          : "border-gray-200 bg-white"
-      }`}
-    >
+    <div className={`relative rounded-lg border p-3 ${tone}`}>
       <p
         className={`text-sm font-semibold tabular-nums ${
-          booked ? "text-white" : "text-gray-800"
+          full ? "text-white" : "text-gray-800"
         }`}
       >
         {fmtTime(slot.startTime)} – {fmtTime(slot.endTime)}
       </p>
       {slot.location && (
-        <p
-          className={`mt-0.5 inline-flex items-center gap-1 text-xs ${
-            booked ? "text-emerald-50" : "text-gray-500"
-          }`}
-        >
+        <p className={`mt-0.5 inline-flex items-center gap-1 text-xs ${muted}`}>
           <MapPin className="h-3 w-3" />
           {slot.location}
         </p>
       )}
-      <p
-        className={`mt-1 truncate text-xs ${
-          booked ? "text-emerald-50" : "text-gray-400"
-        }`}
-      >
-        {booked
-          ? (slot.bookedBy?.displayName ?? slot.bookedBy?.email ?? "Booked")
-          : "Free"}
+      <p className={`mt-1 text-xs font-medium tabular-nums ${muted}`}>
+        {group ? (
+          <>
+            <Users className="mr-1 inline h-3 w-3 align-[-2px]" />
+            {slot.occupancy}/{slot.capacity} booked
+          </>
+        ) : occupied ? (
+          "Booked"
+        ) : (
+          "Free"
+        )}
       </p>
+      {occupied && (
+        <p className={`mt-0.5 truncate text-xs ${muted}`}>
+          {occupantSummary(slot)}
+        </p>
+      )}
 
       {/* Actions — always visible so they work on touch too. */}
       <div className="absolute right-1.5 top-1.5 flex items-center gap-0.5">
-        {!booked && (
-          <button
-            onClick={() => setEditing(true)}
-            aria-label="Edit slot"
-            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </button>
-        )}
+        {/* Edit stays available on an occupied slot: the capacity is editable
+            there (raising it re-opens the slot), and the server refuses any
+            time/location change while anyone is booked. */}
+        <button
+          onClick={() => setEditing(true)}
+          aria-label="Edit slot"
+          className={`rounded p-1 ${
+            full
+              ? "text-emerald-100 hover:bg-emerald-700 hover:text-white"
+              : "text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+          }`}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
         <button
           onClick={() => {
             if (
-              booked &&
+              occupied &&
               !window.confirm(
-                "This slot is booked. Cancelling sends that applicant back to reschedule. Continue?",
+                `This slot has ${slot.occupancy} applicant${
+                  slot.occupancy === 1 ? "" : "s"
+                } booked. Cancelling sends ${
+                  slot.occupancy === 1 ? "them" : "all of them"
+                } back to reschedule. Continue?`,
               )
             ) {
               return;
@@ -623,7 +738,7 @@ function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
           disabled={cancel.isPending}
           aria-label="Cancel slot"
           className={`rounded p-1 disabled:opacity-50 ${
-            booked
+            full
               ? "text-emerald-100 hover:bg-emerald-700 hover:text-white"
               : "text-gray-400 hover:bg-red-50 hover:text-red-600"
           }`}
@@ -656,7 +771,9 @@ function SlotEditForm({
     slot.endTime !== null ? toTimeInput(slot.endTime) : "",
   );
   const [location, setLocation] = useState(slot.location ?? "");
+  const [capacity, setCapacity] = useState(slot.capacity);
   const [err, setErr] = useState<string | null>(null);
+  const locked = slot.occupancy > 0;
 
   const update = api.ccaApplicationsHead.updateSlot.useMutation({
     onSuccess: onDone,
@@ -669,18 +786,29 @@ function SlotEditForm({
       setErr("Pick a date, start and end.");
       return;
     }
+    // Refuse locally what the server refuses, so the head is told BEFORE the
+    // round trip that they would be evicting someone.
+    if (capacity < slot.occupancy) {
+      setErr(
+        `${slot.occupancy} applicant${
+          slot.occupancy === 1 ? " has" : "s have"
+        } already booked this slot — capacity can't go below ${slot.occupancy}.`,
+      );
+      return;
+    }
     const parsed = editSlotInput.safeParse({
       ccaID,
       slotID: slot.slotID,
       startTime,
       endTime,
       location: location.trim() || undefined,
+      capacity,
     });
     if (!parsed.success) {
       setErr(
         parsed.error.issues[0]?.message === "END_BEFORE_START"
           ? "End has to be after start."
-          : "That isn't valid.",
+          : `That isn't valid — people per slot must be 1–${SLOT_CAPACITY_MAX}.`,
       );
       return;
     }
@@ -694,25 +822,51 @@ function SlotEditForm({
       : update.error.message === "SLOT_IN_PAST"
         ? "That's in the past."
         : update.error.message === "SLOT_BOOKED"
-          ? "This slot was just booked — cancel it instead."
-          : "That didn't save."
+          ? "Someone's booked on this slot — you can change how many people it takes, but not when or where. Cancel it instead."
+          : update.error.message === "CAPACITY_BELOW_OCCUPANCY"
+            ? "Someone booked while you were editing — capacity can't go below the number already on this slot."
+            : "That didn't save."
     : null;
 
   return (
     <div className="space-y-2">
-      <div className="grid gap-2 sm:grid-cols-4">
-        <input type="date" value={date} onChange={(e) => setDate(e.target.value)} className={inputCls} />
-        <input type="time" value={from} onChange={(e) => setFrom(e.target.value)} className={inputCls} />
-        <input type="time" value={to} onChange={(e) => setTo(e.target.value)} className={inputCls} />
+      {/* Time and location are DISABLED once anyone is booked — the server
+          refuses to move an occupied slot, so offering the field would only
+          produce a rejection. Capacity stays live: raising it is the whole
+          reason to open this form on an occupied slot. */}
+      <div className="grid gap-2 sm:grid-cols-5">
+        <input type="date" value={date} disabled={locked} onChange={(e) => setDate(e.target.value)} className={inputCls} />
+        <input type="time" value={from} disabled={locked} onChange={(e) => setFrom(e.target.value)} className={inputCls} />
+        <input type="time" value={to} disabled={locked} onChange={(e) => setTo(e.target.value)} className={inputCls} />
         <input
           type="text"
           value={location}
+          disabled={locked}
           maxLength={INTERVIEW_LOCATION_MAX}
           onChange={(e) => setLocation(e.target.value)}
           placeholder="Location"
           className={inputCls}
         />
+        <label className="text-sm">
+          <span className="sr-only">People per slot</span>
+          <input
+            type="number"
+            min={Math.max(1, slot.occupancy)}
+            max={SLOT_CAPACITY_MAX}
+            value={capacity}
+            onChange={(e) => setCapacity(Number(e.target.value) || 0)}
+            aria-label="People per slot"
+            title="People per slot"
+            className={inputCls}
+          />
+        </label>
       </div>
+      <p className="text-xs text-gray-500">
+        People per slot: {capacity}
+        {slot.occupancy > 0
+          ? ` · ${slot.occupancy} already booked (time and location are locked while anyone is booked)`
+          : ""}
+      </p>
       {(err ?? serverErr) && <p className="text-sm text-red-600">{err ?? serverErr}</p>}
       <div className="flex items-center gap-2">
         <Button onClick={save} disabled={update.isPending} className="inline-flex items-center gap-1.5">

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -198,7 +198,7 @@ export default function CcaApplyPanel({ ccaID }: { ccaID: number }) {
         <ApplicationInProgress
           ccaID={ccaID}
           app={app}
-          openSlotCount={d.openSlotCount}
+          openSeatCount={d.openSeatCount}
           onWithdraw={() =>
             withdraw.mutate({ applicationID: app.applicationID })
           }
@@ -310,11 +310,18 @@ function Card({ children }: { children: React.ReactNode }) {
 
 type AppShape = RouterOutputs["ccaApplications"]["getCca"]["application"];
 
-/** The panel shown while an application is live (submitted / scheduled). */
+/**
+ * The panel shown while an application is live (submitted / scheduled).
+ *
+ * `openSeatCount` is SEATS across every future open slot, not slots — one group
+ * slot taking four people is four bookable things. It is only ever tested as
+ * "> 0" here (is there anything to book at all?), but it is named for what it
+ * counts so a future "3 slots open" caption cannot quietly print the wrong noun.
+ */
 function ApplicationInProgress({
   ccaID,
   app,
-  openSlotCount,
+  openSeatCount,
   onWithdraw,
   withdrawing,
   onCancelSlot,
@@ -323,7 +330,7 @@ function ApplicationInProgress({
 }: {
   ccaID: number;
   app: NonNullable<AppShape>;
-  openSlotCount: number;
+  openSeatCount: number;
   onWithdraw: () => void;
   withdrawing: boolean;
   onCancelSlot: () => void;
@@ -346,7 +353,7 @@ function ApplicationInProgress({
           </span>
           <p className="mt-2 text-sm text-gray-600">
             {app.status === "submitted" &&
-              (openSlotCount > 0
+              (openSeatCount > 0
                 ? "Your application is in. Book an interview slot below."
                 : "Your application is in. The CCA will open interview slots soon.")}
             {scheduled && "Your interview is booked."}
@@ -382,7 +389,7 @@ function ApplicationInProgress({
                     {cancelingSlot ? "Cancelling…" : "Cancel interview"}
                   </button>
                 </>
-              ) : openSlotCount > 0 ? (
+              ) : openSeatCount > 0 ? (
                 <Button
                   onClick={() => setPicking(true)}
                   className="inline-flex items-center gap-1.5"

--- a/src/app/ccas/_components/SlotPicker.tsx
+++ b/src/app/ccas/_components/SlotPicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MapPin } from "lucide-react";
+import { MapPin, Users } from "lucide-react";
 
 import { api } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
@@ -16,6 +16,12 @@ import { formatSlot } from "../_lib/status";
  * `onDone` fires after a successful book and OWNS the cache invalidation for
  * whichever surface mounted this (getCca vs myApplications), so the picker stays
  * agnostic about where it lives.
+ *
+ * A slot may take more than one person. When it does the label says so BEFORE
+ * the applicant commits — turning up to what you thought was a 1:1 and finding
+ * three other people in the room is a bad surprise, and it is the reason
+ * capacity is shown to residents at all. What they never see is WHO else booked:
+ * the server sends counts only.
  */
 export default function SlotPicker({
   ccaID,
@@ -74,10 +80,19 @@ export default function SlotPicker({
                       : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
                   }`}
                 >
-                  <span className="font-medium text-gray-800">
-                    {formatSlot(s.startTime, s.endTime)}
+                  <span className="min-w-0">
+                    <span className="block font-medium text-gray-800">
+                      {formatSlot(s.startTime, s.endTime)}
+                    </span>
+                    {s.capacity > 1 && (
+                      <span className="mt-0.5 block text-xs text-amber-700">
+                        <Users className="mr-1 inline h-3 w-3 align-[-2px]" />
+                        Group interview · up to {s.capacity} people —{" "}
+                        {s.seatsLeft} seat{s.seatsLeft === 1 ? "" : "s"} left
+                      </span>
+                    )}
                   </span>
-                  <span className="flex items-center gap-3 text-gray-500">
+                  <span className="flex shrink-0 items-center gap-3 text-gray-500">
                     {s.location && (
                       <span className="inline-flex items-center gap-1">
                         <MapPin className="h-3.5 w-3.5" />
@@ -97,8 +112,8 @@ export default function SlotPicker({
 
       {book.error && (
         <p className="text-sm text-red-600">
-          {book.error.message === "SLOT_TAKEN"
-            ? "Someone just took that slot. Pick another."
+          {book.error.message === "SLOT_FULL"
+            ? "That slot just filled up. Pick another."
             : book.error.message === "SLOT_IN_PAST"
               ? "That slot has passed. Pick another."
               : "That didn't book. Try again."}

--- a/src/lib/schemas/ccaApplication.ts
+++ b/src/lib/schemas/ccaApplication.ts
@@ -56,8 +56,26 @@ export const APPLICATION_NOTES_MAX = 1500;
 export const INTERVIEW_LOCATION_MAX = 200;
 export const INTERVIEW_NOTE_MAX = 2000;
 export const DECISION_REASON_MAX = 1000;
-/** Soft cap on how many slots a head opens in one request — a sanity bound. */
+/** Soft cap on how many slots a head opens in one request — a sanity bound.
+ *  Unchanged by group slots: seats cost no rows, so 50 × 20 is still 50 rows. */
 export const MAX_SLOTS_PER_OPEN = 50;
+
+/**
+ * How many applicants may share one interview slot.
+ *
+ * These two live HERE rather than beside slotCapacity() in
+ * services/ccaApplications.ts because the head's slot generator is a client
+ * component and needs the VALUES — importing them from the server tree risks
+ * pulling Prisma into the browser bundle (see the module header). The service
+ * imports them back; there is still exactly one definition of each.
+ *
+ * DEFAULT is 1 because that is what every slot written before group slots
+ * existed means, and because capacity 1 must stay byte-for-byte today's
+ * behaviour. MAX is 20: big enough for a mass audition, small enough that a
+ * fat-fingered "200" is refused rather than opening a slot nobody can fill.
+ */
+export const SLOT_CAPACITY_DEFAULT = 1;
+export const SLOT_CAPACITY_MAX = 20;
 
 /** Reused everywhere a CCA is the target. ccaID 0 is RESERVED (cascade.ts). */
 const ccaID = z.number().int().positive();
@@ -65,6 +83,12 @@ const applicationID = z.number().int().positive();
 const slotID = z.number().int().positive();
 /** UNIX epoch SECONDS, matching Bookings.startTime/endTime. */
 const epochSeconds = z.number().int().positive();
+/**
+ * Seats on one slot. HEAD-ONLY — see the SECURITY note at the top of this file:
+ * this key must never appear on a resident input, or a resident could widen the
+ * slot they are about to book.
+ */
+const capacity = z.number().int().min(1).max(SLOT_CAPACITY_MAX);
 
 /* -------------------------------------------------------------------------- */
 /* Resident inputs                                                             */
@@ -97,12 +121,21 @@ export type CcaTargetInput = z.input<typeof ccaTargetInput>;
 /* Head inputs                                                                 */
 /* -------------------------------------------------------------------------- */
 
-/** One slot a head is opening. The clock check (not in the past) is server-side. */
+/**
+ * One slot a head is opening. The clock check (not in the past) is server-side.
+ *
+ * `capacity` DEFAULTS rather than being optional: the row must be written with
+ * an explicit number, never left absent, because Prisma+Mongo's `{ capacity:
+ * null }` does not match an absent field (§0.4 of the design doc). The generator
+ * applies one capacity to the whole batch; per-slot edits come later via
+ * editSlotInput.
+ */
 export const slotDraftSchema = z
   .object({
     startTime: epochSeconds,
     endTime: epochSeconds,
     location: z.string().trim().max(INTERVIEW_LOCATION_MAX).optional(),
+    capacity: capacity.default(SLOT_CAPACITY_DEFAULT),
   })
   .refine((s) => s.endTime > s.startTime, {
     message: "END_BEFORE_START",
@@ -120,7 +153,15 @@ export type OpenSlotsInput = z.input<typeof openSlotsInput>;
 export const cancelSlotInput = z.object({ ccaID, slotID });
 export type CancelSlotInput = z.input<typeof cancelSlotInput>;
 
-/** Edit an OPEN slot's time/location. A booked slot is refused server-side. */
+/**
+ * Edit a slot. Moving an OCCUPIED slot's time/location is refused server-side —
+ * that would change an interview out from under whoever booked it.
+ *
+ * `capacity` is OPTIONAL here, unlike slotDraftSchema: omitted means "leave it
+ * alone", which is what a client written before group slots sends. Lowering it
+ * below the seats already taken is refused (CAPACITY_BELOW_OCCUPANCY) — an edit
+ * never evicts anyone.
+ */
 export const editSlotInput = z
   .object({
     ccaID,
@@ -128,6 +169,7 @@ export const editSlotInput = z
     startTime: epochSeconds,
     endTime: epochSeconds,
     location: z.string().trim().max(INTERVIEW_LOCATION_MAX).optional(),
+    capacity: capacity.optional(),
   })
   .refine((s) => s.endTime > s.startTime, {
     message: "END_BEFORE_START",

--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -14,6 +14,8 @@ import {
   APPLICATION_COUNTER_KEY,
   assertApplicationsEnabled,
   nextCounter,
+  occupancyBySlot,
+  slotCapacity,
   withCcaLock,
 } from "~/server/api/services/ccaApplications";
 import {
@@ -63,21 +65,13 @@ async function ownApplicationOr404(
   return app;
 }
 
-/**
- * Return a slot to the open pool, but ONLY if it is still this resident's — a
- * conditional updateMany, so a slot the head already reassigned or canceled is
- * never clobbered. Idempotent: a no-op if the slot moved on.
+/*
+ * There is no releaseSlotIfMine any more. Releasing a seat is now exactly
+ * `interviewSlotID = null` on the caller's own application — the slot row holds
+ * no claim to put back, so the conditional "only if it is still mine" update
+ * that used to guard against clobbering a reassigned slot has nothing left to
+ * guard. Ownership is checked once, by ownApplicationOr404.
  */
-async function releaseSlotIfMine(
-  db: PrismaClient,
-  slotID: number,
-  userID: string,
-): Promise<void> {
-  await db.ccaInterviewSlot.updateMany({
-    where: { slotID, bookedByUserID: userID },
-    data: { bookedByUserID: null, bookedApplicationID: null, bookedAt: null },
-  });
-}
 
 export type HeadContact = {
   userID: string;
@@ -220,8 +214,15 @@ export const ccaApplicationsRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_CCA" });
       }
 
-      const [profile, membership, apps, futureSlots, headRows, memberRows] =
-        await Promise.all([
+      const [
+        profile,
+        membership,
+        apps,
+        futureSlots,
+        occupancy,
+        headRows,
+        memberRows,
+      ] = await Promise.all([
         ctx.db.ccaProfile.findUnique({
           where: { ccaID: input.ccaID },
           select: { description: true, logoUrl: true, bannerUrl: true },
@@ -241,15 +242,15 @@ export const ccaApplicationsRouter = createTRPCRouter({
           },
           orderBy: { applicationID: "desc" },
         }),
-        // Fetch future slots and count the open ones in JS — a `bookedByUserID:
-        // null` / `canceledAt: null` filter would miss slots where those fields
-        // are ABSENT (Prisma+Mongo's null filter only matches a stored null),
-        // which is every freshly-opened slot. See the note in
-        // ccaApplicationsHead.listSlots.
+        // Fetch future slots and count the free SEATS in JS — a `canceledAt:
+        // null` filter would miss slots where the field is ABSENT (Prisma+
+        // Mongo's null filter only matches a stored null), which is every
+        // freshly-opened slot. See the note in ccaApplicationsHead.listSlots.
         ctx.db.ccaInterviewSlot.findMany({
           where: { ccaID: input.ccaID, endTime: { gt: now } },
-          select: { bookedByUserID: true, canceledAt: true },
+          select: { slotID: true, capacity: true, canceledAt: true },
         }),
+        occupancyBySlot(ctx.db, input.ccaID),
         ctx.db.ccaHead.findMany({
           where: { ccaID: input.ccaID },
           select: { userID: true },
@@ -262,9 +263,21 @@ export const ccaApplicationsRouter = createTRPCRouter({
         }),
       ]);
 
-      const openSlotCount = futureSlots.filter(
-        (s) => s.bookedByUserID === null && s.canceledAt === null,
-      ).length;
+      // SEATS, not slots — one group slot with 4 free seats is 4 things a
+      // resident can book. Named openSeatCount (not openSlotCount) so any
+      // caller that still means "slots" is a compile error rather than a
+      // silently wrong number on a page that only uses it as "> 0".
+      const openSeatCount = futureSlots
+        .filter((s) => s.canceledAt === null)
+        .reduce(
+          (n, s) =>
+            n +
+            Math.max(
+              0,
+              slotCapacity(s.capacity) - (occupancy.get(s.slotID) ?? 0),
+            ),
+          0,
+        );
       const latest = apps[0] ?? null;
       const hasOpenApplication =
         latest !== null && !isTerminalStatus(latest.status);
@@ -286,7 +299,7 @@ export const ccaApplicationsRouter = createTRPCRouter({
         // The client still shows an Apply button and the server re-checks — this
         // just drives the default affordance.
         canApply: !isMember && !hasOpenApplication,
-        openSlotCount,
+        openSeatCount,
         heads,
         memberCount: memberRows.length,
       };
@@ -533,37 +546,59 @@ export const ccaApplicationsRouter = createTRPCRouter({
         });
       }
 
-      // Open + future slots. `bookedByUserID`/`canceledAt` are filtered in JS,
-      // not the query: their null filter would miss slots where the field is
-      // ABSENT (every freshly-opened one). See ccaApplicationsHead.listSlots.
-      const candidates = await ctx.db.ccaInterviewSlot.findMany({
-        where: { ccaID: input.ccaID, endTime: { gt: now } },
-        select: {
-          slotID: true,
-          startTime: true,
-          endTime: true,
-          location: true,
-          bookedByUserID: true,
-          canceledAt: true,
-        },
-        orderBy: { startTime: "asc" },
-      });
+      // Open + future slots. `canceledAt` is filtered in JS, not the query: its
+      // null filter would miss slots where the field is ABSENT (every
+      // freshly-opened one). See ccaApplicationsHead.listSlots.
+      const [candidates, occupancy] = await Promise.all([
+        ctx.db.ccaInterviewSlot.findMany({
+          where: { ccaID: input.ccaID, endTime: { gt: now } },
+          select: {
+            slotID: true,
+            startTime: true,
+            endTime: true,
+            location: true,
+            capacity: true,
+            canceledAt: true,
+          },
+          orderBy: { startTime: "asc" },
+        }),
+        occupancyBySlot(ctx.db, input.ccaID),
+      ]);
       const slots = candidates
-        .filter((s) => s.bookedByUserID === null && s.canceledAt === null)
-        .map((s) => ({
-          slotID: s.slotID,
-          startTime: s.startTime,
-          endTime: s.endTime,
-          location: s.location,
-        }));
+        .filter((s) => s.canceledAt === null)
+        .map((s) => {
+          const capacity = slotCapacity(s.capacity);
+          const taken = occupancy.get(s.slotID) ?? 0;
+          return {
+            slotID: s.slotID,
+            startTime: s.startTime,
+            endTime: s.endTime,
+            location: s.location,
+            // COUNTS ONLY. A resident is told how many seats are left and how
+            // big the room is — never who else booked. occupancyBySlot loads no
+            // applicant row at all, so there is nothing here to leak.
+            capacity,
+            seatsLeft: Math.max(0, capacity - taken),
+          };
+        })
+        // A FULL slot is hidden exactly as a taken one was — including the one
+        // the caller holds, if it is now full. That is deliberately today's
+        // behaviour unchanged at capacity 1 (a resident never saw their own
+        // 1:1 in this list either); on a group slot with seats to spare they
+        // now do see it, and the picker marks it "Current".
+        .filter((s) => s.seatsLeft > 0);
 
       return { slots, mySlotID: live.interviewSlotID };
     }),
 
   /**
-   * Book an open slot against one's own live application. Rebooking is allowed
-   * and releases the previously held slot in the same locked section, so the two
-   * cannot both end up claimed.
+   * Book a seat on an open slot against one's own live application. Rebooking is
+   * allowed: moving the pointer IS releasing the old seat, so the two cannot
+   * both end up claimed — there is no second write to forget.
+   *
+   * The seat count and the claim happen in the SAME locked section. Counting
+   * outside the lock and writing inside it is the over-book: two residents both
+   * read "1 seat left" and both take it.
    */
   bookSlot: identifiedProcedure
     .input(bookSlotInput)
@@ -596,7 +631,7 @@ export const ccaApplicationsRouter = createTRPCRouter({
             ccaID: true,
             endTime: true,
             canceledAt: true,
-            bookedByUserID: true,
+            capacity: true,
           },
         });
         if (!slot || slot.ccaID !== app.ccaID || slot.canceledAt !== null) {
@@ -605,23 +640,21 @@ export const ccaApplicationsRouter = createTRPCRouter({
         if (slot.endTime !== null && slot.endTime <= now) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
         }
-        if (slot.bookedByUserID !== null) {
-          throw new TRPCError({ code: "CONFLICT", message: "SLOT_TAKEN" });
+
+        // The seat check. Skipped when the caller ALREADY points at this slot:
+        // their own application is inside the count, so re-booking a full slot
+        // they hold would refuse itself. Moving the pointer to where it already
+        // is changes no occupancy — the re-book is a no-op by construction.
+        if (app.interviewSlotID !== input.slotID) {
+          const occupancy = await occupancyBySlot(ctx.db, app.ccaID);
+          const taken = occupancy.get(input.slotID) ?? 0;
+          if (taken >= slotCapacity(slot.capacity)) {
+            throw new TRPCError({ code: "CONFLICT", message: "SLOT_FULL" });
+          }
         }
 
-        // Rebook: free the old slot first (only if still ours).
-        if (app.interviewSlotID !== null && app.interviewSlotID !== input.slotID) {
-          await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
-        }
-
-        await ctx.db.ccaInterviewSlot.update({
-          where: { slotID: input.slotID },
-          data: {
-            bookedByUserID: userID,
-            bookedApplicationID: app.applicationID,
-            bookedAt: new Date(),
-          },
-        });
+        // Rebooking needs no release: the pointer is the claim, and the single
+        // update below moves it off the old slot and onto this one atomically.
         await ctx.db.ccaApplication.update({
           where: { applicationID: app.applicationID },
           data: {
@@ -664,7 +697,8 @@ export const ccaApplicationsRouter = createTRPCRouter({
           });
         }
 
-        await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
+        // Nulling the pointer IS releasing the seat — one write, nothing to
+        // keep in step on the slot row.
         await ctx.db.ccaApplication.update({
           where: { applicationID: app.applicationID },
           data: {
@@ -707,9 +741,7 @@ export const ccaApplicationsRouter = createTRPCRouter({
           });
         }
 
-        if (app.interviewSlotID !== null) {
-          await releaseSlotIfMine(ctx.db, app.interviewSlotID, userID);
-        }
+        // interviewSlotID: null frees the seat, whether or not one was held.
         await ctx.db.ccaApplication.update({
           where: { applicationID: app.applicationID },
           data: {

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -11,6 +11,8 @@ import { addCcaMember, membershipKeysFor } from "~/server/api/services/ccaMember
 import {
   assertApplicationsEnabled,
   nextCounter,
+  occupancyBySlot,
+  slotCapacity,
   SLOT_COUNTER_KEY,
   withCcaLock,
 } from "~/server/api/services/ccaApplications";
@@ -180,12 +182,28 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           const slotIDs = apps
             .map((a) => a.interviewSlotID)
             .filter((s): s is number => s !== null);
-          if (slotIDs.length === 0) return new Map<number, { startTime: number | null; endTime: number | null; location: string | null }>();
+          // slotID is IN the value, not just the key: the run-sheet groups
+          // applicants by the slot they share, and it needs something to group
+          // on. `capacity` rides along for the "3 of 4 seats" header.
+          type SlotRow = {
+            slotID: number;
+            startTime: number | null;
+            endTime: number | null;
+            location: string | null;
+            capacity: number | null;
+          };
+          if (slotIDs.length === 0) return new Map<number, SlotRow>();
           const rows = await ctx.db.ccaInterviewSlot.findMany({
             where: { slotID: { in: slotIDs } },
-            select: { slotID: true, startTime: true, endTime: true, location: true },
+            select: {
+              slotID: true,
+              startTime: true,
+              endTime: true,
+              location: true,
+              capacity: true,
+            },
           });
-          return new Map(rows.map((r) => [r.slotID, r]));
+          return new Map<number, SlotRow>(rows.map((r) => [r.slotID, r]));
         })(),
       ]);
 
@@ -199,10 +217,13 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           decidedAt: a.decidedAt,
           decisionReason: a.decisionReason,
           applicant: people.get(a.userID) ?? EMPTY_APPLICANT,
-          slot:
-            a.interviewSlotID !== null
-              ? (slots.get(a.interviewSlotID) ?? null)
-              : null,
+          slot: (() => {
+            if (a.interviewSlotID === null) return null;
+            const s = slots.get(a.interviewSlotID);
+            // Normalised HERE so no client ever sees a raw `capacity: null` and
+            // has to know that absent means 1.
+            return s ? { ...s, capacity: slotCapacity(s.capacity) } : null;
+          })(),
         })),
       };
     }),
@@ -291,7 +312,14 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       };
     }),
 
-  /** All interview slots for a CCA, with who booked each — the head's calendar. */
+  /**
+   * All interview slots for a CCA with their occupants — the head's calendar.
+   *
+   * Occupancy is DERIVED from the applications that point at each slot, so this
+   * reads the applications rather than the slot row. The head (unlike a
+   * resident) gets the roster, not just a count: running a group interview means
+   * knowing who is in the room.
+   */
   listSlots: identifiedProcedure
     .input(ccaTargetInput)
     .query(async ({ ctx, input }) => {
@@ -306,34 +334,69 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       // absent field — so that filter silently hides every open slot. Prisma
       // deserializes an absent optional scalar as null, so filtering in JS on
       // `s.canceledAt === null` catches both the absent and the null case.
-      const all = await ctx.db.ccaInterviewSlot.findMany({
-        where: { ccaID: input.ccaID },
-        select: {
-          slotID: true,
-          startTime: true,
-          endTime: true,
-          location: true,
-          bookedByUserID: true,
-          bookedApplicationID: true,
-          canceledAt: true,
-        },
-        orderBy: { startTime: "asc" },
-      });
+      const [all, claims] = await Promise.all([
+        ctx.db.ccaInterviewSlot.findMany({
+          where: { ccaID: input.ccaID },
+          select: {
+            slotID: true,
+            startTime: true,
+            endTime: true,
+            location: true,
+            capacity: true,
+            canceledAt: true,
+          },
+          orderBy: { startTime: "asc" },
+        }),
+        // A HEAD-ONLY read, deliberately NOT occupancyBySlot(): that helper
+        // projects interviewSlotID alone because it also runs on resident
+        // paths. Here the extra fields are the point, and one query gives both
+        // the counts and the roster.
+        ctx.db.ccaApplication.findMany({
+          where: { ccaID: input.ccaID },
+          select: {
+            applicationID: true,
+            userID: true,
+            status: true,
+            interviewSlotID: true,
+          },
+          orderBy: { applicationID: "asc" },
+        }),
+      ]);
       const slots = all.filter((s) => s.canceledAt === null);
 
-      const booked = slots
-        .map((s) => s.bookedByUserID)
-        .filter((u): u is string => u !== null);
-      const people = await resolveApplicants(ctx.db, booked);
+      // Group the claims by slot. `interviewSlotID` is tested in JS for the
+      // same absent-vs-null reason as canceledAt above.
+      const bySlot = new Map<number, typeof claims>();
+      for (const c of claims) {
+        if (c.interviewSlotID === null) continue;
+        const arr = bySlot.get(c.interviewSlotID) ?? [];
+        arr.push(c);
+        bySlot.set(c.interviewSlotID, arr);
+      }
+      const people = await resolveApplicants(
+        ctx.db,
+        slots.flatMap((s) => (bySlot.get(s.slotID) ?? []).map((c) => c.userID)),
+      );
 
       return {
-        slots: slots.map((s) => ({
-          ...s,
-          bookedBy:
-            s.bookedByUserID !== null
-              ? (people.get(s.bookedByUserID) ?? EMPTY_APPLICANT)
-              : null,
-        })),
+        slots: slots.map((s) => {
+          const occupants = bySlot.get(s.slotID) ?? [];
+          return {
+            slotID: s.slotID,
+            startTime: s.startTime,
+            endTime: s.endTime,
+            location: s.location,
+            canceledAt: s.canceledAt,
+            capacity: slotCapacity(s.capacity),
+            occupancy: occupants.length,
+            occupants: occupants.map((c) => ({
+              applicationID: c.applicationID,
+              userID: c.userID,
+              status: c.status,
+              applicant: people.get(c.userID) ?? EMPTY_APPLICANT,
+            })),
+          };
+        }),
       };
     }),
 
@@ -413,11 +476,12 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
               location: s.location ?? null,
               createdBy: userID,
               createdAt: new Date(),
-              // Explicit nulls (not absent) so other queries' null filters match
-              // — Prisma+Mongo's null filter does not match an absent field.
-              bookedByUserID: null,
-              bookedApplicationID: null,
-              bookedAt: null,
+              // EXPLICIT, never absent — Prisma+Mongo's null filter does not
+              // match an absent field, and `capacity` is written as a real
+              // number for the same reason: a row whose capacity is absent
+              // reads back as null and only survives because slotCapacity()
+              // normalises it. New rows should not need that rescue.
+              capacity: s.capacity,
               canceledAt: null,
             },
           });
@@ -430,7 +494,12 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           targetCcaID: input.ccaID,
           action: "ccaInterviewSlot.open",
           batchId,
-          reason: `${scope.via}: opened ${created.length} slot(s)`,
+          // The capacity is in the audit line because "we opened 20 slots" and
+          // "we opened 20 slots for 6 people each" are very different decisions
+          // to have to reconstruct later.
+          reason: `${scope.via}: opened ${created.length} slot(s), ${
+            input.slots.reduce((n, s) => n + s.capacity, 0)
+          } seat(s)`,
         });
 
         return { ccaID: input.ccaID, opened: created.length, slotIDs: created };
@@ -438,10 +507,21 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
     }),
 
   /**
-   * Edit an OPEN slot's time and/or location. A BOOKED slot is refused — moving
-   * a slot out from under an applicant who already claimed it would silently
-   * change their interview time; the head must cancel it (which reverts the
-   * applicant) and open a new one instead.
+   * Edit a slot's time, location and/or capacity.
+   *
+   * MOVING an OCCUPIED slot is refused — changing the time out from under
+   * applicants who already claimed it would silently move their interview; the
+   * head must cancel it (which reverts every occupant) and open a new one.
+   * That is unchanged from the single-seat rule, just counted instead of
+   * boolean.
+   *
+   * CAPACITY is different, and is allowed on an occupied slot: raising it
+   * re-opens a full slot immediately, which is the whole point of the field.
+   * Lowering it below the seats already taken is refused
+   * (CAPACITY_BELOW_OCCUPANCY) — an edit never evicts anyone, and picking WHO
+   * to evict is not a decision a number in a form should make. So the guard is
+   * "unchanged time/location" rather than "unoccupied": a capacity-only save on
+   * an occupied slot sends the same start/end back and passes.
    */
   updateSlot: identifiedProcedure
     .input(editSlotInput)
@@ -457,30 +537,61 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           select: {
             slotID: true,
             ccaID: true,
+            startTime: true,
+            endTime: true,
+            location: true,
+            capacity: true,
             canceledAt: true,
-            bookedByUserID: true,
           },
         });
         if (!slot || slot.ccaID !== input.ccaID || slot.canceledAt !== null) {
           throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_SLOT" });
         }
-        if (slot.bookedByUserID !== null) {
+
+        // Counted INSIDE the lock, like every other check-then-write here: a
+        // capacity read outside it could be lowered onto an occupant who booked
+        // in between.
+        const occupancy =
+          (await occupancyBySlot(ctx.db, input.ccaID)).get(input.slotID) ?? 0;
+        const nextLocation = input.location ?? null;
+        // "" and null are the SAME location. The client sends `trim() ||
+        // undefined`, so a cleared box arrives as undefined -> null; treating a
+        // stored "" as different would make a capacity-only save on an occupied
+        // slot look like a move and be refused.
+        const moved =
+          input.startTime !== slot.startTime ||
+          input.endTime !== slot.endTime ||
+          (nextLocation ?? "") !== (slot.location ?? "");
+        if (occupancy > 0 && moved) {
           throw new TRPCError({ code: "CONFLICT", message: "SLOT_BOOKED" });
         }
+        if (input.capacity !== undefined && input.capacity < occupancy) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "CAPACITY_BELOW_OCCUPANCY",
+          });
+        }
+
         const now = Math.floor(Date.now() / 1000);
         if (input.endTime <= now) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
         }
 
         // Overlap against every OTHER non-canceled slot for this CCA.
-        const others = await ctx.db.ccaInterviewSlot.findMany({
-          where: {
-            ccaID: input.ccaID,
-            canceledAt: null,
-            slotID: { not: input.slotID },
-          },
-          select: { startTime: true, endTime: true },
-        });
+        //
+        // canceledAt is filtered in JS, NOT in the query. `{ canceledAt: null }`
+        // matches a stored null but NOT an ABSENT field (Prisma+Mongo), and 4 of
+        // the 34 production slots have it absent — those were invisible to this
+        // check, so an edit that overlapped one of them was accepted while
+        // openSlots (which already filters in JS) would have refused the same
+        // times. Every sibling site in this file does it this way; this one was
+        // the outlier.
+        const others = (
+          await ctx.db.ccaInterviewSlot.findMany({
+            where: { ccaID: input.ccaID, slotID: { not: input.slotID } },
+            select: { startTime: true, endTime: true, canceledAt: true },
+          })
+        ).filter((o) => o.canceledAt === null);
         const clash = others.some(
           (o) =>
             o.startTime !== null &&
@@ -496,7 +607,12 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           data: {
             startTime: input.startTime,
             endTime: input.endTime,
-            location: input.location ?? null,
+            location: nextLocation,
+            // Omitted capacity means "leave it alone", so the key is left out
+            // of `data` entirely — writing `capacity: undefined` and writing
+            // nothing are the same to Prisma, but spelling it out makes the
+            // "absent input, untouched field" contract visible.
+            ...(input.capacity !== undefined ? { capacity: input.capacity } : {}),
           },
         });
 
@@ -505,7 +621,11 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           actorRoles: roles,
           targetCcaID: input.ccaID,
           action: "ccaInterviewSlot.edit",
-          reason: `${scope.via}: edited slot #${input.slotID}`,
+          reason: `${scope.via}: edited slot #${input.slotID}${
+            input.capacity !== undefined
+              ? ` (capacity ${slotCapacity(slot.capacity)} → ${input.capacity}, ${occupancy} booked)`
+              : ""
+          }`,
         });
 
         return { slotID: input.slotID };
@@ -513,9 +633,11 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
     }),
 
   /**
-   * Cancel a slot. If it was booked, the applicant's application is reverted to
-   * `submitted` (so they can rebook) BEFORE the slot is marked canceled — a
-   * booked slot is never yanked out from under a resident silently.
+   * Cancel a slot. EVERY occupant is reverted to `submitted` (so they can
+   * rebook) BEFORE the slot is marked canceled — a claimed slot is never yanked
+   * out from under a resident silently, and on a group slot that is now four
+   * people, not one. One locked section, one audit row carrying a batchId, so
+   * the whole revert is attributable as a single act.
    */
   cancelSlot: identifiedProcedure
     .input(cancelSlotInput)
@@ -528,44 +650,34 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       return withCcaLock(ctx.db, input.ccaID, async () => {
         const slot = await ctx.db.ccaInterviewSlot.findUnique({
           where: { slotID: input.slotID },
-          select: {
-            slotID: true,
-            ccaID: true,
-            canceledAt: true,
-            bookedApplicationID: true,
-          },
+          select: { slotID: true, ccaID: true, canceledAt: true },
         });
         if (!slot || slot.ccaID !== input.ccaID || slot.canceledAt !== null) {
           throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_SLOT" });
         }
 
-        let revertedApplicationID: number | null = null;
-        if (slot.bookedApplicationID !== null) {
-          // Only revert if that application is still pointing at THIS slot and
-          // is not already decided.
-          const reverted = await ctx.db.ccaApplication.updateMany({
-            where: {
-              applicationID: slot.bookedApplicationID,
-              interviewSlotID: slot.slotID,
-              status: "interview_scheduled",
-            },
-            data: {
-              status: "submitted",
-              interviewSlotID: null,
-              updatedAt: new Date(),
-            },
-          });
-          if (reverted.count > 0) revertedApplicationID = slot.bookedApplicationID;
-        }
+        // Every application still pointing HERE and still merely scheduled.
+        // `interviewSlotID: slot.slotID` is a value match, not a null filter,
+        // so the absent-field trap does not apply. A decided/interviewed
+        // occupant keeps its pointer, exactly as before: the interview is
+        // history at that point, not a booking to release.
+        const batchId = randomUUID();
+        const reverted = await ctx.db.ccaApplication.updateMany({
+          where: {
+            ccaID: input.ccaID,
+            interviewSlotID: slot.slotID,
+            status: "interview_scheduled",
+          },
+          data: {
+            status: "submitted",
+            interviewSlotID: null,
+            updatedAt: new Date(),
+          },
+        });
 
         await ctx.db.ccaInterviewSlot.update({
           where: { slotID: input.slotID },
-          data: {
-            canceledAt: new Date(),
-            bookedByUserID: null,
-            bookedApplicationID: null,
-            bookedAt: null,
-          },
+          data: { canceledAt: new Date() },
         });
 
         await writeAudit(ctx.db, {
@@ -573,27 +685,28 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           actorRoles: roles,
           targetCcaID: input.ccaID,
           action: "ccaInterviewSlot.cancel",
+          batchId,
           reason: `${scope.via}: canceled slot #${input.slotID}${
-            revertedApplicationID !== null
-              ? ` (reverted application #${revertedApplicationID})`
+            reverted.count > 0
+              ? ` (reverted ${reverted.count} application(s) to submitted)`
               : ""
           }`,
         });
 
-        return { slotID: input.slotID, revertedApplicationID };
+        return { slotID: input.slotID, revertedCount: reverted.count };
       });
     }),
 
   /**
-   * Clear every FREE (unbooked, non-canceled) slot for a CCA in one go — the
+   * Clear every FREE (occupancy 0, non-canceled) slot for a CCA in one go — the
    * bulk counterpart to cancelSlot, so a head doesn't delete a whole day one
    * card at a time.
    *
-   * BOOKED slots are DELIBERATELY untouched: cancelling one reverts an
-   * applicant to reschedule, which must stay a per-slot, confirmed action
-   * (cancelSlot), never a side effect of "clear". So this only ever removes
-   * slots nobody has claimed. Idempotent — clearing when there are none is a
-   * no-op that returns 0.
+   * OCCUPIED slots are DELIBERATELY untouched, and free means occupancy EXACTLY
+   * zero — a group slot with one person on it and three seats spare is NOT
+   * free. Cancelling it reverts that applicant to reschedule, which must stay a
+   * per-slot, confirmed action (cancelSlot), never a side effect of "clear".
+   * Idempotent — clearing when there are none is a no-op that returns 0.
    */
   clearFreeSlots: identifiedProcedure
     .input(ccaTargetInput)
@@ -604,15 +717,21 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
 
       return withCcaLock(ctx.db, input.ccaID, async () => {
-        // Filter in JS, NOT the query: `{ canceledAt: null }` / `{ bookedByUserID
-        // : null }` miss absent-field slots on Prisma+Mongo (see listSlots), which
-        // would leave old free slots behind. Fetch, then filter both in memory.
-        const all = await ctx.db.ccaInterviewSlot.findMany({
-          where: { ccaID: input.ccaID },
-          select: { slotID: true, canceledAt: true, bookedByUserID: true },
-        });
+        // Filter in JS, NOT the query: `{ canceledAt: null }` misses
+        // absent-field slots on Prisma+Mongo (see listSlots), which would leave
+        // old free slots behind. Fetch, then filter in memory.
+        const [all, occupancy] = await Promise.all([
+          ctx.db.ccaInterviewSlot.findMany({
+            where: { ccaID: input.ccaID },
+            select: { slotID: true, canceledAt: true },
+          }),
+          occupancyBySlot(ctx.db, input.ccaID),
+        ]);
         const freeIDs = all
-          .filter((s) => s.canceledAt === null && s.bookedByUserID === null)
+          .filter(
+            (s) =>
+              s.canceledAt === null && (occupancy.get(s.slotID) ?? 0) === 0,
+          )
           .map((s) => s.slotID);
 
         if (freeIDs.length === 0) {
@@ -620,7 +739,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         }
 
         // Mark them canceled by slotID list (not a null-filter), so absent-field
-        // rows are included. Nothing to revert — these were unbooked.
+        // rows are included. Nothing to revert — these hold nobody.
         await ctx.db.ccaInterviewSlot.updateMany({
           where: { slotID: { in: freeIDs } },
           data: { canceledAt: new Date() },
@@ -820,22 +939,23 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           };
         }
 
-        // REJECT. Free a still-future booked slot so another applicant can take
-        // it; a past interview slot is left as the historical record.
+        // REJECT. Free this applicant's SEAT — and only theirs — when the slot
+        // is still in the future, so someone else can take it; a past interview
+        // is left pointing at its slot as the historical record.
+        //
+        // Today's rule expressed on the pointer instead of the slot: the claim
+        // now IS the pointer, so "release the slot" and "null interviewSlotID"
+        // are the same write. On a group slot the other occupants are untouched
+        // by construction — nothing here reads or writes the slot row.
+        let freedSlot = false;
         if (app.interviewSlotID !== null) {
           const nowSec = Math.floor(Date.now() / 1000);
-          await ctx.db.ccaInterviewSlot.updateMany({
-            where: {
-              slotID: app.interviewSlotID,
-              bookedApplicationID: app.applicationID,
-              endTime: { gt: nowSec },
-            },
-            data: {
-              bookedByUserID: null,
-              bookedApplicationID: null,
-              bookedAt: null,
-            },
+          const slot = await ctx.db.ccaInterviewSlot.findUnique({
+            where: { slotID: app.interviewSlotID },
+            select: { endTime: true },
           });
+          const endTime = slot?.endTime ?? null;
+          freedSlot = endTime !== null && endTime > nowSec;
         }
 
         await ctx.db.ccaApplication.update({
@@ -846,6 +966,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             decidedAt: now,
             decisionReason: input.reason ?? null,
             updatedAt: now,
+            ...(freedSlot ? { interviewSlotID: null } : {}),
           },
         });
 
@@ -857,7 +978,7 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           action: "ccaApplication.reject",
           reason: `${scope.via}: application #${app.applicationID}${
             input.reason ? ` — ${input.reason}` : ""
-          }`,
+          }${freedSlot ? ` (freed seat on slot #${app.interviewSlotID})` : ""}`,
         });
 
         return {

--- a/src/server/api/services/ccaApplications.ts
+++ b/src/server/api/services/ccaApplications.ts
@@ -1,9 +1,15 @@
 import type { PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 
+import {
+  SLOT_CAPACITY_DEFAULT,
+  SLOT_CAPACITY_MAX,
+} from "~/lib/schemas/ccaApplication";
+
 /**
  * Infrastructure for the CCA membership-application + interview workflow: the
- * feature's kill switch, an atomic id allocator, and a per-CCA advisory lock.
+ * feature's kill switch, an atomic id allocator, a per-CCA advisory lock, and
+ * the seat arithmetic for group interview slots.
  *
  * The lock and counter reuse the SAME `BookingLock` and `Counter` collections
  * the booking system uses (booking.ts) — a different key namespace, not a new
@@ -169,4 +175,71 @@ export async function withCcaLock<T>(
   } finally {
     await db.bookingLock.deleteMany({ where: { key } });
   }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Interview slot seats                                                        */
+/* -------------------------------------------------------------------------- */
+
+// Re-exported so a server caller reaches for the seat vocabulary in ONE place
+// rather than importing half of it from the zod module. The definitions live in
+// src/lib/schemas/ccaApplication.ts because the head's generator is a client
+// component and needs the values (see the note there).
+export { SLOT_CAPACITY_DEFAULT, SLOT_CAPACITY_MAX };
+
+/**
+ * How many applicants may claim a slot, from its stored `capacity`.
+ *
+ * THE ONLY PLACE THE LEGACY DEFAULT LIVES. Every slot opened before group slots
+ * existed has `capacity` ABSENT, which Prisma hands back as null, and a fresh
+ * `?? 1` sprinkled at each call site is exactly how "absent means 1" drifts into
+ * "absent means 0 seats" at the one site that forgot. Inline `?? 1` NOWHERE
+ * else — call this.
+ *
+ * 0 and negatives also mean 1, deliberately: they are only reachable by a
+ * hand-edit or a partial restore (the zod bound is min 1), and the safe reading
+ * of a corrupt capacity is the pre-feature behaviour, not "this slot can never
+ * be booked" — which would look identical to a full slot and be unfixable from
+ * the UI, since the edit form cannot save a capacity below the occupancy.
+ */
+export function slotCapacity(c: number | null | undefined): number {
+  if (typeof c !== "number" || !Number.isFinite(c)) return SLOT_CAPACITY_DEFAULT;
+  const n = Math.floor(c);
+  return n >= SLOT_CAPACITY_DEFAULT ? n : SLOT_CAPACITY_DEFAULT;
+}
+
+/**
+ * slotID -> seats taken, for one CCA. Slots with nobody on them are ABSENT from
+ * the map, so read it through `occupancy.get(slotID) ?? 0`.
+ *
+ * Occupancy is DERIVED from `CcaApplication.interviewSlotID` — there is no
+ * counter to keep in step and no claim on the slot row, so the pointer cannot
+ * disagree with itself. One application holds at most one seat structurally
+ * (the pointer is a single scalar), which is why a re-book of the slot you
+ * already hold is a no-op rather than a double count.
+ *
+ * PRIVACY: this runs on RESIDENT paths (availableSlots, getCca). It projects
+ * `interviewSlotID` and NOTHING else, so no other applicant's userID, name or
+ * notes is loaded to compute a number a resident is allowed to see. Do not add
+ * a field to this select "while you're here" — add a second, head-only query.
+ *
+ * The null test is done in JS, not in the query: `{ interviewSlotID: { not:
+ * null } }` would miss every application whose pointer is ABSENT rather than a
+ * stored null (Prisma+Mongo), which is most of them, and the count would come
+ * back looking plausible.
+ */
+export async function occupancyBySlot(
+  db: PrismaClient,
+  ccaID: number,
+): Promise<Map<number, number>> {
+  const rows = await db.ccaApplication.findMany({
+    where: { ccaID },
+    select: { interviewSlotID: true },
+  });
+  const out = new Map<number, number>();
+  for (const r of rows) {
+    if (r.interviewSlotID === null) continue;
+    out.set(r.interviewSlotID, (out.get(r.interviewSlotID) ?? 0) + 1);
+  }
+  return out;
 }


### PR DESCRIPTION
A CCA head sets how many people may book one interview slot. Default 1 — which is exactly today's behaviour, so this is inert until a head types a bigger number.

## The design

Occupancy is **derived, not stored**. The slot carries `capacity`; seats taken are the count of `CcaApplication` rows pointing at it. The slot's `bookedByUserID` / `bookedApplicationID` / `bookedAt` scalars are **deleted**.

That collapses a mirror rather than adding to one. The application pointer was already maintained alongside those scalars inside the same `withCcaLock` section, so this removes a source of truth instead of introducing a third. Two properties fall out:

- **"One application holds at most one seat" is structural** — the pointer is a single scalar and cannot be counted twice, so re-booking a slot you already hold is idempotent for free. The alternative design needed a unique index to buy this.
- **Every stale reader is a compile error**, not a silent "free" on a full slot. That's why the scalars are deleted outright rather than left unused.

Rejected alternatives, the full edge-case list and the settled decisions are in `docs/plans/cca/01-group-interview-slots.md`.

## Rules worth naming

| | |
|---|---|
| Lowering capacity below occupancy | refused — an edit never evicts anyone |
| Raising capacity | always allowed, re-opens a full slot immediately |
| Cancelling a group slot | reverts **every** occupant, one audit row |
| A partially filled slot | is not "free", never bulk-cleared |
| Residents see | seat counts + a "Group interview · up to N" label, never who else booked |

The occupancy helper projects `interviewSlotID` and nothing else, so no other applicant's row is loaded on a resident path. Over-booking is prevented by the existing per-CCA advisory lock — the same guarantee the single-seat claim already relied on.

## Migration — read before merging

`scripts/remediation/backfill-slot-capacity.mjs`, dry run by default, full pre-image backup, verifier alongside it (`verify-interview-slots.mjs`).

**It refuses to `--commit` while `cca.applications.enabled` is on.** The script snapshots both collections up front, so a reject landing mid-run would strand a seat that no re-run could detect or repair. Quiescing closes the window; `--allow-live` overrides and prints what it is risking.

Live dry run against production:

```
cca.applications.enabled: "on"  <- LIVE
CcaInterviewSlot: 34   canceled: 24   carrying claim FIELDS: 31   real claim: 1
CcaApplication:   78   with a slot pointer: 1
[1] slot <-> application agreement: 0 disagreement(s)
[2] capacity := 1 — to write: 34
[3] terminal applications holding a live future seat: 0
[4] $unset booked* — 31 (by $exists, the same predicate the statement uses)
projected occupancy: 1 slot occupied, 1 seat claimed, none over capacity
```

Deploy order: quiesce → dry run → `--commit` → `prisma db push` → verify → deploy → un-quiesce. **`prisma db push` has not been run**; it has silently dropped a non-schema index in this repo before, so the script prints both collections' index lists for diffing.

## Review

Three adversarial review rounds by an independent agent. Round 1 found a **critical** defect: the migration was destructive on a second `--commit` — after step 4 removed the claim scalars, a re-run reclassified every terminal application as a reject-orphan and nulled its pointer, with the gate unable to see it. Confirmed by hand against production data before fixing. Round 2 verified the fix by fault injection the implementer's own harness couldn't perform, and found that the fix converted a recoverable miss into a permanent one — which is where the quiesce guard came from. Round 3 items are all closed.

The application code was verified sound throughout: state machine transition by transition, lock placement on all four count-then-write paths, resident-path privacy, the authorisation chain on all six head procedures, capacity-edit guards.

`tsc --noEmit` clean, `next lint` clean. No tests — the repo has no test harness; the migration's idempotence was proved against an offline fixture reproducing production's exact census, which is not a substitute for the dry run above.

## Second commit

Two one-off remediation scripts, both already applied to production, kept for the same reason the rest of `scripts/remediation/` is. Note `fix-leia-duplicate.mjs`: it deletes by ObjectId and refuses `deleteUserCascade`, because the broken row stored the *other* account's `userID` — the cascade helper deletes bookings and memberships by that string, so the routine repair would have destroyed the real account and then removed both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tYGVvASfVrPZQfK4eJsaw
