### PR TITLE
Trim the member Excel export to contact details

### DIFF
--- a/src/app/_components/RosterPanel.tsx
+++ b/src/app/_components/RosterPanel.tsx
@@ -117,9 +117,6 @@ export default function RosterPanel({
       "Matric",
       "Block",
       "Telegram",
-      "Bio",
-      "Membership records",
-      "Notes",
     ];
     const rows = dir.entries.map((e) => [
       e.name ?? (e.resolved ? "" : "Unmatched record"),
@@ -129,9 +126,6 @@ export default function RosterPanel({
       e.matric ?? "",
       e.block != null ? String(e.block) : "",
       e.telegramHandle ? `@${e.telegramHandle}` : "",
-      e.bio ?? "",
-      String(e.membershipRecords),
-      e.note ?? "",
     ]);
     const slug =
       (dir.cca.ccaName ?? `cca-${ccaID}`)
@@ -248,7 +242,7 @@ export default function RosterPanel({
               !!directory.error ||
               (directory.data?.entries.length ?? 0) === 0
             }
-            title="Download every member and their details as an Excel file"
+            title="Download every member's contact details as an Excel file"
           >
             <Download className="mr-2 h-4 w-4" />
             Export to Excel


### PR DESCRIPTION
## What

The CCA member list's **Export to Excel** dropped three columns:

- **Bio**
- **Membership records**
- **Notes**

The exported sheet is now: Name, Email, Role, User ID, Matric, Block, Telegram.

## Why

Bio and Notes are free text meant for the head's own screen, and Membership records is an internal drift counter — none of the three are useful in a spreadsheet that gets forwarded around, and Notes in particular is the head's private commentary on a member.

## What is unchanged

All three fields still render on the expandable member detail rows (`RosterTable.tsx:167-190`) — this only narrows the spreadsheet, not the UI. The `cca.memberDirectory` query is untouched and still returns them, because the detail rows need them.

The export button's tooltip changed from "every member and their details" to "every member's contact details," so the copy matches what the file now contains.

## Testing

`npx tsc --noEmit` passes. The change is confined to the column list and row mapping in `exportExcel()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZae4G1jzbUxj3RknSJbtr