### PR TITLE
Book a facility for interview slots, and fix the midnight window

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -561,9 +561,25 @@ model CcaInterviewSlot {
   /// (services/ccaApplications.ts) and NEVER inline `?? 1`, so the legacy
   /// default lives in exactly one place.
   capacity   Int?
+  /// The facility this slot runs in, or null/absent for a free-text location.
+  /// When set, `location` is the DENORMALIZED facility name (same rule as
+  /// Event.location) so every display path renders without a join.
+  /// NOT a foreign key — Bookings/Facilities key on facilityID.
+  facilityID Int?
+  /// The bookingID of the facility booking that holds the room for this slot.
+  /// ONE booking covers a whole generated window, so every slot in that batch
+  /// carries the SAME bookingID; the room is released only when the last live
+  /// slot pointing at it is canceled. Null when the location is free text, or
+  /// for any slot written before facility booking existed.
+  bookingID  Int?
   canceledAt DateTime?
   createdAt  DateTime? @default(now())
 
+  /// NO index on bookingID, deliberately. The release check ("is any live slot
+  /// still holding this room?") filters ccaID + bookingID and is covered by the
+  /// ccaID prefix below, so these two fields need no `db push` — which matters,
+  /// because a push silently drops the non-schema indexes this database relies
+  /// on (email_unique_ci). `prisma generate` is enough for this change.
   @@index([ccaID, startTime, endTime], map: "cca_time")
 }
 

--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  CalendarClock,
   Check,
   MapPin,
   Pencil,
@@ -59,6 +58,48 @@ function toEpoch(dateStr: string, hhmm: string): number | null {
   }
   return Math.floor(new Date(Y!, M! - 1, D!, h!, m!, 0, 0).getTime() / 1000);
 }
+/**
+ * The window [start, end) for one date plus a from/to time, ROLLING THE END
+ * PAST MIDNIGHT when it would otherwise not be after the start.
+ *
+ * "22:00 → 00:00" is how a 24-hour time picker spells "run until the end of the
+ * day", and "22:00 → 02:00" spells a late session — but read literally against
+ * the same date both land BEFORE the start, so the generator produced zero
+ * candidates and the form looked broken with nothing to explain it. Midnight is
+ * not an edge case here: it is the value a head reaches for whenever the last
+ * interview is the last thing of the day.
+ *
+ * `nextDay` is returned rather than kept quiet so the preview can SAY the window
+ * crosses midnight. A rollover the head did not intend (a mistyped 14:00 → 09:00)
+ * is then visible as "ends tomorrow" plus a preview full of slots, instead of
+ * being applied silently.
+ */
+function toWindow(
+  dateStr: string,
+  fromHHMM: string,
+  toHHMM: string,
+): { start: number; end: number; nextDay: boolean } | null {
+  const start = toEpoch(dateStr, fromHHMM);
+  const sameDayEnd = toEpoch(dateStr, toHHMM);
+  if (start === null || sameDayEnd === null) return null;
+  if (sameDayEnd > start) return { start, end: sameDayEnd, nextDay: false };
+  // Start == end is a typo, not a 24-hour day of interviews. Rolling it over
+  // would silently propose 96 slots off two identical times.
+  if (sameDayEnd === start) return null;
+  // +1 DAY in local terms, via the date parts — NOT +86400 seconds, which is an
+  // hour out either side of a DST change. Singapore has none, but the app's
+  // time inputs are local and this helper should not be the thing that has to
+  // be revisited if that ever stops being true.
+  const [Y, M, D] = dateStr.split("-").map(Number);
+  const [h, m] = toHHMM.split(":").map(Number);
+  if ([Y, M, D, h, m].some((n) => n === undefined || Number.isNaN(n))) {
+    return null;
+  }
+  const end = Math.floor(
+    new Date(Y!, M! - 1, D! + 1, h!, m!, 0, 0).getTime() / 1000,
+  );
+  return { start, end, nextDay: true };
+}
 function toDateInput(epoch: number): string {
   const d = new Date(epoch * 1000);
   const p = (n: number) => String(n).padStart(2, "0");
@@ -78,6 +119,24 @@ function fmtTime(epoch: number | null): string {
 }
 function overlaps(aS: number, aE: number, bS: number, bE: number): boolean {
   return aS < bE && bS < aE;
+}
+
+/**
+ * `value`, but only after it has stopped changing for `ms`.
+ *
+ * The room-availability lookup is keyed on the window the head is typing, and a
+ * `<input type="time">` emits a change per keystroke — without this, "14:30"
+ * fires four range scans of the whole Bookings collection, three of them for
+ * windows that existed for 80ms. Debounce on a STRING key, never on the range
+ * object: a fresh object every render would reset the timer forever.
+ */
+function useDebounced<T>(value: T, ms: number): T {
+  const [settled, setSettled] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setSettled(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return settled;
 }
 
 /* ================================ component ================================= */
@@ -130,7 +189,7 @@ export default function InterviewSlots({ ccaID }: { ccaID: number }) {
                   window.confirm(
                     `Clear all ${freeCount} empty slot${
                       freeCount === 1 ? "" : "s"
-                    }? Slots with anyone booked on them are kept.`,
+                    }? Slots with anyone booked on them are kept, and any room held only by the cleared slots is given back.`,
                   )
                 ) {
                   clear.mutate({ ccaID });
@@ -186,9 +245,27 @@ function SlotGenerator({
   // the card afterwards — a per-chip capacity picker in the preview would be a
   // lot of UI for a case that barely happens.
   const [capacity, setCapacity] = useState(SLOT_CAPACITY_DEFAULT);
+  /** "" = no location, "other" = free text, otherwise a facilityID as a string —
+   *  the same encoding the event proposal form uses, so the two location
+   *  pickers behave identically. */
+  const [facilitySelection, setFacilitySelection] = useState("");
   const [location, setLocation] = useState("");
   const [removed, setRemoved] = useState<Set<number>>(new Set());
   const [formError, setFormError] = useState<string | null>(null);
+
+  // Public query (it feeds the signed-out calendar too), so a head with no
+  // facility-booking role still sees the list — booking a room for interviews is
+  // authorised by heading the CCA, and the server is the enforcement point.
+  const facilitiesQuery = api.bookings.getAllFacilities.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const facilities = facilitiesQuery.data ?? [];
+  const facilityID =
+    facilitySelection !== "" && facilitySelection !== "other"
+      ? Number(facilitySelection)
+      : null;
+  const facilityName =
+    facilities.find((f) => f.facilityID === facilityID)?.facilityName ?? null;
 
   const create = api.ccaApplicationsHead.openSlots.useMutation({
     onSuccess: async () => {
@@ -203,11 +280,12 @@ function SlotGenerator({
   // Build the candidate slots from the range + duration, then annotate each with
   // whether it collides with an already-open slot (client-side, so the head sees
   // conflicts before submitting rather than getting a whole-batch rejection).
+  const window = useMemo(() => toWindow(date, from, to), [date, from, to]);
+
   const candidates = useMemo(() => {
-    const startEpoch = toEpoch(date, from);
-    const endEpoch = toEpoch(date, to);
-    if (startEpoch === null || endEpoch === null || duration <= 0) return [];
-    if (endEpoch <= startEpoch) return [];
+    if (window === null || duration <= 0) return [];
+    const startEpoch = window.start;
+    const endEpoch = window.end;
     const durSec = duration * 60;
     const gapSec = Math.max(0, gap) * 60;
     const now = Math.floor(Date.now() / 1000);
@@ -236,23 +314,105 @@ function SlotGenerator({
       index += 1;
     }
     return out;
-  }, [date, from, to, duration, gap, existing]);
+  }, [window, duration, gap, existing]);
 
   const creatable = candidates.filter(
     (c) => !c.conflict && !c.past && !removed.has(c.index),
   );
   const overCap = creatable.length > MAX_SLOTS_PER_OPEN;
 
+  /* ----------------------- which rooms are free then ---------------------- */
+
+  // The window that would actually be BOOKED — the first creatable slot's start
+  // to the last one's end, not the typed window, because excluded/past/clashing
+  // chips are never opened and the room is not held for them. Falls back to the
+  // typed window so the picker starts annotating as soon as the times are in,
+  // before a duration has produced any chips.
+  //
+  // A plain derivation, NOT a useMemo: `creatable` is a fresh array every
+  // render, so a memo keyed on it would recompute anyway — and the STRING is
+  // what the rest of this depends on, which is stable whenever the times are.
+  const rangeKey =
+    creatable.length > 0
+      ? `${Math.min(...creatable.map((c) => c.startTime))}:${Math.max(
+          ...creatable.map((c) => c.endTime),
+        )}`
+      : window
+        ? `${window.start}:${window.end}`
+        : "";
+  const settledKey = useDebounced(rangeKey, 400);
+  const settledRange = useMemo(() => {
+    if (settledKey === "") return null;
+    const [s, e] = settledKey.split(":").map(Number);
+    return s !== undefined && e !== undefined
+      ? { startTime: s, endTime: e }
+      : null;
+  }, [settledKey]);
+
+  const availabilityQuery = api.bookings.getFacilityAvailability.useQuery(
+    settledRange ?? { startTime: 0, endTime: 0 },
+    {
+      enabled: settledRange !== null,
+      staleTime: 30 * 1000,
+      // react-query v5 spelling. Keeps the last answer on screen while the next
+      // one loads, so the option labels don't flicker back to bare names.
+      placeholderData: (prev) => prev,
+    },
+  );
+
+  // Only annotate when the ANSWER MATCHES THE WINDOW ON SCREEN. While the head
+  // is still typing, the newest data describes an older window, and a room
+  // labelled "free" for a window nobody asked about is worse than one labelled
+  // nothing at all.
+  const availabilityFresh =
+    rangeKey !== "" && rangeKey === settledKey && !availabilityQuery.isFetching;
+  const availability = useMemo(
+    () =>
+      new Map(
+        (availabilityFresh ? (availabilityQuery.data ?? []) : []).map((a) => [
+          a.facilityID,
+          a,
+        ]),
+      ),
+    [availabilityFresh, availabilityQuery.data],
+  );
+  const freeCount = [...availability.values()].filter((a) => a.available).length;
+  const selectedAvailability =
+    facilityID !== null ? (availability.get(facilityID) ?? null) : null;
+  const selectedBusy =
+    selectedAvailability !== null && !selectedAvailability.available
+      ? selectedAvailability.conflict
+      : null;
+
+  /** "Dance Studio" → "Dance Studio — booked 3:00–4:00 PM". */
+  const optionLabel = (f: { facilityID: number; facilityName: string }) => {
+    const a = availability.get(f.facilityID);
+    if (!a || a.available || !a.conflict) return f.facilityName;
+    return `${f.facilityName} — booked ${fmtTime(
+      a.conflict.startTime,
+    )}–${fmtTime(a.conflict.endTime)}`;
+  };
+
+  const msg = create.error?.message ?? "";
+  // The room clash carries the taken window (FACILITY_BOOKED:start:end) so the
+  // head is told WHEN it is taken and can move, rather than just "no".
+  const clash = /^FACILITY_BOOKED:(\d+):(\d+)$/.exec(msg);
   const serverError = create.error
-    ? create.error.message === "DUPLICATE_SLOT"
-      ? "One of these is identical to a slot you've already opened."
-      : create.error.message === "SLOT_OVERLAP"
-        ? "One of these overlaps a slot that was just taken. Refresh and regenerate."
-        : create.error.message === "SLOT_IN_PAST"
-          ? "Some of these are in the past."
-          : create.error.message === "NOT_A_HEAD_OF_THIS_CCA"
-            ? "You're no longer a head of this CCA."
-            : "Those didn't open. Try again."
+    ? clash
+      ? `${facilityName ?? "That room"} is already booked ${fmtTime(
+          Number(clash[1]),
+        )}–${fmtTime(Number(clash[2]))}. Pick another time or room — nothing was opened.`
+      : msg === "NO_SUCH_FACILITY"
+        ? "That room no longer exists. Pick another."
+        : msg === "DUPLICATE_SLOT"
+          ? "One of these is identical to a slot you've already opened."
+          : msg === "SLOT_OVERLAP"
+            ? "One of these overlaps a slot that was just taken. Refresh and regenerate."
+            : msg === "SLOT_IN_PAST"
+              ? "Some of these are in the past."
+              : msg === "NOT_A_HEAD_OF_THIS_CCA"
+                ? "You're no longer a head of this CCA."
+                : "Those didn't open. Try again."
     : null;
 
   const submit = () => {
@@ -269,13 +429,32 @@ function SlotGenerator({
       );
       return;
     }
+    if (facilitySelection === "other" && location.trim() === "") {
+      setFormError("Type the location, or pick a room from the list.");
+      return;
+    }
+    // Advisory check — the server re-checks under the facility lock and is the
+    // only thing that can actually refuse (I-7). This just saves a round trip
+    // for the case the head can already see on screen.
+    if (selectedBusy) {
+      setFormError(
+        `${facilityName} is booked ${fmtTime(
+          selectedBusy.startTime,
+        )}–${fmtTime(selectedBusy.endTime)}. Pick another room or move the window.`,
+      );
+      return;
+    }
     // Validate each against the shared schema before sending. `capacity` is
     // sent explicitly rather than left to the schema default, so what the head
     // sees in the preview is literally what is transmitted.
+    //
+    // `location` is only sent for a free-text choice: when a facility is picked
+    // the SERVER denormalizes its name into every slot, so the browser never
+    // gets to decide what the room is called.
     const slots = creatable.map((c) => ({
       startTime: c.startTime,
       endTime: c.endTime,
-      location: location.trim() || undefined,
+      location: facilityID === null ? location.trim() || undefined : undefined,
       capacity,
     }));
     for (const s of slots) {
@@ -285,7 +464,11 @@ function SlotGenerator({
       }
     }
     setFormError(null);
-    create.mutate({ ccaID, slots });
+    create.mutate({
+      ccaID,
+      slots,
+      ...(facilityID !== null ? { facilityID } : {}),
+    });
   };
 
   return (
@@ -324,16 +507,86 @@ function SlotGenerator({
           />
         </Field>
         <Field label="Location">
-          <input
-            type="text"
-            value={location}
-            maxLength={INTERVIEW_LOCATION_MAX}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="e.g. JCRC Room (optional)"
+          <select
+            value={facilitySelection}
+            onChange={(e) => setFacilitySelection(e.target.value)}
             className={inputCls}
-          />
+          >
+            <option value="">No location</option>
+            {facilities.map((f) => {
+              const a = availability.get(f.facilityID);
+              return (
+                <option
+                  key={f.facilityID}
+                  value={String(f.facilityID)}
+                  // Taken rooms stay VISIBLE and disabled rather than being
+                  // filtered out: a room that silently disappears when the head
+                  // changes the time reads as a bug, where "booked 3:00–4:00 PM"
+                  // reads as something to work around.
+                  disabled={a !== undefined && !a.available}
+                >
+                  {optionLabel(f)}
+                </option>
+              );
+            })}
+            <option value="other">Other (type it in)</option>
+          </select>
+          {facilitySelection === "other" && (
+            <input
+              type="text"
+              value={location}
+              maxLength={INTERVIEW_LOCATION_MAX}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. the void deck outside Block C"
+              className={`${inputCls} mt-1.5`}
+            />
+          )}
         </Field>
       </div>
+
+      {/* What the list is showing right now: whose availability, for when, and
+          whether it is still being worked out. */}
+      {facilitySelection !== "other" && (
+        <p className="mt-2 text-xs text-gray-500">
+          {rangeKey === ""
+            ? "Pick a date and time to see which rooms are free then."
+            : !availabilityFresh
+              ? "Checking which rooms are free…"
+              : `${freeCount} of ${availability.size} room${
+                  availability.size === 1 ? "" : "s"
+                } free ${fmtTime(settledRange!.startTime)}–${fmtTime(
+                  settledRange!.endTime,
+                )}. Booked ones are greyed out.`}
+        </p>
+      )}
+
+      {/* The room was free when it was picked and is not any more — the head
+          changed the times afterwards. Said here rather than left to the server
+          to refuse on submit. */}
+      {selectedBusy && (
+        <p className="mt-2 text-xs font-medium text-red-600">
+          {facilityName} is booked {fmtTime(selectedBusy.startTime)}–
+          {fmtTime(selectedBusy.endTime)}
+          {selectedBusy.eventName ? ` (${selectedBusy.eventName})` : ""} — pick
+          another room or move the window.
+        </p>
+      )}
+
+      {/* Say what picking a room DOES, before it is done: it takes the room out
+          of the hall booking calendar for the whole window. */}
+      {facilityID !== null && selectedBusy === null && (
+        <p className="mt-2 text-xs text-emerald-700">
+          {facilityName} is booked for you the moment you open these slots —
+          one booking covering the whole window, under your name. Cancelling
+          every slot in it gives the room back.
+        </p>
+      )}
+      {facilitySelection === "other" && (
+        <p className="mt-2 text-xs text-gray-500">
+          Free text is a label only — no room is held. Pick a room from the list
+          if you need the hall booking.
+        </p>
+      )}
 
       <div className="mt-3 flex flex-wrap items-end gap-4">
         <div>
@@ -418,6 +671,22 @@ function SlotGenerator({
         </p>
       )}
 
+      {/* An empty preview now EXPLAINS itself. A window that fits nothing used
+          to render as no preview at all and a dead "Open slots" button, which is
+          how the midnight bug read to the heads who hit it: not "your times are
+          impossible" but "the page is broken". */}
+      {date !== "" && from !== "" && to !== "" && candidates.length === 0 && (
+        <p className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {window === null
+            ? "Start and end are the same time — set an end after the start."
+            : duration <= 0
+              ? "Set how many minutes each interview runs."
+              : `${fmtTime(window.start)}–${fmtTime(
+                  window.end,
+                )} isn't long enough for one ${duration}-minute interview. Widen the window or shorten each interview.`}
+        </p>
+      )}
+
       {/* Preview */}
       {candidates.length > 0 && (
         <div className="mt-4 rounded-md border border-gray-200 bg-gray-50 p-3">
@@ -482,6 +751,19 @@ function SlotGenerator({
               );
             })}
           </ul>
+          {window?.nextDay && (
+            <p className="mt-2 text-xs text-amber-700">
+              This window runs past midnight — it ends at {fmtTime(window.end)}{" "}
+              on {fmtDayTab(window.end)}.
+            </p>
+          )}
+          {facilityID !== null && creatable.length > 0 && (
+            <p className="mt-2 text-xs text-emerald-700">
+              {facilityName} will be booked{" "}
+              {fmtTime(Math.min(...creatable.map((c) => c.startTime)))}–
+              {fmtTime(Math.max(...creatable.map((c) => c.endTime)))}.
+            </p>
+          )}
           {candidates.some((c) => c.conflict) && (
             <p className="mt-2 text-xs text-gray-500">
               Struck-through times overlap slots you&rsquo;ve already opened and
@@ -683,6 +965,22 @@ function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
         <p className={`mt-0.5 inline-flex items-center gap-1 text-xs ${muted}`}>
           <MapPin className="h-3 w-3" />
           {slot.location}
+          {/* A held room reads differently from a typed-in label: one of them
+              means nobody else can have the room. */}
+          {slot.facilityID != null && (
+            <span
+              title={
+                slot.booking
+                  ? `Room booked ${fmtTime(slot.booking.startTime)}–${fmtTime(
+                      slot.booking.endTime,
+                    )}`
+                  : "Room booking was removed — the room is no longer held"
+              }
+              className={slot.booking ? "" : "text-red-600"}
+            >
+              {slot.booking ? "· booked" : "· not held"}
+            </span>
+          )}
         </p>
       )}
       <p className={`mt-1 text-xs font-medium tabular-nums ${muted}`}>
@@ -780,12 +1078,14 @@ function SlotEditForm({
   });
 
   const save = () => {
-    const startTime = toEpoch(date, from);
-    const endTime = toEpoch(date, to);
-    if (startTime === null || endTime === null) {
+    // Same midnight rollover as the generator: an interview that ends at 00:00
+    // ends at midnight TONIGHT, not this morning.
+    const win = toWindow(date, from, to);
+    if (win === null) {
       setErr("Pick a date, start and end.");
       return;
     }
+    const { start: startTime, end: endTime } = win;
     // Refuse locally what the server refuses, so the head is told BEFORE the
     // round trip that they would be evicting someone.
     if (capacity < slot.occupancy) {
@@ -816,16 +1116,26 @@ function SlotEditForm({
     update.mutate(parsed.data);
   };
 
+  const upMsg = update.error?.message ?? "";
+  const outside = /^OUTSIDE_BOOKING:(\d+):(\d+)$/.exec(upMsg);
   const serverErr = update.error
-    ? update.error.message === "SLOT_OVERLAP"
-      ? "That overlaps another slot."
-      : update.error.message === "SLOT_IN_PAST"
-        ? "That's in the past."
-        : update.error.message === "SLOT_BOOKED"
-          ? "Someone's booked on this slot — you can change how many people it takes, but not when or where. Cancel it instead."
-          : update.error.message === "CAPACITY_BELOW_OCCUPANCY"
-            ? "Someone booked while you were editing — capacity can't go below the number already on this slot."
-            : "That didn't save."
+    ? outside
+      ? `${slot.location ?? "That room"} is only held ${fmtTime(
+          Number(outside[1]),
+        )}–${fmtTime(
+          Number(outside[2]),
+        )}. Keep this slot inside that, or cancel it and open a new window.`
+      : upMsg === "FACILITY_LOCATION_LOCKED"
+        ? "This slot's location is the room booked for it — cancel it and open a new one to move rooms."
+        : upMsg === "SLOT_OVERLAP"
+          ? "That overlaps another slot."
+          : upMsg === "SLOT_IN_PAST"
+            ? "That's in the past."
+            : upMsg === "SLOT_BOOKED"
+              ? "Someone's booked on this slot — you can change how many people it takes, but not when or where. Cancel it instead."
+              : upMsg === "CAPACITY_BELOW_OCCUPANCY"
+                ? "Someone booked while you were editing — capacity can't go below the number already on this slot."
+                : "That didn't save."
     : null;
 
   return (
@@ -838,13 +1148,23 @@ function SlotEditForm({
         <input type="date" value={date} disabled={locked} onChange={(e) => setDate(e.target.value)} className={inputCls} />
         <input type="time" value={from} disabled={locked} onChange={(e) => setFrom(e.target.value)} className={inputCls} />
         <input type="time" value={to} disabled={locked} onChange={(e) => setTo(e.target.value)} className={inputCls} />
+        {/* A booked room is not editable text: `location` IS the facility's
+            name, and the server refuses to change it (FACILITY_LOCATION_LOCKED)
+            because moving rooms means releasing one booking and taking another.
+            Shown, disabled, rather than hidden — the head still needs to see
+            where the interview is. */}
         <input
           type="text"
           value={location}
-          disabled={locked}
+          disabled={locked || slot.facilityID != null}
           maxLength={INTERVIEW_LOCATION_MAX}
           onChange={(e) => setLocation(e.target.value)}
           placeholder="Location"
+          title={
+            slot.facilityID != null
+              ? "Booked room — cancel the slot to move rooms"
+              : undefined
+          }
           className={inputCls}
         />
         <label className="text-sm">
@@ -867,6 +1187,13 @@ function SlotEditForm({
           ? ` · ${slot.occupancy} already booked (time and location are locked while anyone is booked)`
           : ""}
       </p>
+      {slot.facilityID != null && slot.booking && (
+        <p className="text-xs text-emerald-700">
+          {slot.location} is held {fmtTime(slot.booking.startTime)}–
+          {fmtTime(slot.booking.endTime)} — this slot can move anywhere inside
+          that.
+        </p>
+      )}
       {(err ?? serverErr) && <p className="text-sm text-red-600">{err ?? serverErr}</p>}
       <div className="flex items-center gap-2">
         <Button onClick={save} disabled={update.isPending} className="inline-flex items-center gap-1.5">

--- a/src/lib/schemas/ccaApplication.ts
+++ b/src/lib/schemas/ccaApplication.ts
@@ -89,6 +89,12 @@ const epochSeconds = z.number().int().positive();
  * slot they are about to book.
  */
 const capacity = z.number().int().min(1).max(SLOT_CAPACITY_MAX);
+/**
+ * A bookable facility (Facilities.facilityID). HEAD-ONLY, like `capacity`:
+ * choosing one makes the server hold the room, so a resident input must never
+ * carry this key.
+ */
+const facilityID = z.number().int().positive();
 
 /* -------------------------------------------------------------------------- */
 /* Resident inputs                                                             */
@@ -143,9 +149,23 @@ export const slotDraftSchema = z
   });
 export type SlotDraft = z.input<typeof slotDraftSchema>;
 
+/**
+ * Open a batch of slots, optionally IN a facility.
+ *
+ * `facilityID` is on the BATCH, not on each slot, because the room is held once
+ * for the whole window (one Bookings row spanning the first slot's start to the
+ * last slot's end) rather than once per 15-minute slot. Per-slot facilities
+ * would mean per-slot bookings — fifty rows in the facility calendar for one
+ * afternoon of interviews.
+ *
+ * When it is set the server denormalizes the facility NAME into every slot's
+ * `location` (so the resident-facing list still reads "JCRC Room" with no
+ * join), and any `location` text on the drafts is ignored.
+ */
 export const openSlotsInput = z.object({
   ccaID,
   slots: z.array(slotDraftSchema).min(1).max(MAX_SLOTS_PER_OPEN),
+  facilityID: facilityID.optional(),
 });
 export type OpenSlotsInput = z.input<typeof openSlotsInput>;
 

--- a/src/server/api/routers/ccaApplicationsHead.ts
+++ b/src/server/api/routers/ccaApplicationsHead.ts
@@ -17,6 +17,12 @@ import {
   withCcaLock,
 } from "~/server/api/services/ccaApplications";
 import {
+  findFacilityConflict,
+  nextBookingId,
+  resolveFacility,
+  withFacilityLock,
+} from "~/server/api/services/booking";
+import {
   addNoteInput,
   cancelSlotInput,
   ccaTargetInput,
@@ -146,6 +152,56 @@ function overlaps(
   bEnd: number,
 ): boolean {
   return aStart < bEnd && bStart < aEnd;
+}
+
+/**
+ * Release the facility bookings that no longer hold anything.
+ *
+ * ONE booking covers a whole generated window, so several slots share a
+ * bookingID; the room must be freed exactly when the LAST live slot pointing at
+ * it goes away, never on the first cancel. Call this AFTER the slots have been
+ * marked canceled, with the bookingIDs those slots carried.
+ *
+ * BEST-EFFORT, like the event-rejection path: a booking that has already been
+ * deleted (by hand, on the bookings page) is not an error, and a failure here
+ * must not roll back a cancel the head has already been told happened. The worst
+ * case is a stale hold on a room, which a human can delete; the alternative —
+ * failing the cancel — leaves applicants booked into an interview that is off.
+ *
+ * `canceledAt` is filtered in JS, not the query: `{ canceledAt: null }` misses
+ * ABSENT fields on Prisma+Mongo, which would make a live slot invisible here and
+ * free a room that is still in use. Same trap as listSlots.
+ */
+async function releaseUnusedBookings(
+  db: PrismaClient,
+  ccaID: number,
+  bookingIDs: readonly number[],
+): Promise<number[]> {
+  const ids = [...new Set(bookingIDs.filter((b): b is number => b !== null))];
+  const released: number[] = [];
+  for (const bookingID of ids) {
+    try {
+      const holders = (
+        await db.ccaInterviewSlot.findMany({
+          where: { ccaID, bookingID },
+          select: { slotID: true, canceledAt: true },
+        })
+      ).filter((s) => s.canceledAt === null);
+      if (holders.length > 0) continue;
+      await db.bookings.deleteMany({ where: { bookingID } });
+      released.push(bookingID);
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          evt: "interview_slot_booking_release_failed",
+          ccaID,
+          bookingID,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+  return released;
 }
 
 export const ccaApplicationsHeadRouter = createTRPCRouter({
@@ -343,6 +399,8 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             endTime: true,
             location: true,
             capacity: true,
+            facilityID: true,
+            bookingID: true,
             canceledAt: true,
           },
           orderBy: { startTime: "asc" },
@@ -373,10 +431,31 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         arr.push(c);
         bySlot.set(c.interviewSlotID, arr);
       }
-      const people = await resolveApplicants(
-        ctx.db,
-        slots.flatMap((s) => (bySlot.get(s.slotID) ?? []).map((c) => c.userID)),
-      );
+      // The rooms held for these slots. Sent so the head's edit form can say
+      // WHICH window is held ("2:00–5:00 PM") instead of refusing a move with a
+      // bare error — and so a hold deleted by hand on the bookings page shows up
+      // here as `booking: null` rather than as a silent claim to a room nobody
+      // has any more.
+      const bookingIDs = [
+        ...new Set(
+          slots
+            .map((s) => s.bookingID)
+            .filter((b): b is number => b !== null && b !== undefined),
+        ),
+      ];
+      const [people, bookings] = await Promise.all([
+        resolveApplicants(
+          ctx.db,
+          slots.flatMap((s) => (bySlot.get(s.slotID) ?? []).map((c) => c.userID)),
+        ),
+        bookingIDs.length > 0
+          ? ctx.db.bookings.findMany({
+              where: { bookingID: { in: bookingIDs } },
+              select: { bookingID: true, startTime: true, endTime: true },
+            })
+          : Promise.resolve([]),
+      ]);
+      const bookingByID = new Map(bookings.map((b) => [b.bookingID, b]));
 
       return {
         slots: slots.map((s) => {
@@ -386,6 +465,11 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             startTime: s.startTime,
             endTime: s.endTime,
             location: s.location,
+            facilityID: s.facilityID,
+            booking:
+              s.bookingID != null
+                ? (bookingByID.get(s.bookingID) ?? null)
+                : null,
             canceledAt: s.canceledAt,
             capacity: slotCapacity(s.capacity),
             occupancy: occupants.length,
@@ -404,6 +488,25 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
    * Open one or more interview slots. Rejects a slot in the past, a zero/negative
    * duration (the schema already blocks end<=start), or one overlapping an
    * existing open slot OR another slot in the same batch.
+   *
+   * FACILITY. When `facilityID` is given the room is BOOKED HERE, at open time —
+   * this is the answer to "when does it auto-book?", and it is deliberately
+   * different from events (which book on JCRC approval, because an event is a
+   * proposal until then). A head opening interview slots is already authorised;
+   * there is nothing left to approve, and a room that is only held once someone
+   * books a slot is a room that can be taken from under the whole schedule.
+   *
+   * ONE booking spans the whole window (first start → last end), not one per
+   * slot: the head needs the room for the session, and fifty rows in the
+   * facility calendar for one afternoon helps nobody. A clash REFUSES the entire
+   * batch — unlike the events path, which flags and carries on, because there is
+   * no approval step here to review the flag, and half-opening a schedule into a
+   * room someone else has is worse than opening nothing.
+   *
+   * The facility ROLE gate (getBookableFacilityMap) is intentionally not applied:
+   * heading a CCA that is running interviews IS the authorization, exactly as
+   * JCRC approval is on the events path. The physical time-conflict check is
+   * kept, because two groups cannot share a room whatever their roles say.
    */
   openSlots: identifiedProcedure
     .input(openSlotsInput)
@@ -463,29 +566,105 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           accepted.push({ startTime: s.startTime, endTime: s.endTime });
         }
 
+        // Hold the room BEFORE writing any slot, so a clash leaves nothing
+        // behind. The window is the whole batch: first start → last end.
+        const facility =
+          input.facilityID != null
+            ? await resolveFacility(ctx.db, input.facilityID)
+            : null;
+        let bookingID: number | null = null;
+        if (facility) {
+          const windowStart = Math.min(...input.slots.map((s) => s.startTime));
+          const windowEnd = Math.max(...input.slots.map((s) => s.endTime));
+          const cca = await ctx.db.cCA.findUnique({
+            where: { ccaID: input.ccaID },
+            select: { ccaName: true },
+          });
+          // Nested INSIDE withCcaLock. The two locks are on disjoint keyspaces
+          // (`cca:` vs `facility:`) and are always taken in this order, so they
+          // cannot deadlock against each other.
+          bookingID = await withFacilityLock(
+            ctx.db,
+            facility.facilityID,
+            async () => {
+              const clash = await findFacilityConflict(
+                ctx.db,
+                facility.facilityID,
+                windowStart,
+                windowEnd,
+              );
+              if (clash) {
+                // Times ride in the message so the head is told WHEN the room is
+                // taken and can move the window, instead of "it didn't work".
+                throw new TRPCError({
+                  code: "CONFLICT",
+                  message: `FACILITY_BOOKED:${clash.startTime}:${clash.endTime}`,
+                });
+              }
+              const id = await nextBookingId(ctx.db);
+              await ctx.db.bookings.create({
+                data: {
+                  bookingID: id,
+                  ccaID: input.ccaID,
+                  facilityID: facility.facilityID,
+                  startTime: windowStart,
+                  endTime: windowEnd,
+                  userID,
+                  eventName: `${cca?.ccaName ?? `CCA #${input.ccaID}`} interviews`,
+                  description: `Auto-booked for ${input.slots.length} interview slot(s)`,
+                },
+              });
+              return id;
+            },
+          );
+        }
+
         const batchId = randomUUID();
         const created: number[] = [];
-        for (const s of input.slots) {
-          const slotID = await nextCounter(ctx.db, SLOT_COUNTER_KEY);
-          await ctx.db.ccaInterviewSlot.create({
-            data: {
-              slotID,
-              ccaID: input.ccaID,
-              startTime: s.startTime,
-              endTime: s.endTime,
-              location: s.location ?? null,
-              createdBy: userID,
-              createdAt: new Date(),
-              // EXPLICIT, never absent — Prisma+Mongo's null filter does not
-              // match an absent field, and `capacity` is written as a real
-              // number for the same reason: a row whose capacity is absent
-              // reads back as null and only survives because slotCapacity()
-              // normalises it. New rows should not need that rescue.
-              capacity: s.capacity,
-              canceledAt: null,
-            },
-          });
-          created.push(slotID);
+        try {
+          for (const s of input.slots) {
+            const slotID = await nextCounter(ctx.db, SLOT_COUNTER_KEY);
+            await ctx.db.ccaInterviewSlot.create({
+              data: {
+                slotID,
+                ccaID: input.ccaID,
+                startTime: s.startTime,
+                endTime: s.endTime,
+                // A facility wins over any free text on the draft: `location`
+                // is the DENORMALIZED name, so every reader (the resident slot
+                // list, the run-sheet) renders the room with no join.
+                location: facility ? facility.name : (s.location ?? null),
+                createdBy: userID,
+                createdAt: new Date(),
+                // EXPLICIT, never absent — Prisma+Mongo's null filter does not
+                // match an absent field, and `capacity` is written as a real
+                // number for the same reason: a row whose capacity is absent
+                // reads back as null and only survives because slotCapacity()
+                // normalises it. New rows should not need that rescue.
+                capacity: s.capacity,
+                facilityID: facility ? facility.facilityID : null,
+                bookingID,
+                canceledAt: null,
+              },
+            });
+            created.push(slotID);
+          }
+        } catch (err) {
+          // Never leave a room held for slots that do not exist. The slots
+          // written before the failure are canceled too, so the batch is
+          // all-or-nothing from the head's point of view.
+          if (created.length > 0) {
+            await ctx.db.ccaInterviewSlot.updateMany({
+              where: { slotID: { in: created } },
+              data: { canceledAt: new Date() },
+            });
+          }
+          if (bookingID !== null) {
+            await ctx.db.bookings
+              .deleteMany({ where: { bookingID } })
+              .catch(() => undefined);
+          }
+          throw err;
         }
 
         await writeAudit(ctx.db, {
@@ -496,13 +675,24 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           batchId,
           // The capacity is in the audit line because "we opened 20 slots" and
           // "we opened 20 slots for 6 people each" are very different decisions
-          // to have to reconstruct later.
+          // to have to reconstruct later. The room and its booking are there for
+          // the same reason: a held facility is a physical claim, and it must be
+          // attributable to the head who made it.
           reason: `${scope.via}: opened ${created.length} slot(s), ${
             input.slots.reduce((n, s) => n + s.capacity, 0)
-          } seat(s)`,
+          } seat(s)${
+            facility
+              ? ` in ${facility.name} (booking #${bookingID})`
+              : ""
+          }`,
         });
 
-        return { ccaID: input.ccaID, opened: created.length, slotIDs: created };
+        return {
+          ccaID: input.ccaID,
+          opened: created.length,
+          slotIDs: created,
+          bookingID,
+        };
       });
     }),
 
@@ -541,6 +731,8 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             endTime: true,
             location: true,
             capacity: true,
+            facilityID: true,
+            bookingID: true,
             canceledAt: true,
           },
         });
@@ -575,6 +767,42 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         const now = Math.floor(Date.now() / 1000);
         if (input.endTime <= now) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "SLOT_IN_PAST" });
+        }
+
+        // A slot in a booked room may be nudged WITHIN the window that was held
+        // for it, but never outside it and never renamed.
+        //
+        // The room is held once for a whole batch, so several slots share this
+        // booking: growing it for one of them could clash with another CCA, and
+        // shrinking it would hand away time the sibling slots are still using.
+        // Changing the ROOM is likewise a cancel-and-reopen, not an edit — the
+        // same rule the time already follows on an occupied slot. The alternative
+        // (re-booking per edited slot) fragments one afternoon's hold into a
+        // dozen rows and has to reason about a slot conflicting with its own
+        // batch's booking.
+        if (slot.facilityID != null) {
+          if ((nextLocation ?? "") !== (slot.location ?? "")) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "FACILITY_LOCATION_LOCKED",
+            });
+          }
+          const held =
+            slot.bookingID != null
+              ? await ctx.db.bookings.findUnique({
+                  where: { bookingID: slot.bookingID },
+                  select: { startTime: true, endTime: true },
+                })
+              : null;
+          if (
+            held &&
+            (input.startTime < held.startTime || input.endTime > held.endTime)
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: `OUTSIDE_BOOKING:${held.startTime}:${held.endTime}`,
+            });
+          }
         }
 
         // Overlap against every OTHER non-canceled slot for this CCA.
@@ -650,7 +878,12 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
       return withCcaLock(ctx.db, input.ccaID, async () => {
         const slot = await ctx.db.ccaInterviewSlot.findUnique({
           where: { slotID: input.slotID },
-          select: { slotID: true, ccaID: true, canceledAt: true },
+          select: {
+            slotID: true,
+            ccaID: true,
+            bookingID: true,
+            canceledAt: true,
+          },
         });
         if (!slot || slot.ccaID !== input.ccaID || slot.canceledAt !== null) {
           throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_SLOT" });
@@ -680,6 +913,13 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           data: { canceledAt: new Date() },
         });
 
+        // AFTER the cancel, so the just-canceled slot no longer counts as a
+        // holder. Frees the room only if this was the last live slot on it.
+        const released =
+          slot.bookingID != null
+            ? await releaseUnusedBookings(ctx.db, input.ccaID, [slot.bookingID])
+            : [];
+
         await writeAudit(ctx.db, {
           actorUserID: userID,
           actorRoles: roles,
@@ -690,10 +930,18 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
             reverted.count > 0
               ? ` (reverted ${reverted.count} application(s) to submitted)`
               : ""
+          }${
+            released.length > 0
+              ? ` (released facility booking #${released.join(", #")})`
+              : ""
           }`,
         });
 
-        return { slotID: input.slotID, revertedCount: reverted.count };
+        return {
+          slotID: input.slotID,
+          revertedCount: reverted.count,
+          releasedBookings: released.length,
+        };
       });
     }),
 
@@ -723,19 +971,17 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
         const [all, occupancy] = await Promise.all([
           ctx.db.ccaInterviewSlot.findMany({
             where: { ccaID: input.ccaID },
-            select: { slotID: true, canceledAt: true },
+            select: { slotID: true, bookingID: true, canceledAt: true },
           }),
           occupancyBySlot(ctx.db, input.ccaID),
         ]);
-        const freeIDs = all
-          .filter(
-            (s) =>
-              s.canceledAt === null && (occupancy.get(s.slotID) ?? 0) === 0,
-          )
-          .map((s) => s.slotID);
+        const free = all.filter(
+          (s) => s.canceledAt === null && (occupancy.get(s.slotID) ?? 0) === 0,
+        );
+        const freeIDs = free.map((s) => s.slotID);
 
         if (freeIDs.length === 0) {
-          return { ccaID: input.ccaID, cleared: 0 };
+          return { ccaID: input.ccaID, cleared: 0, releasedBookings: 0 };
         }
 
         // Mark them canceled by slotID list (not a null-filter), so absent-field
@@ -745,15 +991,34 @@ export const ccaApplicationsHeadRouter = createTRPCRouter({
           data: { canceledAt: new Date() },
         });
 
+        // Then free every room no live slot is standing on any more. A window
+        // that still has ONE booked slot in it keeps its room — clearing the
+        // empties around an interview must not cancel the room it runs in.
+        const released = await releaseUnusedBookings(
+          ctx.db,
+          input.ccaID,
+          free
+            .map((s) => s.bookingID)
+            .filter((b): b is number => b !== null && b !== undefined),
+        );
+
         await writeAudit(ctx.db, {
           actorUserID: userID,
           actorRoles: roles,
           targetCcaID: input.ccaID,
           action: "ccaInterviewSlot.clear",
-          reason: `${scope.via}: cleared ${freeIDs.length} free slot(s)`,
+          reason: `${scope.via}: cleared ${freeIDs.length} free slot(s)${
+            released.length > 0
+              ? `, released ${released.length} facility booking(s)`
+              : ""
+          }`,
         });
 
-        return { ccaID: input.ccaID, cleared: freeIDs.length };
+        return {
+          ccaID: input.ccaID,
+          cleared: freeIDs.length,
+          releasedBookings: released.length,
+        };
       });
     }),
 

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -18,7 +18,11 @@ import {
   nextEventId,
   withEventLock,
 } from "~/server/api/services/events";
-import { nextBookingId, withFacilityLock } from "~/server/api/services/booking";
+import {
+  nextBookingId,
+  resolveFacility,
+  withFacilityLock,
+} from "~/server/api/services/booking";
 import { canonicalUserID } from "~/lib/identity";
 import {
   createDraftInput,
@@ -208,25 +212,9 @@ async function attachCcaNames(
   return byID;
 }
 
-/**
- * Resolve a chosen facility to its id + name. The name is denormalized into
- * Event.location so every display path (timeline, detail, CSV) renders the
- * location without a join; the id drives the auto-booking on approval. Throws
- * if the facility does not exist.
- */
-async function resolveFacility(
-  db: PrismaClient,
-  facilityID: number,
-): Promise<{ facilityID: number; name: string }> {
-  const f = await db.facilities.findUnique({
-    where: { facilityID },
-    select: { facilityName: true },
-  });
-  if (!f) {
-    throw new TRPCError({ code: "BAD_REQUEST", message: "NO_SUCH_FACILITY" });
-  }
-  return { facilityID, name: f.facilityName };
-}
+/* resolveFacility lives in services/booking.ts — the interview-slot flow
+ * resolves a facility the same way, and one definition is what keeps the two
+ * agreeing about what a missing facility means. */
 
 /* -------------------------------------------------------------------------- */
 /* Router                                                                      */

--- a/src/server/api/routers/facilitiesBooking.ts
+++ b/src/server/api/routers/facilitiesBooking.ts
@@ -137,6 +137,87 @@ export const facilityBookingRouter = createTRPCRouter({
       );
     }),
 
+  /**
+   * Every facility, each annotated with whether it is FREE for a given window
+   * and — when it is not — the booking that takes it.
+   *
+   * Deliberately NOT getAvailableFacilities, which returns the free ones and
+   * drops the rest: a picker built on that shows a room vanishing from the list
+   * when the head changes the time, with nothing to say why. A room that reads
+   * "Dance Studio — booked 3:00–4:00 PM" tells them to move the window; a room
+   * that is simply absent tells them the page is broken.
+   *
+   * ADVISORY, exactly like getFacilitiesForBooking (I-7): the window can be
+   * taken between this query and the write, so the booking path re-checks under
+   * withFacilityLock and remains the only thing that can refuse. Never gate a
+   * write on this result alone.
+   *
+   * `conflict` is the EARLIEST overlapping booking, not all of them — the picker
+   * needs one concrete "taken from X to Y" to act on, and a room with three
+   * clashes is no more available than a room with one.
+   */
+  getFacilityAvailability: protectedProcedure
+    .input(
+      z.object({
+        startTime: z.number().int(),
+        endTime: z.number().int(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      if (input.endTime <= input.startTime) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "END_BEFORE_START",
+        });
+      }
+      const [facilities, clashes] = await Promise.all([
+        ctx.db.facilities.findMany({ orderBy: { facilityID: "asc" } }),
+        // Half-open overlap, matching findFacilityConflict and every other
+        // overlap check here: a booking ending exactly when this window starts
+        // does not take the room.
+        ctx.db.bookings.findMany({
+          where: {
+            AND: [
+              { startTime: { lt: input.endTime } },
+              { endTime: { gt: input.startTime } },
+            ],
+          },
+          select: {
+            facilityID: true,
+            startTime: true,
+            endTime: true,
+            eventName: true,
+          },
+          orderBy: { startTime: "asc" },
+        }),
+      ]);
+
+      const firstClash = new Map<number, (typeof clashes)[number]>();
+      for (const c of clashes) {
+        if (!firstClash.has(c.facilityID)) firstClash.set(c.facilityID, c);
+      }
+
+      return facilities.map((f) => {
+        const clash = firstClash.get(f.facilityID);
+        return {
+          facilityID: f.facilityID,
+          facilityName: f.facilityName,
+          facilityLocation: f.facilityLocation,
+          available: clash === undefined,
+          // `eventName` is what the hall calendar already shows publicly for a
+          // booking, so surfacing it here leaks nothing new — and "taken by
+          // Dance Club auditions" is what makes the clash resolvable.
+          conflict: clash
+            ? {
+                startTime: clash.startTime,
+                endTime: clash.endTime,
+                eventName: clash.eventName,
+              }
+            : null,
+        };
+      });
+    }),
+
   // Get booking by bookingID
   getBooking: protectedProcedure
     .input(z.number())

--- a/src/server/api/services/booking.ts
+++ b/src/server/api/services/booking.ts
@@ -57,6 +57,55 @@ export async function nextBookingId(db: PrismaClient): Promise<number> {
 }
 
 /**
+ * Resolve a chosen facility to its id + name. The name is DENORMALIZED into the
+ * owning row (Event.location, CcaInterviewSlot.location) so every display path
+ * renders the location without a join; the id drives the auto-booking. Throws if
+ * the facility does not exist.
+ *
+ * Lives here rather than in either router because both the events flow and the
+ * interview-slot flow resolve a facility the same way, and a second copy is a
+ * second chance for the two to disagree about what a missing facility means.
+ */
+export async function resolveFacility(
+  db: PrismaClient,
+  facilityID: number,
+): Promise<{ facilityID: number; name: string }> {
+  const f = await db.facilities.findUnique({
+    where: { facilityID },
+    select: { facilityName: true },
+  });
+  if (!f) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "NO_SUCH_FACILITY" });
+  }
+  return { facilityID, name: f.facilityName };
+}
+
+/**
+ * The FIRST booking overlapping [startTime, endTime) on a facility, or null.
+ *
+ * Half-open, matching every other overlap check in the codebase: a booking that
+ * ends exactly when this one starts does NOT conflict. MUST be called inside
+ * withFacilityLock by anything that then creates a booking — otherwise two
+ * requests can both read "free" and both insert.
+ */
+export async function findFacilityConflict(
+  db: PrismaClient,
+  facilityID: number,
+  startTime: number,
+  endTime: number,
+): Promise<{ bookingID: number; startTime: number; endTime: number } | null> {
+  const clash = await db.bookings.findFirst({
+    where: {
+      facilityID,
+      AND: [{ endTime: { gt: startTime } }, { startTime: { lt: endTime } }],
+    },
+    select: { bookingID: true, startTime: true, endTime: true },
+    orderBy: { startTime: "asc" },
+  });
+  return clash;
+}
+
+/**
  * Run `fn` while holding a per-facility advisory lock so overlapping-time
  * conflict checks and the subsequent create can't interleave.
  */


### PR DESCRIPTION
Three things a CCA head hits on the **Interview slots** tab.

## End time 00:00 opened nothing

The generator built its window with `toEpoch(date, "00:00")` — midnight at the **start** of that day — so `endEpoch <= startEpoch` and the candidate loop produced nothing: no preview, a dead "Open slots" button, no explanation. Midnight isn't an edge case here; it's what "run until the end of the day" looks like in a 24-hour time picker.

`toWindow()` now rolls the end past midnight when it isn't after the start, so `22:00 → 00:00` and `22:30 → 02:00` both mean the next morning. It adds a day via local date parts rather than `+86400`, so month and year ends are right. `start == end` stays invalid — that's a typo, not 24 hours of interviews. The slot edit form had the identical bug and now shares the helper, and an empty preview explains itself instead of rendering nothing.

## No facility picker

Location was free text, so the room an interview ran in was never actually held. It's now the same dropdown the event proposal form uses (facility / Other / none), and picking a room **books** it.

**When it books: at open time** — not on first applicant, not on approval. Events book on JCRC approval because an event is a proposal until then; interviews have no approval step, the head is already authorised, and a room held only once someone books a slot can be taken out from under the whole schedule.

- **One** booking spans the window, not one per slot — fifty rows in the facility calendar for one afternoon helps nobody.
- A clash **refuses the whole batch** with the taken times shown. Unlike the events path, which flags and carries on, there's no approval step here to review a flag, and half-opening a schedule into someone else's room is worse than opening nothing.
- Cancelling the last live slot on a booking releases the room; clearing empties around a booked interview keeps it.
- The facility *role* gate is skipped, as on the events path — heading the CCA is the authorization. The physical time-conflict check is kept.

## The room list ignored the time

Once a date and window are picked, each room is annotated free/booked for the window that would **actually** be booked (first creatable slot to last, not the raw typed range, since excluded/past/clashing chips are never opened). Taken rooms stay visible and greyed out with "booked 3:00–4:00 PM" — a room that silently disappears when the head changes the time reads as a bug.

The new `bookings.getFacilityAvailability` is advisory, like `getFacilitiesForBooking`: `openSlots` re-checks under `withFacilityLock` and stays the only thing that can refuse. The lookup is debounced 400 ms and annotations only render when the answer matches the window on screen, so a mid-type state says "checking", never a stale "free".

## Deploying

`CcaInterviewSlot` gains `facilityID` and `bookingID`. **`prisma generate` only — no `db push`.** There's deliberately no index on `bookingID` (the release check is covered by the `ccaID` prefix), because a push silently drops the non-schema indexes this database relies on (`email_unique_ci`).

`resolveFacility` moves to `services/booking.ts`, so the events flow and the interview flow share one definition of what a missing facility means.

## Testing

`tsc --noEmit`, `eslint` on the touched files, and `next build` are clean. **Not yet exercised against real data** — the room-clash path wants one manual run with a deliberately double-booked room before this is relied on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FhWkvPHeuZ617V3HTmPbF
