### PR TITLE
Click a CCA banner to see the whole image

### DIFF
--- a/scripts/remediation/rename-cca-95.mjs
+++ b/scripts/remediation/rename-cca-95.mjs
@@ -1,0 +1,102 @@
+/**
+ * One-off rename: "BakeRH's" -> "BakeRHs and Cooks".
+ *
+ *   node scripts/remediation/rename-cca-95.mjs            # dry run
+ *   node scripts/remediation/rename-cca-95.mjs --commit   # apply
+ *
+ * KEYED ON ccaID, asserting the name. Same rule as reconcile-ccas.mjs: a rename
+ * keeps the ccaID, so every Bookings / UserCCA / CcaHead / CcaProfile /
+ * CcaApplication row that points at it stays attached. Delete-and-recreate would
+ * sever all of them silently, which is why this is an update and nothing else.
+ *
+ * The apostrophe is the point of the change and also the reason to assert the
+ * old value exactly: "BakeRH's" with a typographic apostrophe (U+2019) is a
+ * DIFFERENT string from the ASCII one, and a rename that silently matched
+ * neither would report success having changed nothing.
+ */
+import { PrismaClient } from "@prisma/client";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { isCommit, abort, banner, fileStamp } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+const CCA_ID = 95;
+const EXPECT = "BakeRH's";
+const RENAME_TO = "BakeRHs and Cooks";
+
+async function main() {
+  banner("rename-cca-95.mjs", COMMIT);
+
+  const all = await db.cCA.findMany({ orderBy: { ccaID: "asc" } });
+  const row = all.find((c) => c.ccaID === CCA_ID);
+
+  if (!row) return abort(`no CCA with ccaID ${CCA_ID}.`);
+  if (row.ccaName !== EXPECT) {
+    console.error(`  BLOCK  ccaID ${CCA_ID} is named ${JSON.stringify(row.ccaName)}, not ${JSON.stringify(EXPECT)}`);
+    console.error(`         (codepoints: ${[...row.ccaName].map((ch) => "U+" + ch.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")).join(" ")})`);
+    return abort("the row does not hold the name this rename was written against.");
+  }
+  const clash = all.find((c) => c.ccaID !== CCA_ID && c.ccaName === RENAME_TO);
+  if (clash) return abort(`ccaID ${clash.ccaID} is already named ${JSON.stringify(RENAME_TO)} — renaming would duplicate it.`);
+
+  // What stays attached. Printed because "the references survive" is the whole
+  // reason this is a rename, so it should be visible rather than asserted.
+  const counts = {};
+  for (const [coll, field] of [
+    ["Bookings", "ccaID"],
+    ["UserCCA", "ccaID"],
+    ["CcaHead", "ccaID"],
+    ["CcaProfile", "ccaID"],
+    ["CcaApplication", "ccaID"],
+    ["CcaInterviewSlot", "ccaID"],
+    ["Posts", "ccaID"],
+  ]) {
+    const r = await db.$runCommandRaw({
+      aggregate: coll,
+      pipeline: [{ $match: { [field]: CCA_ID } }, { $count: "n" }],
+      cursor: {},
+    });
+    const v = r?.cursor?.firstBatch?.[0]?.n;
+    counts[coll] = typeof v === "object" ? Number(v.$numberInt ?? v.$numberLong ?? 0) : (v ?? 0);
+  }
+
+  console.log(`ccaID ${CCA_ID}  [${row.category}]`);
+  console.log(`  ~ ${JSON.stringify(row.ccaName)}  ->  ${JSON.stringify(RENAME_TO)}`);
+  console.log(`  = ccaID unchanged, so these stay attached: ${JSON.stringify(counts)}`);
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --commit to apply.\n`);
+    return;
+  }
+
+  const out = path.join(process.cwd(), "scripts", "remediation", "backups", `rename-cca-95-${fileStamp()}.json`);
+  try {
+    writeFileSync(out, JSON.stringify({ at: new Date().toISOString(), before: row, to: RENAME_TO }, null, 2), "utf8");
+    console.log(`\nBackup written: ${out}`);
+  } catch (e) {
+    return abort(`could not write the backup (${String(e?.message ?? e)}).`);
+  }
+
+  await db.cCA.update({ where: { ccaID: CCA_ID }, data: { ccaName: RENAME_TO } });
+
+  console.log(`\n=== VERIFY ===`);
+  const after = await db.cCA.findUnique({ where: { ccaID: CCA_ID } });
+  console.log(`  ccaID ${CCA_ID} is now ${JSON.stringify(after?.ccaName)}`);
+  if (after?.ccaName !== RENAME_TO) return abort("the rename did not take.");
+
+  const names = (await db.cCA.findMany()).map((c) => c.ccaName);
+  const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+  console.log(`  duplicate CCA names: ${dupes.length} ${dupes.length ? JSON.stringify([...new Set(dupes)]) : ""}`);
+  if (dupes.length) return abort("the rename created a duplicate name.");
+
+  console.log(`\nDone.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/_components/ImageLightbox.tsx
+++ b/src/app/_components/ImageLightbox.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Expand, X } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "~/components/ui/dialog";
+
+/**
+ * A cropped image that opens to its full, uncropped self when clicked.
+ *
+ * WHY THIS EXISTS. Banners are rendered with `object-cover` into containers
+ * whose aspect ratio moves with the viewport — the resident page is roughly 6:1
+ * on a desktop and 2.8:1 on a phone, against a 4:1 upload box — so a third of
+ * the height or a third of the width is cropped away and NOTHING in the app
+ * showed the whole picture. Heads design these banners; they should be able to
+ * see the thing they uploaded.
+ *
+ * `object-contain` INSIDE A FIXED BOX, not a naturally-sized <img>. The intrinsic
+ * dimensions are not known here: the upload pipeline scales to FIT inside
+ * 1600x400 preserving ratio, so a 16:9 original lands at 711x400 and a square one
+ * at 400x400. Passing fixed width/height to next/image would declare a ratio the
+ * file does not have and render it STRETCHED. `fill` + `object-contain` letter-
+ * boxes whatever the real ratio is, undistorted, without needing to know it.
+ *
+ * `unoptimized` matches how these are already rendered: the blobs are pre-scaled
+ * WebP, so the image optimizer would spend a transformation to save almost
+ * nothing.
+ */
+export default function ImageLightbox({
+  src,
+  alt,
+  title,
+  className,
+  priority = false,
+  sizes = "100vw",
+}: {
+  src: string;
+  /** Decorative in context — the accessible name lives on the button. */
+  alt?: string;
+  /** Names the button and the dialog, e.g. "Chess Club banner". */
+  title: string;
+  /** Sizing/rounding for the CROPPED trigger. The caller owns the shape. */
+  className?: string;
+  priority?: boolean;
+  sizes?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  /**
+   * The image's real pixel size, learned on load, used to CAP the frame.
+   *
+   * Without it `object-contain` happily scales a small image UP to fill the
+   * viewport box: an upload that arrived as 711x400 (a 16:9 original, shrunk to
+   * fit the 1600x400 box by its height) would be blown up to ~1.7x and shown
+   * soft — a worse view of the picture than the cropped one it replaced. Capping
+   * the frame at the natural size means "full image" tops out at 1:1.
+   */
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`${title} — view full image`}
+        className={`group cursor-zoom-in ${className ?? ""}`}
+      >
+        <Image
+          src={src}
+          alt={alt ?? ""}
+          fill
+          className="object-cover"
+          sizes={sizes}
+          unoptimized
+          priority={priority}
+        />
+        {/* Affordance. Nothing else on these cards is clickable, so without a
+            hint the interaction is undiscoverable. Appears on hover AND on
+            keyboard focus — focus-within would not fire, the button itself is
+            what receives focus. */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 inline-flex items-center gap-1 rounded-md bg-black/55 px-2 py-1 text-xs font-medium text-white opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100 group-focus:opacity-100"
+        >
+          <Expand className="h-3.5 w-3.5" />
+          Full image
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          // Strip the panel chrome — max-w-lg, border, background, padding — so
+          // the image is the dialog rather than sitting inside a card. The
+          // built-in close button is hidden the same way EditProfileModal hides
+          // it; a dark icon on an arbitrary image is unreadable, so this
+          // supplies its own with a scrim behind it.
+          className="w-auto max-w-none border-0 bg-transparent p-0 shadow-none [&>button.absolute]:hidden"
+          onClick={() => setOpen(false)}
+        >
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+          <div
+            className="relative h-[85vh] w-[92vw] cursor-zoom-out"
+            style={
+              natural
+                ? { maxWidth: natural.w, maxHeight: natural.h }
+                : undefined
+            }
+          >
+            <Image
+              src={src}
+              alt={title}
+              fill
+              className="object-contain"
+              sizes="92vw"
+              unoptimized
+              onLoad={(e) =>
+                setNatural({
+                  w: e.currentTarget.naturalWidth,
+                  h: e.currentTarget.naturalHeight,
+                })
+              }
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label="Close"
+            className="absolute right-2 top-2 rounded-full bg-black/55 p-2 text-white backdrop-blur-sm transition-colors hover:bg-black/75 focus:outline-none focus:ring-2 focus:ring-white/70"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/cca/_components/CcaOverview.tsx
+++ b/src/app/cca/_components/CcaOverview.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { api } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import RosterDriftNote from "~/app/_components/RosterDriftNote";
+import ImageLightbox from "~/app/_components/ImageLightbox";
 import StatTile from "./StatTile";
 import CcaHandoverDialog from "./CcaHandoverDialog";
 
@@ -68,22 +69,17 @@ export default function CcaOverview({ ccaID }: { ccaID: number }) {
           straddle the seam between the banner and the card below it. */}
       {(p?.bannerUrl ?? p?.logoUrl ?? p?.description) && (
         <div>
-          {/* Banner. `unoptimized` because these are already downscaled to
-              1600×400 WebP on upload — running them back through the image
-              optimizer would spend transformations to save almost nothing.
-              object-cover stretches the image to fill the whole banner. */}
+          {/* Banner. object-cover fills the container and therefore CROPS —
+              click to see the whole upload (ImageLightbox explains why that is
+              worth having, and why `unoptimized`). */}
           {p?.bannerUrl && (
-            <div className="relative h-48 w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50 sm:h-64">
-              <Image
-                src={p.bannerUrl}
-                alt=""
-                fill
-                className="object-cover"
-                sizes="100vw"
-                unoptimized
-                priority
-              />
-            </div>
+            <ImageLightbox
+              src={p.bannerUrl}
+              title={`${membership?.ccaName ?? "CCA"} banner`}
+              className="relative block h-48 w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50 sm:h-64"
+              sizes="100vw"
+              priority
+            />
           )}
 
           {(p?.logoUrl ?? p?.description) && (

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/lib/schemas/ccaApplication";
 import { statusBadgeClass, residentStatusLabel } from "../_lib/status";
 import SlotPicker from "./SlotPicker";
+import ImageLightbox from "~/app/_components/ImageLightbox";
 
 /** Friendly copy for the machine-readable error tokens the procedures throw. */
 function applyErrorCopy(message: string | undefined): string | null {
@@ -103,10 +104,15 @@ export default function CcaApplyPanel({ ccaID }: { ccaID: number }) {
 
       {/* Header card */}
       <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        {/* Cropped hard here — this container is ~6:1 on a desktop against a
+            4:1 upload — so it opens to the full image on click. */}
         {d.bannerUrl && (
-          <div className="relative h-32 w-full sm:h-40">
-            <Image src={d.bannerUrl} alt="" fill className="object-cover" />
-          </div>
+          <ImageLightbox
+            src={d.bannerUrl}
+            title={`${d.ccaName} banner`}
+            className="relative block h-32 w-full sm:h-40"
+            sizes="(min-width: 1024px) 960px, 100vw"
+          />
         )}
         <div className="flex items-start gap-4 p-5">
           {d.logoUrl ? (


### PR DESCRIPTION
Banners are cropped everywhere they appear, and until now nothing in the app showed the full picture. Clicking one opens it.

## Why

`object-cover` fills the container and therefore crops, and the container's aspect ratio moves with the viewport:

| Where | Container | Effective ratio |
|---|---|---|
| Resident page, desktop | 960 × 160 | 6:1 — ~⅓ of the height cropped |
| Resident page, mobile | ~358 × 128 | 2.8:1 — ~30% of the width cropped |
| Head's CCA page | ~1100 × 256 | ~4.3:1 |

Against a 1600×400 (4:1) upload box, roughly 250 px each side or 65 px top and bottom are always cut. Heads design these banners; they should be able to see what they uploaded.

## What

One shared `ImageLightbox`, used by both the head's page (`CcaOverview`) and the resident's (`CcaApplyPanel`), so the two can't drift apart.

**It doesn't assume 4:1.** The upload pipeline scales to *fit* inside 1600×400 preserving ratio, so a 16:9 original lands at 711×400 and a square one at 400×400. Handing fixed dimensions to `next/image` would assert a ratio the file doesn't have and render it stretched — `fill` + `object-contain` is correct for any shape without needing to know it.

**It never upscales.** `object-contain` would otherwise blow that 711×400 up to fill an 85vh box and show it soft — a *worse* view than the cropped one it replaced. The frame reads the image's natural size on load and caps itself there, so "full image" tops out at 1:1.

**The affordance is deliberate.** Nothing else on those cards is clickable, so a bare cursor change would leave the interaction undiscoverable. A "Full image" chip fades in on hover **and** on keyboard focus, with `cursor-zoom-in` on the trigger and `cursor-zoom-out` in the overlay.

Built on the existing Radix dialog, so Escape, backdrop click, focus trap and return-focus come for free. The dialog's built-in close X is hidden — a dark icon over an arbitrary image is unreadable — in favour of one with a scrim behind it. Clicking the image closes too.

## Checks

`tsc --noEmit`, `next lint` and a full `next build` all clean. **Not clicked in a browser** — the pages need a login session — so the sizing and chip placement are worth a look on the preview deploy.

## Second commit

`rename-cca-95.mjs`, already applied to production: ccaID 95 `BakeRH's` → `BakeRHs and Cooks`. A rename rather than a delete-and-recreate, since the ccaID is what 2 head grants and 3 applications point at. It asserts the old name exactly and prints codepoints on mismatch — a typographic apostrophe is a different string from the ASCII one, and a rename matching neither would report success having changed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tYGVvASfVrPZQfK4eJsaw
