### PR TITLE
Let admins view, edit and delete user details

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -329,7 +329,20 @@ model RoleAuditLog {
   /// pending.claim | pending.revoke | booking.denied.shadow |
   /// ccaHead.grant | ccaHead.revoke | ccaHead.transfer |
   /// event.approve | event.reject | event.publish | event.cancel |
-  /// event.attendees.export
+  /// event.attendees.export |
+  /// user.detail.read | user.profile.update | user.delete
+  ///
+  /// user.detail.read / user.profile.update / user.delete are the /admin/users
+  /// detail dialog. user.detail.read is a READ — the only one in this list —
+  /// and it is recorded because userAdmin.get discloses matric, telegramHandle
+  /// and bio per target to every jcrc, which listUsers does not; without the row
+  /// a bulk harvest of the hall's PII leaves no trace at all.
+  /// NEITHER WRITE writes a role set — `user.delete` removes the whole UserRole
+  /// DOCUMENT inside the delete transaction (I-14 still holds: applyRoleChange
+  /// and writeCcaHeadString remain the only writers of UserRole.roles). The
+  /// delete's row carries rolesBefore, because it is the only surviving record
+  /// of the privilege that was destroyed — which is why this collection stays
+  /// append-only and is NOT touched by deleteUserAccountCascade.
   action           String
   rolesBefore      String[] @default([])
   rolesAfter       String[] @default([])

--- a/scripts/remediation/verify-user-admin-safety.mjs
+++ b/scripts/remediation/verify-user-admin-safety.mjs
@@ -1,0 +1,405 @@
+/**
+ * Pre/post flight for the admin user-detail feature (/admin/users → Details,
+ * and the account delete behind `admin.userDelete.enabled`).
+ *
+ *   node scripts/remediation/verify-user-admin-safety.mjs
+ *   node scripts/remediation/verify-user-admin-safety.mjs --names
+ *
+ * THIS SCRIPT PERFORMS NO WRITES. There is no --commit flag, deliberately — it
+ * measures the population an IRREVERSIBLE feature will act on, and a measurement
+ * tool with a write path is a tool someone eventually runs with the wrong
+ * argument. Every database call below is findAll() / countWhere() /
+ * aggregateAll(), all of which issue `find` / `aggregate` and nothing else.
+ * `isCommit()` is consulted ONLY to refuse.
+ *
+ * Exits 1 on any RED line, matching rbac-doctor.mjs, so it can gate a rollout.
+ *
+ * RUN IT BEFORE AND AFTER any manual test of the delete path. Lines 3, 4 and 5
+ * are the invariants `deleteUserAccountCascade` exists to preserve: if a delete
+ * moves any of them off zero, the cascade dropped a collection.
+ *
+ * WHAT EACH LINE IS FOR:
+ *   1  keyMismatch accounts        the population userAdmin.delete REFUSES
+ *   1b User rows sharing one id    the SHARED_CANONICAL_ID population
+ *   2  CCAs with exactly one head  the SOLE_HEAD_OF_CCA population
+ *   3  orphaned UserRole rows      RED — the escalation residue, BUT only the
+ *                                 rows the audit log cannot explain as a grant
+ *                                 made ahead of signup (see the block at 3/4:
+ *                                 the two populations look identical and the
+ *                                 first version of this script conflated them)
+ *   4  orphaned CcaHead rows       RED — the dead-cca_head residue, same split
+ *   5  CH-1 drift                  RED — string <-> row disagreement
+ *   6  User.block BSON types       informational; the WARN-only validator
+ */
+import { PrismaClient } from "@prisma/client";
+import { canonicalUserID, isCanonicalResidentID } from "./lib/identity.mjs";
+import { findAll, numify, aggregateAll, isCommit, abort } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const ALL_NAMES = process.argv.includes("--names");
+
+const red = [];
+const W = 46;
+
+/** One report line. `bad` non-empty makes it RED and records the offenders. */
+function line(label, value, { bad = null, note = "", info = false } = {}) {
+  const isRed = Array.isArray(bad) ? bad.length > 0 : !!bad;
+  const tag = isRed ? "  <- RED" : info ? "  [informational]" : "";
+  console.log(
+    `${label.padEnd(W, ".")} ${String(value).padStart(5)}${tag}${note ? `  ${note}` : ""}`,
+  );
+  if (isRed) {
+    const list = Array.isArray(bad) ? bad : [];
+    red.push({ label, value, offenders: list });
+    if (list.length) {
+      const shown = ALL_NAMES ? list : list.slice(0, 20);
+      console.error(
+        `      ${shown.join(", ")}${!ALL_NAMES && list.length > 20 ? `  … (+${list.length - 20} more; --names for all)` : ""}`,
+      );
+    }
+  }
+}
+
+const sample = (list) =>
+  (ALL_NAMES ? list : list.slice(0, 20)).join(", ") +
+  (!ALL_NAMES && list.length > 20
+    ? `  … (+${list.length - 20} more; --names for all)`
+    : "");
+
+async function main() {
+  // Defence in depth. Nothing below can write, but a run invoked with --commit
+  // means the operator believes they are running a migration; refuse rather than
+  // print a measurement under a banner they will misread.
+  if (isCommit()) {
+    return abort(
+      "verify-user-admin-safety.mjs is READ-ONLY and has no write path. Drop --commit / APPLY=yes.",
+    );
+  }
+
+  console.log(
+    `\n=== verify-user-admin-safety.mjs (READ-ONLY) ===  ${new Date().toISOString()}\n`,
+  );
+
+  const users = await findAll(db, "User", { _id: 1, email: 1, userID: 1 });
+  const userRole = await findAll(db, "UserRole", {
+    userID: 1,
+    roles: 1,
+    role: 1,
+  });
+  const ccaHead = await findAll(db, "CcaHead", { userID: 1, ccaID: 1 });
+
+  // The live canonical population, keyed exactly as the app keys it. Built with
+  // canonicalUserID from lib/identity.mjs — the MIRROR of src/lib/identity.ts,
+  // whose parity is gated by verify-identity-parity.mjs. Never re-implement the
+  // derivation here: a second copy is how the orphan hunt starts disagreeing
+  // with the code it is auditing.
+  const liveCanonical = new Set();
+  for (const u of users) {
+    const id = canonicalUserID(u.email);
+    if (isCanonicalResidentID(id)) liveCanonical.add(id);
+  }
+
+  line("users(total)", users.length);
+  line("users(eligible canonical identities)", liveCanonical.size);
+
+  /* ---- 1. keyMismatch: the accounts the delete REFUSES ------------------- */
+  //
+  // Exactly admin.listUsers' `keyMismatch` flag, and exactly
+  // computeDeleteRefusals' LEGACY_KEY_MISMATCH. These are the split identities
+  // the one-off scripts exist for: fix-claresta-duplicate.mjs documents an
+  // account whose stored User.userID is ANOTHER live user's canonical key.
+  // Cleaning dependents under a key that is not provably this row's is how you
+  // delete a stranger's bookings, so the feature declines them by design.
+  //
+  // Informational, NOT red: it is a pre-existing data fact, and a gate that can
+  // never reach zero gets commented out — which deletes the detector.
+  const mismatched = [];
+  for (const u of users) {
+    const stored = typeof u.userID === "string" ? u.userID : "";
+    if (!stored) continue;
+    if (stored !== canonicalUserID(u.email)) {
+      mismatched.push(`${u.email} (stored ${stored})`);
+    }
+  }
+  line("keyMismatch accounts (delete REFUSES these)", mismatched.length, {
+    info: true,
+    note: "LEGACY_KEY_MISMATCH — use a hand-audited merge script",
+  });
+  if (mismatched.length) console.log(`      ${sample(mismatched)}`);
+
+  /* ---- 1b. User rows sharing ONE canonical id --------------------------- */
+  //
+  // The population `computeDeleteRefusals` refuses with SHARED_CANONICAL_ID.
+  // LEGACY_KEY_MISMATCH above proves a row's canonical key is COMPLETE; this
+  // one is about the other half — whether it is EXCLUSIVE. The cascade removes
+  // ONE User document by _id but cleans thirteen collections by
+  // `{ userID: cid }`, so if two rows resolve to one id, deleting either takes
+  // the OTHER account's roles, headships, matric and bookings while its User row
+  // survives, stripped. `email_unique_ci` does not prevent it: that collation
+  // folds CASE, not WHITESPACE, and canonicalUserID trims — merge-by-canonical.mjs
+  // exists for exactly these sets.
+  //
+  // Informational, NOT red, on the same reasoning as line 1: it is a pre-existing
+  // data fact the feature declines rather than a residue the feature created. It
+  // is printed BEFORE the delete is armed so the operator knows the size of the
+  // population that will refuse.
+  //
+  // IT IS NOT ONLY THE DELETE THAT REFUSES. `userAdmin.updateProfile` refuses
+  // the CANONICAL-keyed half of a save on these rows too — the UserMatric write
+  // and the ProfileCompletion clearing — because those land on the shared id
+  // while displayName/block/telegramHandle/bio land on the `_id` that was
+  // clicked, i.e. one save reaching two different humans. So this count is also
+  // the number of accounts whose matric field the detail dialog will show
+  // read-only.
+  const byCanonical = new Map();
+  for (const u of users) {
+    const id = canonicalUserID(u.email);
+    if (!isCanonicalResidentID(id)) continue;
+    if (!byCanonical.has(id)) byCanonical.set(id, []);
+    byCanonical.get(id).push(u.email);
+  }
+  const shared = [...byCanonical]
+    .filter(([, emails]) => emails.length > 1)
+    .map(
+      ([id, emails]) =>
+        `${id} (${emails.map((e) => JSON.stringify(e)).join(" | ")})`,
+    );
+  line("User rows sharing one canonical id", shared.length, {
+    info: true,
+    note: "SHARED_CANONICAL_ID — merge with merge-by-canonical.mjs first",
+  });
+  if (shared.length) console.log(`      ${sample(shared)}`);
+
+  /* ---- 2. CCAs with exactly one head ------------------------------------ */
+  //
+  // The SOLE_HEAD_OF_CCA population. setCcaHeads: "a headless CCA is the
+  // unrecoverable state", so deleting any of these people is refused until the
+  // CCA is handed over with admin.transferCcaHead. Informational — a
+  // single-headed CCA is normal, it just constrains who may be deleted.
+  const headsByCca = new Map();
+  for (const h of ccaHead) {
+    const id = numify(h.ccaID);
+    headsByCca.set(id, (headsByCca.get(id) ?? 0) + 1);
+  }
+  const soleHeaded = [...headsByCca]
+    .filter(([, n]) => n === 1)
+    .map(([id]) => String(id));
+  line("CCAs with exactly one head", soleHeaded.length, {
+    info: true,
+    note: "SOLE_HEAD_OF_CCA — transfer before deleting that head",
+  });
+  if (soleHeaded.length) console.log(`      ccaIDs ${sample(soleHeaded)}`);
+
+  /* ---- 3/4. ORPHANS — AND THE TWO VERY DIFFERENT THINGS THAT PRODUCE THEM */
+  //
+  // An "orphan" is a privilege row keyed on an id no live User canonicalises to.
+  // The first version of this script called EVERY one of them residue and told
+  // the operator to resolve them before arming the delete. Measured against
+  // production on 2026-08-04 that was WRONG, and wrong in the expensive
+  // direction: all 16 orphans were legitimate, and following the instruction
+  // would have destroyed eight real CCA-head appointments.
+  //
+  // TWO POPULATIONS, IDENTICAL IN SHAPE, OPPOSITE IN MEANING:
+  //
+  //   (a) A GRANT MADE AHEAD OF SIGNUP. admin.grantCcaHead writes CcaHead +
+  //       UserRole keyed on the canonical id whether or not that person has ever
+  //       signed in — the same trust boundary PendingRoleGrant documents
+  //       ("whoever first controls that NUS address gets this grant"). Until
+  //       they sign up there is no User row, so the rows look exactly like
+  //       residue. E1512588 sat in this state from 2026-07-19 to 2026-08-04.
+  //       INTENDED. Not red. Deleting it revokes a real appointment.
+  //
+  //   (b) RESIDUE A DELETE LEFT BEHIND. The thing this feature exists to never
+  //       create: a role row inherited by whoever next signs in on that address
+  //       (05-verification.md §613), or a CcaHead row keeping a dead `cca_head`
+  //       string alive that revokeCcaHead's `remaining === 0` can never clear
+  //       (cascade.ts GUARD 2). RED.
+  //
+  // THE DISCRIMINATOR IS THE AUDIT LOG, and it is only sound because every
+  // privileged mutation writes one. An id with a `user.delete` row whose
+  // privilege rows are STILL PRESENT is a cascade that did not finish — that is
+  // the failure this script is the detector for, and it stays RED. An id with a
+  // grant and no delete is case (a). An id with NEITHER is unexplained: it
+  // predates the audit log or came from a hand-run script, and it stays RED
+  // because "I cannot account for this privilege row" is not a green condition.
+  //
+  // A caveat the reader must keep: this classifies by INTENT, not by safety.
+  // Case (a) is still an unclaimed credential sitting on an address, and it is
+  // still how the duplicate-account trap is baited — the grantee signs up on
+  // their alias, sees none of it, and registers a second account on the E-number
+  // to claim it (that is exactly how CHUAMINGYUAN / E1512588 happened). It is
+  // reported, loudly, as its own line. It just is not a reason to refuse to arm
+  // a delete feature that had nothing to do with creating it.
+  const auditRows = await findAll(db, "RoleAuditLog", {
+    targetUserID: 1,
+    action: 1,
+  });
+  const deletedIds = new Set();
+  const grantedIds = new Set();
+  for (const a of auditRows) {
+    const id = String(a.targetUserID ?? "");
+    if (!id) continue;
+    const action = String(a.action ?? "");
+    if (action === "user.delete") deletedIds.add(id);
+    // Any action that CONFERS privilege on an id. `revoke` is deliberately
+    // absent: a revoke leaves nothing to be orphaned.
+    else if (
+      action === "ccaHead.grant" ||
+      action === "ccaHead.transfer" ||
+      action === "grant" ||
+      action === "set" ||
+      action === "pending.create" ||
+      action === "pending.claim"
+    )
+      grantedIds.add(id);
+  }
+
+  /** (a) intended-and-waiting, (b) residue, or unexplained. */
+  function classify(id) {
+    if (deletedIds.has(id)) return "residue";
+    if (grantedIds.has(id)) return "awaiting-signup";
+    return "unexplained";
+  }
+
+  const orphanRoleIds = userRole
+    .map((r) => String(r.userID ?? ""))
+    .filter((id) => id && !liveCanonical.has(id));
+  const orphanHeadRows = ccaHead
+    .filter((h) => {
+      const id = String(h.userID ?? "");
+      return id && !liveCanonical.has(id);
+    })
+    .map((h) => ({ id: String(h.userID), label: `${h.userID}@cca${numify(h.ccaID)}` }));
+
+  const roleResidue = orphanRoleIds.filter((id) => classify(id) !== "awaiting-signup");
+  const roleWaiting = orphanRoleIds.filter((id) => classify(id) === "awaiting-signup");
+  const headResidue = orphanHeadRows.filter((h) => classify(h.id) !== "awaiting-signup");
+  const headWaiting = orphanHeadRows.filter((h) => classify(h.id) === "awaiting-signup");
+
+  line("orphaned UserRole rows (RESIDUE)", roleResidue.length, {
+    bad: roleResidue,
+    note: "inherited by the next signup on that address (05 §613)",
+  });
+  if (roleResidue.length) {
+    const unexplained = roleResidue.filter((id) => classify(id) === "unexplained");
+    const deleted = roleResidue.filter((id) => classify(id) === "residue");
+    if (deleted.length)
+      console.log(`      after a user.delete (cascade did not finish): ${sample(deleted)}`);
+    if (unexplained.length)
+      console.log(`      no audit history at all (pre-audit or hand-run): ${sample(unexplained)}`);
+  }
+
+  line("orphaned CcaHead rows (RESIDUE)", headResidue.length, {
+    bad: headResidue.map((h) => h.label),
+    note: "revokeCcaHead's remaining===0 can never fire (GUARD 2)",
+  });
+
+  // Not red — but the duplicate-account trap, so it is never silent.
+  line("grants awaiting first signup (UserRole)", roleWaiting.length, {
+    info: true,
+    note: "INTENDED — do NOT clear; see the duplicate-account note below",
+  });
+  if (roleWaiting.length) console.log(`      ${sample(roleWaiting)}`);
+  line("grants awaiting first signup (CcaHead)", headWaiting.length, {
+    info: true,
+    note: "INTENDED — these are appointments, not residue",
+  });
+  if (headWaiting.length) console.log(`      ${sample(headWaiting.map((h) => h.label))}`);
+  if (roleWaiting.length || headWaiting.length) {
+    console.log(
+      `      NOTE: each of these people is set up to create a DUPLICATE ACCOUNT.\n` +
+        `      The grant is keyed to their E-number; if they sign up with their NUS\n` +
+        `      alias address they get none of it and register a second account to\n` +
+        `      claim it. That is exactly how CHUAMINGYUAN / E1512588 happened.`,
+    );
+  }
+
+  /* ---- 5. CH-1 drift — RED ---------------------------------------------- */
+  //
+  // CH-1: a user holds the `cca_head` string IFF they have >= 1 CcaHead row.
+  // Checked in BOTH directions, because the delete removes the string (via the
+  // whole UserRole document) and the rows in ONE transaction — if either side
+  // survives alone, the cascade dropped a collection.
+  const headRowUsers = new Set(
+    ccaHead.map((h) => String(h.userID ?? "")).filter(Boolean),
+  );
+  const stringHolders = new Set(
+    userRole
+      .filter((r) => {
+        const stored = r.roles?.length ? r.roles : r.role ? [r.role] : [];
+        return stored.includes("cca_head");
+      })
+      .map((r) => String(r.userID ?? ""))
+      .filter(Boolean),
+  );
+  const stringNoRow = [...stringHolders].filter((id) => !headRowUsers.has(id));
+  const rowNoString = [...headRowUsers].filter((id) => !stringHolders.has(id));
+  line("CH-1 drift: cca_head string, NO CcaHead row", stringNoRow.length, {
+    bad: stringNoRow,
+  });
+  line("CH-1 drift: CcaHead row, NO cca_head string", rowNoString.length, {
+    bad: rowNoString,
+  });
+
+  /* ---- 6. User.block BSON type distribution ----------------------------- */
+  //
+  // The `User` collection's validator declares `block` as bsonType "int",
+  // minimum 1, maximum 8 — with validationAction "warn". A NON-CONFORMING WRITE
+  // IS ACCEPTED SILENTLY and only logged; there is no safety net at the
+  // database, which is why the admin edit writes block through Prisma's Int
+  // mapping in exactly the shape user.updateUserData and the register route
+  // already use.
+  //
+  // If this reports anything other than int / missing, those writers are ALREADY
+  // producing it and the admin edit changes nothing — but the house should know.
+  // Counter-evidence worth remembering: services/ccaMembers.ts observed Prisma's
+  // Mongo connector sending an Int as a 64-bit long, rejected by UserCCA's int32
+  // validator with code 121. Matching the existing writer, rather than reasoning
+  // about what Prisma "should" send, is the safe move.
+  const blockTypes = await aggregateAll(db, "User", [
+    { $group: { _id: { $type: "$block" }, n: { $sum: 1 } } },
+    { $sort: { n: -1 } },
+  ]);
+  if (!blockTypes.ok) {
+    line("User.block BSON type distribution", "ERR", {
+      info: true,
+      note: blockTypes.errmsg,
+    });
+  } else {
+    const parts = blockTypes.rows.map((r) => `${String(r._id)}:${numify(r.n)}`);
+    line("User.block BSON type distribution", blockTypes.rows.length, {
+      info: true,
+      note: parts.join("  ") || "(no rows)",
+    });
+  }
+
+  /* ---- verdict ---------------------------------------------------------- */
+  console.log(`\n================================`);
+  if (red.length) {
+    console.error(`RED LINES: ${red.length}`);
+    for (const r of red)
+      console.error(`  RED  ${r.label.replace(/\.+$/, "")} = ${r.value}`);
+    console.error(
+      `\nThese are privilege residues the audit log CANNOT explain as a grant\n` +
+        `made ahead of signup. Resolve them BEFORE arming\n` +
+        `admin.userDelete.enabled — a delete run over an already-drifted\n` +
+        `population cannot be told apart from a delete that caused the drift.\n` +
+        `\n` +
+        `Do NOT clear the "awaiting first signup" lines above to get here: those\n` +
+        `are live appointments whose holder has not signed in yet.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `All gating lines green. This script wrote nothing.\n` +
+      `Re-run it after any manual delete: lines 3-5 must still be zero.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/_components/MatricGate.tsx
+++ b/src/app/_components/MatricGate.tsx
@@ -22,7 +22,19 @@ function isAllowed(pathname: string) {
 
 /**
  * Client-side login gate. Mounted once in the root layout (inside the session
- * provider so `useSession` works). Two distinct states, checked in this order:
+ * provider so `useSession` works). Distinct states, checked in this order:
+ *
+ *  0. NO ACCOUNT ROW (`accountMissing === true`) — the `User` document this
+ *     session's JWT names is gone: the account was deleted through
+ *     `userAdmin.delete`, or this was the losing row of an account merge. It is
+ *     checked FIRST because every flag below describes fields on a row that is
+ *     not there, and the session callback sets them all to their non-blocking
+ *     values — so without this branch nothing redirected and the user got the
+ *     whole app shell with every tRPC call failing FORBIDDEN, for up to the
+ *     30-day JWT lifetime. `hasIdentity` does NOT cover it: the email still
+ *     canonicalises, so that flag is still true. Sends them to
+ *     /onboarding/ineligible, which offers the only action that resolves either
+ *     case — sign out.
  *
  *  1. NO IDENTITY (`hasIdentity === false`) — the session's email does not
  *     canonicalize to an @u.nus.edu id: a non-NUS address, or a pre-cutover JWT
@@ -91,21 +103,33 @@ export default function MatricGate({
   const router = useRouter();
 
   const authed = status === "authenticated";
+  // CHECKED BEFORE EVERYTHING ELSE, because every flag below describes a `User`
+  // row that is not there. The session callback raises this when the `_id` the
+  // JWT was minted against no longer resolves — the account was deleted, or it
+  // was the losing row of a merge — and in both cases the only action that
+  // resolves it is signing out and back in. It is NOT covered by `ineligible`
+  // below: the email still canonicalises, so `hasIdentity` is still true, and
+  // without this branch these sessions rendered the full app with every tRPC
+  // call failing and nothing to click.
+  const accountMissing = authed && session?.user?.accountMissing === true;
   // D-C. `hasIdentity`, never `eligible`: see (1) in the docstring above. This
   // branch is NOT behind `rbac.matric.enforcement` — that switch gates the
   // matric redirect below (`matricRequired`) and nothing else. An empty
   // identity is not a policy question and does not vary by mode.
-  const ineligible = authed && session?.user?.hasIdentity === false;
+  const ineligible =
+    authed && !accountMissing && session?.user?.hasIdentity === false;
   // Post-merge completion. `?? []` matters: a session cookie minted before this
   // field existed has no `profileNeedsFields` at all, and `undefined.length`
   // would throw inside the root layout — i.e. a blank app for every logged-in
   // user until their JWT rolled over. Absent means "not flagged".
   const needsProfileCompletion =
     authed &&
+    !accountMissing &&
     !ineligible &&
     (session?.user?.profileNeedsFields ?? []).length > 0;
   const needsMatric =
     authed &&
+    !accountMissing &&
     !ineligible &&
     !needsProfileCompletion &&
     session?.user?.matricRequired === true &&
@@ -119,19 +143,25 @@ export default function MatricGate({
   // never bounced /onboarding/matric -> /profile for two different prompts.
   const needsProfileDetails =
     authed &&
+    !accountMissing &&
     !ineligible &&
     !needsProfileCompletion &&
     session?.user?.profileIncomplete === true;
 
-  const redirectTo = ineligible
-    ? "/onboarding/ineligible"
-    : needsProfileCompletion
-      ? "/onboarding/complete-profile"
-      : needsProfileDetails
-        ? "/profile"
-        : needsMatric
-          ? "/onboarding/matric"
-          : null;
+  // Both terminal states land on the SAME page, which reads the flag and says
+  // the right thing (see there). One route rather than two because the action
+  // is identical — sign out — and /onboarding is already allow-listed, so a
+  // second segment would only add another way to get the exemption wrong.
+  const redirectTo =
+    accountMissing || ineligible
+      ? "/onboarding/ineligible"
+      : needsProfileCompletion
+        ? "/onboarding/complete-profile"
+        : needsProfileDetails
+          ? "/profile"
+          : needsMatric
+            ? "/onboarding/matric"
+            : null;
   // `pathname !== redirectTo` so the DESTINATION renders instead of blanking:
   // /profile is not on the allow-list (it must stay gated for a COMPLETE user
   // who is merely browsing), but the incomplete user we just sent there has to

--- a/src/app/admin/_components/users/DeleteUserDialog.tsx
+++ b/src/app/admin/_components/users/DeleteUserDialog.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState } from "react";
+
+import { api } from "~/trpc/react";
+import { Alert, AlertDescription } from "~/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Skeleton } from "~/components/ui/skeleton";
+
+import {
+  FOOTPRINT_ORDER,
+  footprintPhrase,
+  friendlyError,
+  refusalCopy,
+  soleHeadCcaID,
+} from "../../_lib/userDetail";
+
+/**
+ * The destructive confirmation for `userAdmin.delete`.
+ *
+ * An AlertDialog — the same primitive ManageRolesDialog uses for its
+ * self-demotion interstitial — and never a bare `confirm()`: this needs to show
+ * the blast radius, and a native confirm can only show a sentence.
+ *
+ * THE OPERATOR MUST SEE THE BLAST RADIUS BEFORE TYPING ANYTHING. A confirmation
+ * over an unknown quantity is theatre: "are you sure?" over 46 bookings the
+ * operator never saw is not consent, it is a reflex. Hence the preflight query,
+ * which is READ-ONLY and writes no audit row (a preview is not an attempt).
+ *
+ * REFUSALS REMOVE THE CONFIRM CONTROL ENTIRELY rather than disabling it. A
+ * disabled destructive button reads as "try harder"; an absent one plus a
+ * sentence naming the remedy reads as "do this other thing first", which is
+ * what every refusal here actually means.
+ */
+export default function DeleteUserDialog({
+  userObjectId,
+  label,
+  onClose,
+  onDeleted,
+}: {
+  userObjectId: string;
+  /** For the title only — displayName if there is one, else the email. */
+  label: string | null;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const utils = api.useUtils();
+  const [typed, setTyped] = useState("");
+
+  // The SAME query key UserDetailDialog primes, so opening this dialog costs no
+  // second round trip. `refusals` and `counts` come from the one implementation
+  // the mutation itself runs — two copies of a refusal list is how a preview
+  // starts saying yes to something the mutation refuses.
+  const impact = api.userAdmin.getDeletionImpact.useQuery(
+    { userObjectId },
+    { retry: false },
+  );
+
+  const refusals = impact.data?.refusals ?? [];
+  const needsCcaNames = refusals.some((r) => soleHeadCcaID(r) !== null);
+
+  // Fetched ONLY when a SOLE_HEAD_OF_CCA refusal needs a name. listCcas is
+  // gated on manageCcaHeads, which every holder of deleteUsers has, but firing
+  // it unconditionally would put a whole-collection read behind every delete
+  // preview for no copy.
+  const ccas = api.admin.listCcas.useQuery(undefined, {
+    enabled: needsCcaNames,
+    retry: false,
+  });
+  const ccaName = (ccaID: number): string | null =>
+    ccas.data?.find((c) => c.ccaID === ccaID)?.ccaName ?? null;
+
+  const remove = api.userAdmin.delete.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.admin.listUsers.invalidate(),
+        utils.admin.getStats.invalidate(),
+        // Head counts move when a head's account goes.
+        utils.ccaAdmin.listAll.invalidate(),
+      ]);
+      onDeleted();
+    },
+    // The dialog stays open on error. A PRECONDITION_FAILED arriving here after
+    // a clean preview is the TOCTOU case — see friendlyError.
+    //
+    // AND THE PREFLIGHT IS RE-RUN, which is the part that makes the error copy
+    // true. Without it the panel keeps rendering the refusal-free preview it
+    // fetched before the state moved: the confirm control stays mounted, the
+    // typed email still matches, and the operator clicks Delete again — writing
+    // one more `denied` RoleAuditLog row per attempt for an operation that can
+    // never now succeed, with the actual reason (a co-head revoked, the target
+    // granted admin) visible nowhere. Re-running it repopulates `refusals`,
+    // which unmounts the button and states the remedy. Deliberately on EVERY
+    // error, not only PRECONDITION_FAILED: a stale preview is never the thing
+    // to keep.
+    onError: async () => {
+      await utils.userAdmin.getDeletionImpact.invalidate({ userObjectId });
+    },
+  });
+
+  const email = impact.data?.email ?? "";
+  // COSMETIC. The server compares the typed value against the STORED email and
+  // refuses with CONFIRM_EMAIL_MISMATCH; a `confirmed: true` from the client is
+  // not evidence. This only stops the button being live before the operator has
+  // read what they are about to destroy.
+  const matches =
+    email !== "" && typed.trim().toLowerCase() === email.trim().toLowerCase();
+
+  // Treated as Record<string, number> so a collection added to the cascade
+  // later still renders (under its raw key) instead of vanishing from the blast
+  // radius — see FOOTPRINT_ORDER's note.
+  const counts: Record<string, number> = impact.data?.counts ?? {};
+  const known = new Set<string>(FOOTPRINT_ORDER);
+  const rows: [string, number][] = [
+    ...FOOTPRINT_ORDER.map((k): [string, number] => [k, counts[k] ?? 0]),
+    ...Object.entries(counts).filter(([k]) => !known.has(k)),
+  ].filter(([, n]) => n > 0);
+
+  const error = friendlyError(remove.error) ?? friendlyError(impact.error);
+
+  return (
+    <AlertDialog
+      open
+      onOpenChange={(o) => {
+        if (!o && !remove.isPending) onClose();
+      }}
+    >
+      <AlertDialogContent className="max-h-[90vh] overflow-y-auto">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this account?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {label ?? email} · this cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {impact.isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        )}
+
+        {impact.data && (
+          <div className="space-y-4 text-sm">
+            {/* ---------- 1. WHAT WILL BE DESTROYED -------------------------- */}
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                What will be destroyed
+              </h3>
+              {/* THE NO-NUSNET-ID BRANCH IS FIRST, and it is not a nicety.
+                  `rows.length === 0` is ALSO true for such an account —
+                  countUserFootprint returns all zeros WITHOUT querying when
+                  there is no canonical id, because there is no key to query on
+                  — so the empty-list copy below was asserting "nothing else is
+                  attached to it" after zero lookups. A pre-cutover account can
+                  still own rows under the key auth.ts used to derive from any
+                  address, which is why the delete now refuses on this state
+                  (ABSENT_CANONICAL_ID) instead of being offered over an empty
+                  list. The panel must state what was actually checked. */}
+              {impact.data.canonicalUserID === null ? (
+                <p className="mt-1 text-gray-600">
+                  This account has no NUSNET id, so its records can&rsquo;t be
+                  located and there is nothing to list here. Anything it owns
+                  would be left behind, unattributed — see below.
+                </p>
+              ) : rows.length === 0 ? (
+                <p className="mt-1 text-gray-600">
+                  The account itself. Nothing else is attached to it.
+                </p>
+              ) : (
+                <ul className="mt-1 space-y-0.5 text-gray-700">
+                  {rows.map(([key, n]) => (
+                    <li key={key}>{footprintPhrase(key, n)}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {/* ---------- 2. WHAT SURVIVES ---------------------------------- */}
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                What survives
+              </h3>
+              <p className="mt-1 text-gray-700">
+                The audit trail keeps a record of this deletion. Events this
+                person filed for a CCA, and interview notes they wrote about
+                other applicants, stay with the CCA.
+              </p>
+              {/* Named explicitly, because it is the one place the cascade does
+                  NOT do what "delete everything of theirs" implies — and the
+                  reason it does not is that dropping these would leave a
+                  published event holding a room that is silently free again.
+                  Counted apart from the bookings above, which really do go. */}
+              {impact.data.retainedBookings > 0 && (
+                <p className="mt-1 text-gray-700">
+                  {footprintPhrase("bookings", impact.data.retainedBookings)}{" "}
+                  {impact.data.retainedBookings === 1 ? "is" : "are"} the room
+                  reservation
+                  {impact.data.retainedBookings === 1 ? "" : "s"} behind a
+                  published event or a live interview slot. {""}
+                  {impact.data.retainedBookings === 1
+                    ? "It stays"
+                    : "They stay"}{" "}
+                  in place, handed to another head of that CCA where there is
+                  one — deleting{" "}
+                  {impact.data.retainedBookings === 1 ? "it" : "them"} would
+                  free the room without telling anyone.
+                </p>
+              )}
+            </section>
+
+            {/* ---------- 3. REFUSALS --------------------------------------- */}
+            {refusals.length > 0 && (
+              <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900">
+                <p className="font-medium">
+                  This account can&rsquo;t be deleted.
+                </p>
+                <ul className="space-y-1.5">
+                  {refusals.map((r) => (
+                    <li key={r}>{refusalCopy(r, ccaName)}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* ---------- 4. THE CONFIRMATION ------------------------------- */}
+            {refusals.length === 0 && (
+              <div className="space-y-1.5">
+                <Label htmlFor="del-confirm">
+                  Type <span className="font-mono">{email}</span> to confirm
+                </Label>
+                <Input
+                  id="del-confirm"
+                  value={typed}
+                  autoComplete="off"
+                  spellCheck={false}
+                  onChange={(e) => setTyped(e.target.value)}
+                />
+              </div>
+            )}
+
+            {!impact.data.enabled && (
+              <p className="text-gray-600">Account deletion is turned off.</p>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription className="flex items-center justify-between gap-4">
+              <span>{error}</span>
+              {/* Matches UserDetailDialog's error panel. Only for the PREFLIGHT:
+                  a failed delete must not offer a one-click retry of a
+                  destructive mutation, and its refusals have already been
+                  re-fetched by onError above. */}
+              {impact.isError && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void impact.refetch()}
+                >
+                  Retry
+                </Button>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            Cancel
+          </AlertDialogCancel>
+          {/* A plain Button, NOT AlertDialogAction: Radix dismisses the dialog
+              on Action click, which would close it while the mutation is still
+              in flight and throw away the error the operator needs to read. */}
+          {impact.data && refusals.length === 0 && (
+            <Button
+              className="bg-red-700 text-white hover:bg-red-800"
+              disabled={!impact.data.enabled || !matches || remove.isPending}
+              onClick={() =>
+                remove.mutate({
+                  userObjectId,
+                  // Sent as typed; the server compares it to the stored address.
+                  confirmEmail: typed.trim(),
+                })
+              }
+            >
+              {remove.isPending ? "Deleting…" : "Delete account"}
+            </Button>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/admin/_components/users/UserDetailDialog.tsx
+++ b/src/app/admin/_components/users/UserDetailDialog.tsx
@@ -1,0 +1,972 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Lock, Trash2 } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import type { RouterOutputs } from "~/trpc/react";
+import { Alert, AlertDescription } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Textarea } from "~/components/ui/textarea";
+import {
+  BIO_MAX,
+  BLOCKS,
+  DISPLAY_NAME_MAX,
+  sanitizeName,
+} from "~/lib/schemas/profile";
+// The field VALIDATORS are not needed here any more: since the form sends only
+// what changed, `adminProfileFormSchema` (the mirror of the server's) is the one
+// place a submitted value is judged. `sanitizeName` stays because the dirty
+// check must compare the value as it would be STORED, not as it was typed.
+// `PROFILE_FIELD_LABEL` is deliberately NOT imported: it is the resident's own
+// second-person copy and every field name on this surface goes through
+// OPERATOR_FIELD_LABEL instead. Leaving it out of the import list is what keeps
+// the two voices from being mixed again by autocomplete.
+import {
+  REQUIRED_PROFILE_FIELDS,
+  type ProfileField,
+} from "~/lib/profileCompleteness";
+
+import { useCapabilities } from "../AdminCapabilityContext";
+import RoleBadge, { KeyMismatchIcon, NoAccessBadge } from "../RoleBadge";
+import {
+  adminProfileFormSchema,
+  fieldErrorsFrom,
+  friendlyError,
+  isRetryable,
+} from "../../_lib/userDetail";
+import type { AdminUserRow } from "../../_lib/types";
+import DeleteUserDialog from "./DeleteUserDialog";
+
+/**
+ * READ + EDIT one account's profile details. The host surface for admin CRUD
+ * over USER DETAILS, opened from a row of the users table.
+ *
+ * A DIALOG, not an /admin/users/[id] route segment, deliberately: AdminShell's
+ * rule is that every segment whose capability is narrower than reachDashboard
+ * must ship its own layout.tsx doing a live role read. A dialog inherits
+ * /admin/users' guard, its search and its pagination for free, and
+ * ManageRolesDialog is the immediate sibling precedent for "act on one row".
+ *
+ * WHAT THIS SURFACE CANNOT DO, and why each is absent rather than disabled:
+ *   - EMAIL. Read-only, with the reason stated to the operator in the panel
+ *     below. Identity is derived from the localpart (canonicalUserID), so an
+ *     edit re-keys the human's whole account; the router carries no email key
+ *     in any input schema, so there is structurally nothing to change it with.
+ *   - ROLES. Read-only badges plus a link to Manage roles. A second role UI is
+ *     how a second role WRITER gets requested, and I-14 reserves `cca_head`
+ *     for the CCA path.
+ *   - CREATE. Signup and PendingRoleGrant own onboarding.
+ *
+ * Every conditional render reads a named boolean off useCapabilities(). No
+ * component under src/app/admin/ may branch on a role string — that is
+ * AdminCapabilityContext's stated rule, and the gate is a grep.
+ */
+
+type UserDetail = RouterOutputs["userAdmin"]["get"];
+
+/**
+ * Gate-field names as an OPERATOR reads them.
+ *
+ * NOT `PROFILE_FIELD_LABEL`, which is second-person copy for the resident's own
+ * completion dialog ("your block", "your matriculation number") and reads as
+ * nonsense on a form about somebody else. That map cannot be re-worded to suit
+ * this surface either — it is what the gated resident is shown — so the two
+ * voices are kept apart. The KEYS are `ProfileField`, so a field added to the
+ * gate vocabulary is a type error here rather than a missing label.
+ */
+const OPERATOR_FIELD_LABEL: Record<ProfileField, string> = {
+  displayName: "display name",
+  telegramHandle: "Telegram handle",
+  block: "block",
+  matric: "matriculation number",
+};
+
+export default function UserDetailDialog({
+  target,
+  onClose,
+  onManageRoles,
+}: {
+  target: AdminUserRow;
+  onClose: () => void;
+  /**
+   * Hand the row back to the table so IT can swap this dialog for
+   * ManageRolesDialog. Roles are not editable here (see the header), and
+   * nesting the two dialogs would give the same row two owners of "which
+   * dialog is open".
+   */
+  onManageRoles?: () => void;
+}) {
+  // The authoritative record, NOT the table row: the list projection carries no
+  // matric, telegramHandle or bio, and its `roles` are redacted for a viewer
+  // without seeAdminIdentities (D-2). Reading it here is also what applies the
+  // G3 target guard — `userAdmin.get` calls assertMayManageUserProfileOf, so a
+  // jcrc opening an admin's row gets FORBIDDEN, audited, and this dialog renders
+  // the error panel instead of the form.
+  const detail = api.userAdmin.get.useQuery(
+    { userObjectId: target.id },
+    { retry: false },
+  );
+
+  // Lifted out of DetailBody because the Dialog that must refuse to close lives
+  // here. See the guard below for why it exists at all.
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <Dialog
+      open
+      // GUARDED, exactly as DeleteUserDialog guards its own: Escape and an
+      // outside click reach this handler while the Close button is disabled, so
+      // an unguarded version discards an in-flight save's RESULT — and if that
+      // save then fails (a matric CONFLICT, CANNOT_MODIFY_AN_ADMIN after a
+      // concurrent promotion), nothing is shown anywhere and the operator
+      // reasonably believes the edit landed.
+      onOpenChange={(o) => {
+        if (!o && !saving) onClose();
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>User details</DialogTitle>
+          <DialogDescription>
+            {target.displayName ?? target.email ?? target.canonicalUserID}
+          </DialogDescription>
+        </DialogHeader>
+
+        {detail.isLoading && (
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-9 w-full" />
+            ))}
+          </div>
+        )}
+
+        {detail.isError && (
+          <Alert variant="destructive">
+            <AlertDescription className="flex items-center justify-between gap-4">
+              <span>{friendlyError(detail.error)}</span>
+              {/* RETRY ONLY WHERE A RETRY CAN CHANGE THE ANSWER. `userAdmin.get`
+                  runs the G3 target guard, which AUDITS its denials, so an
+                  unconditional Retry against a FORBIDDEN writes one more
+                  `denied` RoleAuditLog row per click for an operation that can
+                  never succeed — the audit-noise pattern DeleteUserDialog's
+                  onError block calls out. See isRetryable for the code list and
+                  why each is a property of the request rather than the moment. */}
+              {isRetryable(detail.error) && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void detail.refetch()}
+                >
+                  Retry
+                </Button>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {detail.data && (
+          // Keyed on the record so the form's initial state is re-seeded if the
+          // dialog is ever pointed at a different account without unmounting.
+          <DetailBody
+            key={detail.data.userObjectId}
+            record={detail.data}
+            onClose={onClose}
+            onManageRoles={onManageRoles}
+            onSavingChange={setSaving}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ========================================================================== */
+/* The loaded body                                                            */
+/* ========================================================================== */
+
+function DetailBody({
+  record,
+  onClose,
+  onManageRoles,
+  onSavingChange,
+}: {
+  record: UserDetail;
+  onClose: () => void;
+  onManageRoles?: () => void;
+  /** Reported upward so the Dialog can refuse to close mid-save. */
+  onSavingChange: (saving: boolean) => void;
+}) {
+  const cap = useCapabilities();
+  const utils = api.useUtils();
+
+  /* ---- THE BASELINE, AND WHY IT IS STATE RATHER THAN `record` ---------------
+   * `record` IS LIVE DATA. It is `detail.data` from a React Query hook whose
+   * only staleness control is `staleTime: 30s` (src/trpc/query-client.ts), so
+   * `refetchOnWindowFocus` — on by default — replaces it whenever the operator
+   * alt-tabs back to a dialog that has been open for half a minute, and the
+   * post-save `invalidate` replaces it again. The DetailBody `key` is the
+   * userObjectId, which does not change, so none of that remounts this component
+   * and none of it touches the form state below.
+   *
+   * THE DIRTY CHECK IN `submit` MUST COMPARE AGAINST WHAT THE FORM WAS SEEDED
+   * FROM, NOT AGAINST WHATEVER THE QUERY HOLDS NOW. Reading it off `record` put
+   * the silent revert back exactly where "send only what changed" removed it,
+   * one refetch later: 10:00 the dialog seeds telegramHandle "old"; 10:05 the
+   * resident fixes their own handle to "new"; 10:08 the operator alt-tabs back
+   * and the focus refetch makes `record.telegramHandle` "new" while the input
+   * still shows "old"; 10:10 they change the Block and save — "old" now DIFFERS
+   * from the stored value, so it is sent as a change, and the resident's newer
+   * handle is overwritten by a value nobody typed. Same for displayName, bio,
+   * block and matric.
+   *
+   * So: FROZEN at mount, and moved forward only by a save that landed (see
+   * `update.onSuccess`, which re-seeds it from what the server actually
+   * persisted). `record` stays live for everything that DISPLAYS — the gap
+   * panels, the shared-id warning, the roles — because those must reflect the
+   * refetch; it is only the comparison that is pinned.
+   */
+  const [baseline, setBaseline] = useState(record);
+
+  // Seeded ONCE from the record. Deliberately not re-synced to it on refetch:
+  // after a save the record changes underneath, and overwriting the operator's
+  // typed values with a background refetch is how an edit silently reverts.
+  const [displayName, setDisplayName] = useState(record.displayName ?? "");
+  const [telegramHandle, setTelegramHandle] = useState(
+    record.telegramHandle ?? "",
+  );
+  const [bio, setBio] = useState(record.bio ?? "");
+  // "" is the UNSET state and is distinct from an invalid block. The select is
+  // never defaulted to a real block for a user who never chose one — the same
+  // note src/lib/schemas/profile.ts records about `user?.block ?? 8`, which let
+  // Block 8 be saved by accident.
+  const [block, setBlock] = useState<number | "">(record.block ?? "");
+  const [matric, setMatric] = useState(record.matric ?? "");
+  const [reason, setReason] = useState("");
+
+  /**
+   * WALL 2's tick boxes — which post-merge entries this operator is prepared to
+   * say are correct. See the orange panel below, and WALL 2 in
+   * routers/userAdmin.ts for why the server will not infer this from the fact
+   * that a save happened.
+   */
+  const [confirmed, setConfirmed] = useState<ProfileField[]>([]);
+
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  /**
+   * The delete preflight, fetched HERE so the Danger zone button can reflect
+   * the kill switch without a click that appears to do nothing. Same query key
+   * DeleteUserDialog uses, so opening that dialog costs no second round trip —
+   * React Query serves it from this cache.
+   *
+   * Gated on the capability, not merely hidden: `getDeletionImpact` is
+   * admin-only server-side, so firing it as a jcrc would produce a FORBIDDEN
+   * and an error state on a panel that is not even rendered for them.
+   */
+  const impact = api.userAdmin.getDeletionImpact.useQuery(
+    { userObjectId: record.userObjectId },
+    { enabled: cap.deleteUsers, retry: false },
+  );
+
+  const update = api.userAdmin.updateProfile.useMutation({
+    onSuccess: async (result, variables) => {
+      setFormError(null);
+      setFieldErrors({});
+      setSaved(true);
+      /* THE BASELINE MOVES ONLY HERE, only to values that were PERSISTED, and
+       * ONLY FOR THE FIELDS THIS SAVE ACTUALLY SUBMITTED. Without this the first
+       * save's own fields stay "changed" forever and every subsequent save
+       * re-sends them.
+       *
+       * THE PER-FIELD CONDITION IS THE WHOLE GUARANTEE, not tidiness, and
+       * advancing all four unconditionally re-opened the exact silent revert the
+       * baseline exists to close — one save later instead of one refetch later.
+       * `result` is the POST-WRITE ROW, not an echo of the payload: the server's
+       * `select` returns displayName / telegramHandle / bio / block whatever was
+       * submitted, so an unsubmitted field comes back holding the CURRENT stored
+       * value, including a newer edit the resident made themselves. The form
+       * inputs are seeded once and deliberately never re-synced (see the state
+       * below), so writing that value into `baseline` alone makes input and
+       * baseline DISAGREE — and the next save reads the disagreement as "the
+       * operator changed this" and writes the dialog's stale 10:00 value over
+       * the resident's 10:02 one. It is reachable from a completely no-op first
+       * save: open the dialog, click Save, tick nothing.
+       *
+       * So a field that was not sent keeps its ORIGINAL baseline, which still
+       * matches the untouched input. The live `record` is what displays the
+       * newer stored value (the invalidate below refetches it); the comparison
+       * stays pinned to what the form was seeded from.
+       *
+       * `matricWritten` is null when no matric was submitted, which is NOT the
+       * statement "this account has no matric" — so it falls back to the previous
+       * baseline rather than blanking it. Same trap the server's return comment
+       * names, and the shape the four fields above now follow.
+       */
+      setBaseline((b) => ({
+        ...b,
+        ...(variables.displayName !== undefined
+          ? { displayName: result.displayName }
+          : {}),
+        ...(variables.telegramHandle !== undefined
+          ? { telegramHandle: result.telegramHandle }
+          : {}),
+        ...(variables.bio !== undefined ? { bio: result.bio } : {}),
+        ...(variables.block !== undefined ? { block: result.block } : {}),
+        matric: result.matricWritten ?? b.matric,
+      }));
+      // The tick boxes are an answer to the prompt as it stood; the invalidate
+      // below re-reads what is left of it. Carrying them into the next save
+      // would confirm entries the operator has not seen since.
+      setConfirmed([]);
+      // The dialog STAYS OPEN on success, unlike ManageRolesDialog. The common
+      // reason to be here is clearing a profile gap, and the gap panel below is
+      // rendered from `record` — so the invalidate turns the amber note green
+      // in place. That IS the confirmation; closing would hide it.
+      await Promise.all([
+        utils.userAdmin.get.invalidate({ userObjectId: record.userObjectId }),
+        // displayName and block are columns in the users table.
+        utils.admin.listUsers.invalidate(),
+      ]);
+    },
+    // Inline, and the dialog stays open: the operator's entries are the input
+    // to their next attempt.
+    onError: (e) => {
+      setSaved(false);
+      setFormError(friendlyError(e));
+    },
+  });
+
+  // The Dialog above owns "may this close"; the mutation state lives here.
+  useEffect(() => {
+    onSavingChange(update.isPending);
+  }, [update.isPending, onSavingChange]);
+
+  const submit = () => {
+    setFormError(null);
+    setSaved(false);
+
+    /* ---- ONLY WHAT THE OPERATOR ACTUALLY CHANGED IS SENT -------------------
+     * `undefined` means "leave the stored value alone" on both this schema and
+     * the server's, and EVERY field is omitted unless the typed value differs
+     * from the one this dialog loaded. Two properties fall out of that:
+     *
+     *   - clearing or WORSENING a field is impossible: a changed value is
+     *     validated strictly (no "" on any gate field) and rejected otherwise;
+     *   - a gap the operator cannot close does not block the ones they can, so
+     *     a JCRC who knows a resident's block but not their Telegram handle can
+     *     record the block. AN ADMIN EDIT MAY CLOSE A PROFILE GAP; IT MAY NEVER
+     *     OPEN ONE — and leaving an already-open one exactly as it was does not
+     *     open anything.
+     *
+     * IT USED TO SEND UNCHANGED-BUT-VALID VALUES TOO, and that was a silent
+     * revert. The form is seeded ONCE when the dialog opens (see the state
+     * above) and never re-synced, so a resident who fixes their own Telegram
+     * handle at 10:05 had it overwritten with the 10:00 value by an operator
+     * who at 10:10 changed only the Block — a field they never typed, never saw
+     * flagged as changed, and could only discover afterwards from the audit
+     * diff. The same applies between two JCRC members with the row open.
+     *
+     * EVERY COMPARISON BELOW IS AGAINST `baseline`, NEVER AGAINST `record`, and
+     * that distinction is the whole guarantee. `record` moves under an open
+     * dialog on any refetch, and comparing the 10:00 typed value against the
+     * 10:08 stored one re-creates the identical revert with the dirty check
+     * still in place — see the baseline's own note above.
+     *
+     * Sending them was load-bearing for ONE thing — a save clearing the
+     * post-merge ProfileCompletion prompt on a field whose stored value was
+     * already fine — and that is now an explicit tick box (`confirmFields`)
+     * instead, because "a save happened" is not an answer to "is this stored
+     * value this person's". Do not reintroduce the always-send to fix a
+     * completion flag; it does not clear one any more, and it would bring the
+     * revert back.
+     */
+    const nameTyped = sanitizeName(displayName);
+    const nameStored = sanitizeName(baseline.displayName ?? "");
+    const sendName = nameTyped !== nameStored ? displayName : undefined;
+
+    const tgTyped = telegramHandle.trim().replace(/^@+/, "");
+    const tgStored = (baseline.telegramHandle ?? "").trim().replace(/^@+/, "");
+    const sendTelegram = tgTyped !== tgStored ? telegramHandle : undefined;
+
+    // Compared trimmed, because the server trims before storing: re-sending a
+    // value that differs only in whitespace would write a "change" the audit
+    // diff then reports as none.
+    const sendBio = bio.trim() !== (baseline.bio ?? "").trim() ? bio : undefined;
+
+    // "" can only be reached from a record whose block was already unset: the
+    // Select has no option that returns it to unset, so there is no path from a
+    // stored block back to "". Guarded anyway, because if one is ever added
+    // this must be an error and not a silent omission.
+    if (block === "" && baseline.block != null) {
+      setFieldErrors({ block: "A block can't be cleared here." });
+      return;
+    }
+    const sendBlock =
+      block === "" || block === baseline.block ? undefined : block;
+
+    /* ---- matric: send it ONLY when it actually changed --------------------
+     * `undefined` means "leave the UserMatric row alone", and the server has no
+     * value meaning "clear it". So a blanked matric is refused HERE with copy
+     * that says why, rather than being dropped silently — dropping it would
+     * make the form look like it accepted a removal it never performed.
+     */
+    const nextMatric = matric.trim().toUpperCase();
+    const storedMatric = (baseline.matric ?? "").trim().toUpperCase();
+    const matricChanged = nextMatric !== storedMatric;
+    if (matricChanged && nextMatric === "") {
+      setFieldErrors({
+        matric:
+          "A matric can't be removed here — the profile gate requires it, and clearing it would lock this resident out. Ask a developer if the stored number is wrong.",
+      });
+      return;
+    }
+
+    // Refused HERE as well as on the server, with copy that names the remedy:
+    // the matric row is keyed on the NUSNET id, which this account shares with
+    // another, so the number shown may be the OTHER account's and writing it
+    // would overwrite theirs. The server throws SHARED_CANONICAL_ID regardless —
+    // this only keeps the operator from typing a value that cannot land.
+    if (matricChanged && record.sharedCanonicalID) {
+      setFieldErrors({
+        matric:
+          "Another account resolves to the same NUSNET id, and the matric record is filed under that shared id — saving here would overwrite the other account's number. Ask a developer to run the account merge first.",
+      });
+      return;
+    }
+
+    const parsed = adminProfileFormSchema.safeParse({
+      displayName: sendName,
+      telegramHandle: sendTelegram,
+      bio: sendBio,
+      block: sendBlock,
+      matric: matricChanged ? nextMatric : undefined,
+    });
+    if (!parsed.success) {
+      setFieldErrors(fieldErrorsFrom(parsed.error));
+      return;
+    }
+
+    setFieldErrors({});
+    // EXACTLY the keys updateSchema declares, and nothing else: it is
+    // `.strict()`, so spreading the record in here (email, userID, roles …)
+    // would 400 the whole save rather than being quietly stripped.
+    update.mutate({
+      userObjectId: record.userObjectId,
+      displayName: parsed.data.displayName,
+      telegramHandle: parsed.data.telegramHandle,
+      bio: parsed.data.bio,
+      block: parsed.data.block,
+      matric: parsed.data.matric,
+      /* WALL 2. Re-filtered against the LIVE `record` rather than sent from
+       * state alone: a refetch can retire an entry between the tick and the
+       * Save, and confirming something the panel no longer shows is a claim
+       * about a prompt this operator never read. The server intersects with the
+       * stored row again — this only keeps the payload honest.
+       *
+       * `undefined`, not `[]`, when nothing was ticked: every other key on this
+       * schema uses `undefined` for "no instruction", and an empty array on the
+       * audit-visible payload reads as an instruction that was given.
+       */
+      confirmFields: (() => {
+        const live = new Set<string>(record.profileNeedsFields);
+        const out = confirmed.filter((f) => live.has(f));
+        return out.length ? out : undefined;
+      })(),
+      reason: reason.trim() || undefined,
+    });
+  };
+
+  const gaps = record.profileGaps;
+  /** WALL 2 — the post-merge completion row. A DIFFERENT wall; see below. */
+  const needsFields = record.profileNeedsFields;
+  /**
+   * The WALL-2 entries this dialog can offer a TICK for. Two filters, and the
+   * second is not cosmetic:
+   *   - named by the gate vocabulary — a name a later deploy understands and
+   *     this one does not is preserved untouched by the server, and offering a
+   *     box for it would let an operator confirm something this build cannot
+   *     even evaluate;
+   *   - not ALSO an open gap. There is nothing to confirm about a value that is
+   *     not there, the server refuses to resolve such an entry anyway (the gap
+   *     test is the other half of its rule), and "the stored matriculation
+   *     number is correct" over an empty one reads as a way to dismiss a wall
+   *     without supplying anything. Fill it in the field above instead — that
+   *     clears both walls in one save.
+   */
+  const confirmable = needsFields.filter(
+    (f): f is ProfileField =>
+      (REQUIRED_PROFILE_FIELDS as string[]).includes(f) &&
+      !(gaps as string[]).includes(f),
+  );
+  const deleteEnabled = impact.data?.enabled ?? false;
+  // `!deleteEnabled` alone is not "the switch is off": the preflight also
+  // resolves to undefined on a network fault or a mid-session capability
+  // change, and telling the operator the kill switch is off sends them to flip
+  // a SystemFlag that may already be set.
+  const deleteOff = impact.isSuccess && !impact.data.enabled;
+
+  return (
+    <>
+      <div className="space-y-5">
+        {/* ---------- 1. IDENTITY (read-only) -------------------------------- */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2.5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="flex items-center gap-1.5 text-sm font-medium text-gray-900">
+                <Lock className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+                <span className="truncate">{record.email}</span>
+              </p>
+              <p className="mt-1 text-xs text-gray-500">
+                Email cannot be changed. This account&rsquo;s identity — its
+                bookings, roles, CCA memberships and matric — is derived from
+                the part of the address before @u.nus.edu. Editing it would
+                create a second, empty account and orphan everything attached to
+                this one. To correct an address, ask a developer to run an
+                account merge.
+              </p>
+            </div>
+          </div>
+
+          <dl className="mt-3 grid grid-cols-[auto,1fr] items-center gap-x-3 gap-y-1 text-xs">
+            <dt className="text-gray-500">NUSNET id</dt>
+            <dd className="font-mono text-xs text-gray-900">
+              {record.canonicalUserID ?? (
+                <span className="font-sans text-gray-400">
+                  none — not an @u.nus.edu address
+                </span>
+              )}
+            </dd>
+            {record.legacyUserID && (
+              <>
+                <dt className="text-gray-500">Stored id</dt>
+                <dd className="flex items-center gap-1.5 font-mono text-xs text-gray-900">
+                  {record.legacyUserID}
+                  {/* Reuses the table's marker rather than inventing a second
+                      icon for the same fact. */}
+                  {record.keyMismatch && <KeyMismatchIcon />}
+                </dd>
+              </>
+            )}
+          </dl>
+        </section>
+
+        {/* ---------- 2. ROLES (read-only) ----------------------------------- */}
+        <section>
+          <h3 className="mb-1.5 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Roles
+          </h3>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {record.roles.length === 0 ? (
+              <NoAccessBadge />
+            ) : (
+              record.roles.map((r) => <RoleBadge key={r} role={r} />)
+            )}
+          </div>
+          <p className="mt-1.5 text-xs text-gray-500">
+            Roles are managed from Manage roles.
+          </p>
+          {onManageRoles && record.canonicalUserID && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-1 px-0 text-emerald-700 hover:bg-transparent hover:text-emerald-800"
+              onClick={onManageRoles}
+            >
+              Open Manage roles
+            </Button>
+          )}
+        </section>
+
+        {/* ---------- 3. PROFILE FORM ---------------------------------------- */}
+        <section className="space-y-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Profile
+          </h3>
+
+          {/* THE RECORD IS SPLIT ACROSS TWO ACCOUNTS. Rendered ABOVE both walls
+              because it changes what the fields below MEAN: matric and the
+              post-merge row are read (and would be written) under a NUSNET id
+              this row shares with another live account, so the matric shown may
+              be the other person's. The delete dialog already refuses on this
+              state (SHARED_CANONICAL_ID) — the edit path refuses only the
+              canonical-keyed half, so the copy has to say which half is which
+              or the operator will read "can't edit" and stop. */}
+          {record.sharedCanonicalID && (
+            <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
+              Another account resolves to the same NUSNET id{" "}
+              <span className="font-mono text-xs">
+                {record.canonicalUserID}
+              </span>{" "}
+              — usually a stray space or different capitalisation in one of the
+              two email addresses. The matriculation number and the post-merge
+              prompt are filed under that shared id, so they belong to both rows
+              and cannot be edited here. Name, Telegram handle, block and bio
+              still apply to this row only. Ask a developer to run the account
+              merge (scripts/remediation/merge-by-canonical.mjs) first.
+            </div>
+          )}
+
+          {/* WALL 1 — the strict profile gate, cleared by saving a value.
+              SUPPRESSED ENTIRELY WHEN THERE IS NO NUSNET ID, because both
+              halves of its copy are false for such an account. MatricGate
+              checks `hasIdentity === false` BEFORE `profileIncomplete` and
+              hard-redirects that session to /onboarding/ineligible, so no value
+              typed here unblocks anyone; and `matric` is in `gaps` for every
+              one of these rows by construction (UserMatric is canonical-keyed,
+              so `get` skips the read and returns null), while the matric input
+              below is DISABLED for exactly this case — the one gap the panel
+              names loudest is the one this form structurally cannot fill. An
+              operator following it would type a name, a handle and a block,
+              watch part of the list clear, and conclude they had half-fixed a
+              resident whose actual problem is the email domain. */}
+          {record.canonicalUserID === null ? (
+            <div className="rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+              This account is not on an @u.nus.edu address, so it has no NUSNET
+              id. The app checks that before it looks at profile details: the
+              session is sent to the &ldquo;NUS account required&rdquo; screen
+              whatever these fields say, so filling them in here does not
+              unblock anyone. Correcting the address needs a developer.
+            </div>
+          ) : (
+            gaps.length > 0 && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                {/* OPERATOR_FIELD_LABEL, never PROFILE_FIELD_LABEL — see that
+                    map's own note. This panel is about SOMEBODY ELSE, and the
+                    resident-facing copy is second person ("your block", "your
+                    matriculation number"), which would render as "…until they
+                    supply your block" directly above tick boxes on this same
+                    screen that correctly say "The stored block is correct." */}
+                This resident is currently blocked from the app until these are
+                supplied:{" "}
+                {gaps.map((f, i) => (
+                  <span key={f}>
+                    {i > 0 && (i === gaps.length - 1 ? " and " : ", ")}
+                    {OPERATOR_FIELD_LABEL[f]}
+                  </span>
+                ))}
+                . Filling it in here clears it for them.
+              </div>
+            )
+          )}
+
+          {/* WALL 2 — the post-merge completion flag. A SEPARATE wall, checked
+              FIRST by MatricGate and routed to a DIFFERENT screen
+              (/onboarding/complete-profile), so it has to be surfaced
+              separately: an operator who sees only the amber panel above will
+              fill the form, watch it clear, and leave the resident redirected
+              on every request. That is the trap
+              scripts/remediation/unstick-profile-completion.mjs exists to
+              release people from, and it stranded 18 of them.
+
+              WHAT AN ENTRY MEANS, and why there are TICK BOXES rather than a
+              promise that saving clears it. merge-by-canonical writes a field
+              into `needsFields` when the two merged rows DISAGREED on its value:
+              a value IS stored, it is one of the two candidates, and the open
+              question is which one is this person's. So the entry is not "fill
+              this in", it is "somebody check this". Typing a new value answers
+              it; ticking the box answers it; a Save that never touched the field
+              does not, and the copy here used to say it did. The server applies
+              exactly that rule (routers/userAdmin.ts, WALL 2) — these boxes are
+              the only thing that can send the confirmation. */}
+          {needsFields.length > 0 && (
+            <div className="rounded-md border border-orange-300 bg-orange-50 px-3 py-2 text-sm text-orange-900">
+              <p>
+                A merge also left this account on the post-merge confirmation
+                screen, waiting on:{" "}
+                <span className="font-mono text-xs">
+                  {needsFields.join(", ")}
+                </span>
+                . That is a second, separate block. The merge found two different
+                values for each of those and could not tell which was theirs, so
+                a value IS stored — it may just be the wrong one.
+              </p>
+              {record.sharedCanonicalID ? (
+                // The row is keyed on the SHARED id, so it is as likely to be
+                // the other account's prompt as this one's. Clearing it from
+                // here would take down a wall pointing at a real problem — the
+                // server refuses regardless, so no tick boxes are offered.
+                <p className="mt-1.5">
+                  This save cannot clear it: that record is filed under the
+                  NUSNET id this account shares with another. Run the merge
+                  first.
+                </p>
+              ) : (
+                <>
+                  <p className="mt-1.5">
+                    {confirmable.length > 0
+                      ? "Correct the field above, or — if you have checked the stored value against something reliable and it is right — say so here. Nothing else clears it: a save that leaves a field alone leaves its prompt standing."
+                      : "Fill the field in above and this clears with it. A save that leaves a field alone leaves its prompt standing."}
+                  </p>
+                  {confirmable.length > 0 && (
+                    <div className="mt-2 space-y-1.5">
+                      {confirmable.map((f) => (
+                        <label
+                          key={f}
+                          className="flex items-start gap-2 text-sm"
+                        >
+                          <Checkbox
+                            className="mt-0.5 border-orange-400"
+                            checked={confirmed.includes(f)}
+                            onCheckedChange={(v) =>
+                              setConfirmed((prev) =>
+                                v ? [...prev, f] : prev.filter((x) => x !== f),
+                              )
+                            }
+                          />
+                          <span>
+                            The stored {OPERATOR_FIELD_LABEL[f]} is correct.
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+              <p className="mt-1.5">
+                Anything left in the list that this form does not cover needs a
+                developer.
+              </p>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-display-name">Display name</Label>
+            <Input
+              id="ud-display-name"
+              value={displayName}
+              maxLength={DISPLAY_NAME_MAX}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+            {fieldErrors.displayName && (
+              <p className="text-sm text-red-600">{fieldErrors.displayName}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-telegram">Telegram handle</Label>
+            {/* "@" is a static adornment and any typed "@" is stripped, so
+                there is exactly one canonical stored form — the same rule the
+                resident's own form and the server transform apply. */}
+            <div className="relative">
+              <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 select-none text-sm text-gray-500">
+                @
+              </span>
+              <Input
+                id="ud-telegram"
+                className="pl-7"
+                value={telegramHandle}
+                maxLength={32}
+                onChange={(e) =>
+                  setTelegramHandle(e.target.value.replace(/@/g, ""))
+                }
+              />
+            </div>
+            {fieldErrors.telegramHandle && (
+              <p className="text-sm text-red-600">
+                {fieldErrors.telegramHandle}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-block">Block</Label>
+            <Select
+              // `undefined` renders the placeholder. There is deliberately no
+              // option that returns the select to unset: block is a gate field,
+              // and an admin edit may close a gap but never open one.
+              value={block === "" ? undefined : String(block)}
+              onValueChange={(v) => setBlock(Number(v))}
+            >
+              <SelectTrigger id="ud-block">
+                <SelectValue placeholder="Not set" />
+              </SelectTrigger>
+              <SelectContent>
+                {BLOCKS.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    Block {n}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {fieldErrors.block && (
+              <p className="text-sm text-red-600">{fieldErrors.block}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-matric">Matriculation number</Label>
+            {/* Uppercased as typed, so what is shown is what is stored — the
+                server applies the same transform. */}
+            <Input
+              id="ud-matric"
+              value={matric}
+              maxLength={9}
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="A0234567X"
+              className="font-mono uppercase"
+              // UserMatric is CANONICAL-KEYED, and there are TWO ways that key
+              // can fail to be this row's alone. No key at all (a non-NUS
+              // account — the server refuses with NO_CANONICAL_IDENTITY), or a
+              // key SHARED with another live User row (the server refuses with
+              // SHARED_CANONICAL_ID, because the upsert would land on the other
+              // account's matric). Disabled WITH a reason in both cases, not
+              // silently absent — the value shown is still the stored one, and
+              // on a shared id it may not even be this person's.
+              disabled={
+                record.canonicalUserID === null || record.sharedCanonicalID
+              }
+              title={
+                record.canonicalUserID === null
+                  ? "This account isn't on an @u.nus.edu address, so it has no matric record."
+                  : record.sharedCanonicalID
+                    ? "Another account shares this NUSNET id, so this matric record belongs to both. Run the account merge first."
+                    : undefined
+              }
+              onChange={(e) => setMatric(e.target.value.toUpperCase())}
+            />
+            {fieldErrors.matric && (
+              <p className="text-sm text-red-600">{fieldErrors.matric}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-bio">
+              Bio <span className="text-gray-400">(optional)</span>
+            </Label>
+            <Textarea
+              id="ud-bio"
+              value={bio}
+              maxLength={BIO_MAX}
+              rows={3}
+              onChange={(e) => setBio(e.target.value)}
+            />
+            <p className="text-right text-xs text-gray-500">
+              {bio.length}/{BIO_MAX}
+            </p>
+            {fieldErrors.bio && (
+              <p className="text-sm text-red-600">{fieldErrors.bio}</p>
+            )}
+          </div>
+
+          <p className="text-xs text-gray-500">
+            Display name, Telegram handle, block and matric are required by the
+            profile gate. Saving a blank value would lock this resident behind
+            the completion screen, so the form will not let you. Only the bio
+            can be cleared.
+          </p>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="ud-reason">
+              Reason <span className="text-gray-400">(optional)</span>
+            </Label>
+            {/* Optional deliberately, same as ManageRolesDialog: forcing a
+                reason on every edit makes people type "x". Stored on the audit
+                row when supplied — the field-level diff is recorded either way. */}
+            <Textarea
+              id="ud-reason"
+              value={reason}
+              maxLength={500}
+              rows={2}
+              placeholder="Recorded on the audit entry."
+              onChange={(e) => setReason(e.target.value)}
+            />
+          </div>
+
+          {formError && (
+            <Alert variant="destructive">
+              <AlertDescription>{formError}</AlertDescription>
+            </Alert>
+          )}
+
+          {saved && !update.isPending && (
+            <p className="text-sm text-emerald-700">Saved.</p>
+          )}
+        </section>
+
+        {/* ---------- 4. DANGER ZONE ----------------------------------------- */}
+        {cap.deleteUsers && (
+          <section className="rounded-lg border border-red-300 bg-red-50 px-3 py-2.5">
+            <h3 className="text-sm font-semibold text-red-800">Danger zone</h3>
+            <p className="mt-1 text-xs text-red-700">
+              Deleting an account removes their bookings, posts, CCA
+              memberships, applications and role record permanently. There is no
+              undo.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-2 border-red-300 bg-white text-red-700 hover:bg-red-100 hover:text-red-800"
+              disabled={!deleteEnabled || impact.isLoading}
+              title={deleteOff ? "Account deletion is turned off." : undefined}
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              Delete account
+            </Button>
+            {deleteOff && (
+              <p className="mt-1.5 text-xs text-red-700">
+                Account deletion is turned off.
+              </p>
+            )}
+            {impact.isError && (
+              <p className="mt-1.5 text-xs text-red-700">
+                {friendlyError(impact.error)}
+              </p>
+            )}
+          </section>
+        )}
+      </div>
+
+      <DialogFooter className="mt-6">
+        <Button variant="outline" onClick={onClose} disabled={update.isPending}>
+          Close
+        </Button>
+        <Button
+          className="bg-emerald-700 text-white hover:bg-emerald-800"
+          disabled={update.isPending}
+          onClick={submit}
+        >
+          {update.isPending ? "Saving…" : "Save details"}
+        </Button>
+      </DialogFooter>
+
+      {confirmDelete && (
+        <DeleteUserDialog
+          userObjectId={record.userObjectId}
+          label={record.displayName ?? record.email}
+          onClose={() => setConfirmDelete(false)}
+          // The account is gone: this dialog is describing a row that no longer
+          // exists, so it closes too rather than sitting on a stale record.
+          onDeleted={() => {
+            setConfirmDelete(false);
+            onClose();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/admin/_components/users/UserRoleTable.tsx
+++ b/src/app/admin/_components/users/UserRoleTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
-import { Loader2, Settings2 } from "lucide-react";
+import { Loader2, Settings2, UserCog } from "lucide-react";
 
 import { api } from "~/trpc/react";
 import { Alert, AlertDescription } from "~/components/ui/alert";
@@ -35,6 +35,7 @@ import EmptyState from "../EmptyState";
 import { isMissingBaseline } from "../../_lib/anomalies";
 import type { AdminUserRow } from "../../_lib/types";
 import ManageRolesDialog from "./ManageRolesDialog";
+import UserDetailDialog from "./UserDetailDialog";
 
 export default function UserRoleTable() {
   const cap = useCapabilities();
@@ -42,6 +43,11 @@ export default function UserRoleTable() {
   const [search] = useDebounceValue(rawSearch, 300);
   const [roleFilter, setRoleFilter] = useState<string>("all");
   const [target, setTarget] = useState<AdminUserRow | null>(null);
+  // Separate state from `target`, not a mode flag on one: the two dialogs are
+  // different surfaces over the same row and one of them hands off to the other
+  // (Details → Manage roles), which a single "which dialog" enum would make a
+  // three-way transition instead of two independent booleans.
+  const [detail, setDetail] = useState<AdminUserRow | null>(null);
 
   const {
     data,
@@ -226,20 +232,77 @@ export default function UserRoleTable() {
                     </div>
                   </TableCell>
                   <TableCell className="text-right">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={!u.canonicalUserID}
-                      onClick={() => setTarget(u)}
-                      title={
-                        u.canonicalUserID
-                          ? undefined
-                          : "This account has no canonical NUSNET id, so roles cannot be keyed to it."
-                      }
-                    >
-                      <Settings2 className="mr-1.5 h-3.5 w-3.5" />
-                      Manage
-                    </Button>
+                    <div className="flex items-center justify-end gap-2">
+                      {/* `disabled` is evaluated PER BUTTON and must not be
+                          lifted to the row. Manage roles is disabled without a
+                          canonical id because roles are KEYED on it.
+
+                          Profile details are keyed on the User ObjectId, so a
+                          non-NUS account is reachable in principle — and it is
+                          one of the accounts most likely to need cleaning up.
+                          FOR AN ADMIN. It is NOT viewable by a jcrc, and the
+                          button must say so rather than lead them into a
+                          refusal: assertMayManageUserProfileOf denies every
+                          non-admin actor on a target with no canonical id
+                          (CANNOT_MODIFY_AN_UNKEYED_ACCOUNT) because such a row's
+                          authority is UNEVALUABLE — a pre-cutover UserRole
+                          holding `admin` can still be filed under a key this
+                          deploy cannot derive — and that denial applies to `get`
+                          too. An enabled button therefore led a jcrc to a hard
+                          FORBIDDEN plus a `denied` RoleAuditLog row on the
+                          highest-signal action this system records, once per
+                          click. `modifyAdmins` is the capability that matches:
+                          it is the admin-only tier for "may act on a target
+                          whose authority is admin, or cannot be shown not to
+                          be".
+
+                          `hasAccount` is a SEPARATE refusal and both are needed.
+                          On the ROLE-FILTERED branch of listUsers `id` falls
+                          back to the UserRole `_id` when no User row hydrated it
+                          (`id: u?.id ?? r.id`), which listUsers' own comment
+                          calls a LEGITIMATE state — a claimed pending grant, a
+                          hand-seeded admin. Handing that id to userAdmin.get
+                          returns NOT_FOUND, which the dialog renders as "That
+                          account no longer exists", which is false and whose
+                          suggested remedy does nothing. Disabled rather than
+                          hidden in both cases: the row is real, the profile is
+                          not reachable by this viewer. */}
+                      {cap.manageUserProfiles && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={
+                            !u.hasAccount ||
+                            (!u.canonicalUserID && !cap.modifyAdmins)
+                          }
+                          onClick={() => setDetail(u)}
+                          title={
+                            !u.hasAccount
+                              ? "This role grant has no user account behind it, so there are no profile details to show."
+                              : !u.canonicalUserID && !cap.modifyAdmins
+                                ? "This account isn't on an @u.nus.edu address, so its role record can't be read back and there's no way to check what access it holds. Only an admin can open it."
+                                : undefined
+                          }
+                        >
+                          <UserCog className="mr-1.5 h-3.5 w-3.5" />
+                          Details
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!u.canonicalUserID}
+                        onClick={() => setTarget(u)}
+                        title={
+                          u.canonicalUserID
+                            ? undefined
+                            : "This account has no canonical NUSNET id, so roles cannot be keyed to it."
+                        }
+                      >
+                        <Settings2 className="mr-1.5 h-3.5 w-3.5" />
+                        Manage
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               );
@@ -262,6 +325,20 @@ export default function UserRoleTable() {
 
       {target && (
         <ManageRolesDialog target={target} onClose={() => setTarget(null)} />
+      )}
+
+      {detail && (
+        <UserDetailDialog
+          target={detail}
+          onClose={() => setDetail(null)}
+          // The hand-off. The table owns "which dialog is open", so the swap is
+          // one state transition here rather than two dialogs each trying to
+          // mount the other.
+          onManageRoles={() => {
+            setTarget(detail);
+            setDetail(null);
+          }}
+        />
       )}
     </>
   );

--- a/src/app/admin/_lib/userDetail.ts
+++ b/src/app/admin/_lib/userDetail.ts
@@ -1,0 +1,381 @@
+import { z } from "zod";
+
+import {
+  BIO_MAX,
+  BLOCKS,
+  DISPLAY_NAME_MAX,
+  MATRIC_RE,
+  TELEGRAM_RE,
+  sanitizeName,
+} from "~/lib/schemas/profile";
+import { isDisplayNameValid } from "~/lib/profileCompleteness";
+
+/**
+ * Client-side support for the /admin/users detail dialogs (UserDetailDialog and
+ * DeleteUserDialog). Shared between the two because they surface ONE router's
+ * error vocabulary; two copies of an error map is how the delete dialog starts
+ * rendering "That didn't save" for a message the edit dialog explains properly.
+ *
+ * Deliberately NOT merged with ManageCcaDetail.tsx's own `friendlyError`: that
+ * one maps ccaAdmin's vocabulary, which shares only two strings with this one.
+ * A single map over both routers would grow entries neither surface can produce.
+ */
+
+/* ========================================================================== */
+/* The form schema — a MIRROR of updateSchema in routers/userAdmin.ts          */
+/* ========================================================================== */
+
+/**
+ * WHY THIS IS A MIRROR AND NOT AN IMPORT.
+ *
+ * `updateSchema` lives inside `src/server/api/routers/userAdmin.ts`, which is
+ * not exported and could not be value-imported into a `"use client"` file
+ * anyway — it pulls the whole router, Prisma and @trpc/server into the browser
+ * bundle. That is precisely why the field VALIDATORS live in
+ * src/lib/schemas/profile.ts: every rule below is imported from there, so the
+ * two schemas cannot drift on what a valid telegram handle or matric IS. What
+ * is restated here is only the SHAPE — which fields are required, and which one
+ * may be blank.
+ *
+ * THE SERVER IS THE AUTHORITY. This schema exists so the operator sees a field
+ * error under the field instead of a raw rejection after a round trip; it is
+ * not a control. `updateSchema` is `.strict()` and re-validates everything.
+ *
+ * STRICTER THAN `updateProfileInput` IN EXACTLY ONE DIRECTION, mirroring the
+ * server: displayName may not be empty and telegramHandle has no `""` escape
+ * hatch, because the strict profile-completion gate is ALWAYS ON. An admin who
+ * saves a blank gate field walls that resident behind the completion dialog
+ * with no way to see who did it. AN ADMIN EDIT MAY CLOSE A PROFILE GAP; IT MAY
+ * NEVER OPEN ONE. Only `bio` is clearable — bio is not a gate field.
+ *
+ * EVERY FIELD IS `.optional()`, matching the server, and that is what makes
+ * PARTIAL REPAIR possible rather than what weakens the rule. `undefined` means
+ * "leave the stored value alone"; a value that is PRESENT must satisfy its
+ * validator outright, so the only thing a gate field can be moved TO is a valid
+ * value. UserDetailDialog omits every field the operator did not change — so an
+ * operator who knows a gated resident's block but not their Telegram handle can
+ * record the block instead of being blocked by the very field they came to
+ * supply, and a save that touched one field cannot carry a stale copy of the
+ * others back over somebody else's newer edit.
+ */
+export const adminProfileFormSchema = z.object({
+  displayName: z
+    .string()
+    .min(1, "Enter a display name.")
+    .max(DISPLAY_NAME_MAX, `Keep it to ${DISPLAY_NAME_MAX} characters or fewer`)
+    .transform(sanitizeName)
+    // The same rule the resident's own save applies on EVERY submit, asserted
+    // AFTER sanitizeName so a name made entirely of zero-width characters is
+    // caught here rather than saved as "". Message is byte-identical to the
+    // server's (routers/userAdmin.ts) and to EditProfileModal's — one rule, one
+    // wording, wherever the operator meets it.
+    .refine(isDisplayNameValid, "Enter your real name — not your NUSNET ID.")
+    .optional(),
+
+  // `.optional()` like the gate fields, and for the same reason: omitted means
+  // "leave the stored value alone". Bio is additionally the ONE field where a
+  // present "" is a real instruction (clear it) rather than a validation error,
+  // because bio is not a gate field — so `undefined` and `""` are genuinely
+  // different messages here and the dialog must not conflate them.
+  bio: z
+    .string()
+    .trim()
+    .max(BIO_MAX, `Bio must be ${BIO_MAX} characters or fewer`)
+    .optional(),
+
+  telegramHandle: z
+    .string()
+    .trim()
+    .transform((v) => v.replace(/^@+/, ""))
+    .refine((v) => TELEGRAM_RE.test(v), {
+      message: "Telegram handle must be 5–32 characters: letters, digits or _",
+    })
+    .optional(),
+
+  // BLOCKS is 2..8. The form holds `number | ""` and never reaches here with ""
+  // (see UserDetailDialog) — an unset select is a distinct state from an
+  // invalid one and deserves its own message.
+  block: z
+    .number()
+    .int()
+    .refine((n) => (BLOCKS as readonly number[]).includes(n), "Pick a block.")
+    .optional(),
+
+  // `undefined` means "leave the UserMatric row alone". There is deliberately
+  // no value that means "clear it": matric is a gate field, and the server has
+  // no clearing branch either.
+  matric: z
+    .string()
+    .trim()
+    .transform((v) => v.toUpperCase())
+    .refine((v) => MATRIC_RE.test(v), {
+      message:
+        "Matric must be in the format A0234567X (A + 7 digits + a letter).",
+    })
+    .optional(),
+});
+
+export type AdminProfileFormValues = z.output<typeof adminProfileFormSchema>;
+
+/**
+ * Flatten zod issues into one message per field, first-wins.
+ *
+ * First-wins rather than joined: two messages stacked under one input is noise,
+ * and the operator fixes them one at a time anyway.
+ */
+export function fieldErrorsFrom(error: z.ZodError): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !out[key]) out[key] = issue.message;
+  }
+  return out;
+}
+
+/* ========================================================================== */
+/* Error copy                                                                 */
+/* ========================================================================== */
+
+/**
+ * A tRPC client error, structurally. Typed loosely on purpose so both a
+ * mutation's and a query's error object satisfy it without importing
+ * TRPCClientErrorLike<AppRouter> and dragging the router type in here.
+ */
+export type ClientErrorLike =
+  | { message?: string | null; data?: { code?: string } | null }
+  | null
+  | undefined;
+
+/**
+ * Server messages this surface can produce, mapped to operator copy.
+ *
+ * The matric duplicate is mapped by CODE (CONFLICT) rather than by text: the
+ * server's prose is written for the resident editing their own profile
+ * (services/profile.ts) and must not be re-worded there just to read well here.
+ *
+ * Anything unmapped falls through to a generic line. That is deliberate — an
+ * unmapped message may be a zod issue array serialised as JSON, and dumping it
+ * into the dialog is worse than saying nothing useful.
+ */
+const MESSAGE_COPY: Record<string, string> = {
+  // "open or edit", not "edit": G3 is applied on `userAdmin.get` as well as on
+  // the writes, so this string is what a jcrc sees when the DIALOG LOADS, before
+  // any form is shown.
+  CANNOT_MODIFY_AN_ADMIN: "You can't open or edit an admin's details.",
+  // The OTHER G3 denial (services/userAdmin.ts). Deliberately not folded into
+  // NO_CANONICAL_IDENTITY below: that one is updateProfile's matric refusal and
+  // says the account has no matric record, which would read here as a field
+  // problem rather than as "you may not open this at all". Worded so an operator
+  // knows the remedy is a person, not a retry.
+  CANNOT_MODIFY_AN_UNKEYED_ACCOUNT:
+    "This account isn't on an @u.nus.edu address, so it has no NUSNET id and its role record can't be read back — there's no way to check what access it holds. Only an admin can open it.",
+  NO_SUCH_USER: "That account no longer exists. Reload the page.",
+  NO_CANONICAL_IDENTITY:
+    "This account isn't on an @u.nus.edu address, so it has no matric record.",
+  USER_DELETE_DISABLED: "Account deletion is turned off.",
+  CONFIRM_EMAIL_MISMATCH: "That email doesn't match.",
+  // Produced by BOTH dialogs and mapped here rather than falling through to the
+  // PRECONDITION_FAILED line below, which says "something changed while you
+  // were confirming" — true for the delete's TOCTOU case and wrong for this
+  // one, which is a standing state of the data and will not clear on a retry.
+  SHARED_CANONICAL_ID:
+    "Another account resolves to the same NUSNET id as this one, and matric and post-merge records are filed under that shared id. Ask a developer to run the account merge (scripts/remediation/merge-by-canonical.mjs) first.",
+  // Mapped for the SAME reason SHARED_CANONICAL_ID is: it arrives as a
+  // PRECONDITION_FAILED, and that code's generic line ("something changed while
+  // you were confirming") is wrong here — this is a standing property of the
+  // address and no retry will clear it. Normally the operator never reaches it,
+  // because the preflight lists it as a refusal and the confirm control is not
+  // mounted; this covers the paths that skip the preview.
+  ABSENT_CANONICAL_ID:
+    "This account has no NUSNET id, so its records can't be located and it can't be deleted safely. Ask a developer to clear it out first.",
+  // Passed through verbatim: the server, EditProfileModal and the mirror schema
+  // above all use this exact string, and it is already operator-readable.
+  "Enter your real name — not your NUSNET ID.":
+    "Enter their real name — not their NUSNET ID.",
+};
+
+export function friendlyError(err: ClientErrorLike): string | null {
+  if (!err) return null;
+  const message = err.message ?? "";
+  const code = err.data?.code;
+
+  if (MESSAGE_COPY[message]) return MESSAGE_COPY[message]!;
+
+  // The ObjectId shape check in routers/userAdmin.ts is a ZOD refusal, so its
+  // message arrives as a serialised issue array rather than as the bare string.
+  // Matched by substring so the operator gets "that account no longer exists"
+  // — the true statement — instead of the generic retry line, which would send
+  // them back at a call that can never resolve.
+  if (message.includes("NO_SUCH_USER")) return MESSAGE_COPY.NO_SUCH_USER!;
+
+  // The matric duplicate guard in services/profile.ts. By code, not by text.
+  if (code === "CONFLICT")
+    return "That matric number is already registered to another account.";
+
+  if (message.startsWith("CAPABILITY_REQUIRED"))
+    return "You don't have permission to do that.";
+
+  /**
+   * PRECONDITION_FAILED reaching a dialog means the state moved underneath the
+   * operator. The delete's refusals are rendered from the preflight and the
+   * confirm control is not even mounted while any exist, so a refusal arriving
+   * at COMMIT time can only be the TOCTOU case the in-transaction re-checks
+   * exist to catch: a co-head revoked, or the target granted admin, in the
+   * seconds between the preview and the typed confirmation.
+   */
+  if (code === "PRECONDITION_FAILED")
+    return "Something changed while you were confirming. Reload and check again.";
+
+  return "That didn't save. Try again.";
+}
+
+/**
+ * May this error be re-attempted, i.e. is a Retry control honest?
+ *
+ * IT IS NOT MERELY COSMETIC. `userAdmin.get` applies the G3 target guard
+ * (assertMayManageUserProfileOf), and that guard AUDITS ITS OWN DENIALS — so a
+ * Retry offered against a FORBIDDEN writes one more `denied` RoleAuditLog row,
+ * on the highest-signal action this system records, per click, for an operation
+ * that can never now succeed. DeleteUserDialog's onError block names the same
+ * pattern from the other direction (it re-runs the preflight so the dead confirm
+ * button unmounts). Noise on the audit surface is not free: it is the surface an
+ * admin reads to find a real probe.
+ *
+ * The three refusals below are properties of the REQUEST, not of the moment, and
+ * this dialog's query input is fixed for its lifetime:
+ *   FORBIDDEN   — the capability or the target guard. Needs a different actor.
+ *   NOT_FOUND   — no such User row. The copy already says "Reload the page."
+ *   BAD_REQUEST — the ObjectId shape refusal (a zod issue, hence the NO_SUCH_USER
+ *                 substring match above). The same id will fail identically.
+ * Everything else — a network fault, INTERNAL_SERVER_ERROR, TIMEOUT — is the
+ * transient class a Retry is FOR, and must keep the button.
+ */
+const NON_RETRYABLE_CODES = new Set(["FORBIDDEN", "NOT_FOUND", "BAD_REQUEST"]);
+
+export function isRetryable(err: ClientErrorLike): boolean {
+  const code = err?.data?.code;
+  return !(code && NON_RETRYABLE_CODES.has(code));
+}
+
+/* ========================================================================== */
+/* Deletion footprint copy                                                    */
+/* ========================================================================== */
+
+/**
+ * Render order and labels for `getDeletionImpact`'s `counts`.
+ *
+ * A MIRROR of FOOTPRINT_COLLECTIONS in src/server/api/services/userAdmin.ts,
+ * not a value import: that module imports @trpc/server and services/access, so
+ * pulling it into a client component drags server code into the browser bundle.
+ * services/roles.ts may be imported here (it is runtime-pure, which is why
+ * AdminCapabilityContext imports it); services/userAdmin.ts may not.
+ *
+ * Drift is SAFE IN ONE DIRECTION and that is by design: any key present in
+ * `counts` but absent from this list is still rendered, under its raw name, by
+ * the fallback in DeleteUserDialog. A collection added to the cascade shows up
+ * in the blast radius immediately, ugly but VISIBLE — the same call RoleBadge
+ * makes for an unknown role string. Silently omitting it would under-report
+ * what a delete destroys, which is the one thing this panel exists to prevent.
+ *
+ * `order` was here and is gone: the cascade no longer touches the supper domain
+ * (see the residue block in services/userAdmin.ts). Listing a collection the
+ * cascade does not delete is the same defect as omitting one it does, pointing
+ * the other way — and the server no longer emits the key, so the entry would
+ * simply have rendered `0` forever.
+ */
+export const FOOTPRINT_ORDER = [
+  "ccaHead",
+  "userRole",
+  "pendingRoleGrant",
+  "userMatric",
+  "profileCompletion",
+  "eventSignup",
+  "ccaInterviewNote",
+  "ccaApplication",
+  "userCCA",
+  "bookings",
+  "posts",
+  "gym",
+] as const;
+
+/** Singular / plural copy. Written for a sentence, not for a schema. */
+const FOOTPRINT_LABEL: Record<string, { one: string; many: string }> = {
+  ccaHead: { one: "CCA headship", many: "CCA headships" },
+  userRole: { one: "role record", many: "role records" },
+  pendingRoleGrant: { one: "pending role grant", many: "pending role grants" },
+  userMatric: { one: "matric record", many: "matric records" },
+  profileCompletion: {
+    one: "profile-completion flag",
+    many: "profile-completion flags",
+  },
+  eventSignup: { one: "event signup", many: "event signups" },
+  ccaInterviewNote: {
+    one: "interview note about them",
+    many: "interview notes about them",
+  },
+  ccaApplication: { one: "CCA application", many: "CCA applications" },
+  userCCA: { one: "CCA membership", many: "CCA memberships" },
+  bookings: { one: "booking", many: "bookings" },
+  posts: { one: "post", many: "posts" },
+  gym: { one: "gym record", many: "gym records" },
+};
+
+/** `46 bookings`, `1 role record`, or the raw key for a collection added later. */
+export function footprintPhrase(key: string, n: number): string {
+  const label = FOOTPRINT_LABEL[key];
+  if (!label) return `${n} × ${key}`;
+  return `${n} ${n === 1 ? label.one : label.many}`;
+}
+
+/* ========================================================================== */
+/* Refusals                                                                   */
+/* ========================================================================== */
+
+/** `SOLE_HEAD_OF_CCA:12` -> 12. null for every other refusal. */
+export function soleHeadCcaID(refusal: string): number | null {
+  const prefix = "SOLE_HEAD_OF_CCA:";
+  if (!refusal.startsWith(prefix)) return null;
+  const id = Number(refusal.slice(prefix.length));
+  return Number.isFinite(id) ? id : null;
+}
+
+/**
+ * Why the delete is refused, and — more importantly — what the operator does
+ * next. Every one of these is a deliberate refusal with a documented remedy;
+ * copy that only said "not allowed" would read as the feature being broken,
+ * which matters most for LEGACY_KEY_MISMATCH because that population is exactly
+ * the messy duplicate an admin most wants to clean up.
+ *
+ * `ccaName` resolves SOLE_HEAD_OF_CCA's id; it may be absent (the CCA list is
+ * a separate query and may still be loading), in which case the id is shown.
+ */
+export function refusalCopy(
+  refusal: string,
+  ccaName: (ccaID: number) => string | null,
+): string {
+  const ccaID = soleHeadCcaID(refusal);
+  if (ccaID !== null) {
+    const name = ccaName(ccaID) ?? `CCA #${ccaID}`;
+    return `They are the only head of ${name}. Hand that CCA over to someone else first — a CCA with no head can't be recovered from the app.`;
+  }
+  switch (refusal) {
+    case "CANNOT_DELETE_SELF":
+      return "You can't delete your own account.";
+    // NOT the same string as NO_CANONICAL_IDENTITY in MESSAGE_COPY above, and
+    // deliberately so: that one is updateProfile's matric refusal, and this map
+    // and that one are both consumed by the delete dialog.
+    case "ABSENT_CANONICAL_ID":
+      return "This account isn't on an @u.nus.edu address, so it has no NUSNET id and its records can't be located. Deleting it would remove the account and leave anything it owns — bookings that still hold a room, posts — behind with no owner. Ask a developer to clear it out first (scripts/remediation/rbac-doctor.mjs --nonnus lists what it owns).";
+    case "CANNOT_DELETE_AN_ADMIN":
+      return "This account holds the admin role. Remove that role from Manage roles first — deleting an admin directly could leave the hall with no administrator, and there is no way to create the first one from inside the app.";
+    case "LEGACY_KEY_MISMATCH":
+      return "This account's stored ID doesn't match its email, so its records can't be attributed safely. This is the split-account case — ask a developer to run a merge script instead.";
+    case "SHARED_CANONICAL_ID":
+      return "Another account resolves to the same NUSNET id as this one (usually a stray space or a different capitalisation in the email). Deleting either one would take the other's roles, bookings and matric with it, because those records are filed under the shared id. Ask a developer to run the account merge (scripts/remediation/merge-by-canonical.mjs) first.";
+    default:
+      // Same call as the unknown-collection fallback above: an unmapped refusal
+      // must still BLOCK and still be visible, never silently disappear and let
+      // the confirm control render.
+      return `This account can't be deleted (${refusal}).`;
+  }
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -10,7 +10,10 @@ export default function AdminUsersPage() {
         <p className="text-sm text-gray-500">
           Roles are keyed on the NUSNET id, not the stored account id. An amber
           icon beside the roles marks an account that should hold the Resident
-          baseline but does not — that user cannot book until it repairs.
+          baseline but does not — that user cannot book until it repairs. Open
+          Details to correct someone&rsquo;s name, block, Telegram handle or
+          matric. Email addresses can&rsquo;t be changed — identity is derived
+          from them.
         </p>
       </div>
       <UserRoleTable />

--- a/src/app/onboarding/ineligible/page.tsx
+++ b/src/app/onboarding/ineligible/page.tsx
@@ -1,61 +1,104 @@
 "use client";
 
 import React from "react";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { ShieldAlert } from "lucide-react";
 
 /**
- * D-7 terminal state. Reached by MatricGate when `session.user.hasIdentity` is
- * false — the signed-in email does not canonicalize to an @u.nus.edu id. That
- * is a non-NUS address, or a JWT minted before the eligibility cutover on one
- * (session.maxAge is 30 days and the signIn callback does not re-run for a live
- * token).
+ * TWO terminal states, ONE page, because the resolving action is the same in
+ * both — sign out — and a second route would only be a second thing to
+ * allow-list correctly in MatricGate.
  *
- * D-C: the gate keys off `hasIdentity`, not `eligible`. Until that change this
- * page was effectively UNREACHABLE, because `eligible` is flag-aware (I-11) and
- * is `true` for these sessions in every mode but `enforce`. Do not "simplify"
- * the gate back onto `eligible`.
+ * 1. D-7 INELIGIBLE. Reached when `session.user.hasIdentity` is false: the
+ *    signed-in email does not canonicalize to an @u.nus.edu id. That is a
+ *    non-NUS address, or a JWT minted before the eligibility cutover on one
+ *    (session.maxAge is 30 days and the signIn callback does not re-run for a
+ *    live token).
+ *
+ *    D-C: the gate keys off `hasIdentity`, not `eligible`. Until that change
+ *    this page was effectively UNREACHABLE, because `eligible` is flag-aware
+ *    (I-11) and is `true` for these sessions in every mode but `enforce`. Do not
+ *    "simplify" the gate back onto `eligible`.
+ *
+ * 2. NO ACCOUNT ROW. Reached when `session.user.accountMissing` is true: the
+ *    `User` document this JWT was minted against is gone — deleted through
+ *    `userAdmin.delete`, or removed as the losing row of an account merge. The
+ *    copy has to be DIFFERENT from state 1's, because state 1's is a false
+ *    statement here: their address is fine, and telling someone whose account
+ *    was merged that they need an NUS account sends them to create a duplicate
+ *    of the row the merge just cleaned up. It is also checked FIRST, since such
+ *    a session still canonicalizes and would otherwise read as eligible.
  *
  * Deliberately calls NO tRPC procedure — not even one that would succeed today.
  * Under `enforce` every procedure is built on protectedProcedure and denies
- * this session with NUS_ACCOUNT_REQUIRED, so anything data-driven here would
- * render as an opaque error in exactly the mode where this page matters most.
- * The page states the requirement and offers the one action that actually
- * resolves it: sign out and sign back in with an NUS account.
+ * state 1 with NUS_ACCOUNT_REQUIRED, and state 2 is denied the same way once
+ * the account is genuinely gone, so anything data-driven here would render as an
+ * opaque error in exactly the modes where this page matters most. The page
+ * states the requirement and offers the one action that resolves it.
  */
 export default function IneligibleAccountPage() {
+  const { data: session } = useSession();
+  const accountMissing = session?.user?.accountMissing === true;
+
   return (
     <div className="mt-16 flex items-center justify-center p-4">
       <div className="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-8 shadow-xl">
         <div className="mb-6 text-center">
           <ShieldAlert className="mx-auto mb-3 text-amber-600" size={40} />
-          <h1 className="mb-2 text-2xl font-bold text-gray-900">
-            NUS account required
-          </h1>
-          <p className="text-gray-600">
-            The RH App is only available to Raffles Hall residents signing in
-            with their NUS student account — an address ending in{" "}
-            <span className="font-semibold text-gray-900">@u.nus.edu</span>.
-          </p>
-          <p className="mt-3 text-gray-600">
-            You are signed in with a different address. Bookings and posts made
-            from this account cannot be linked back to you, so it can no longer
-            use the rest of the app. Sign in with your NUS student account and
-            everything works normally.
-          </p>
+
+          {accountMissing ? (
+            <>
+              <h1 className="mb-2 text-2xl font-bold text-gray-900">
+                This session is no longer valid
+              </h1>
+              <p className="text-gray-600">
+                The account this browser is signed in as no longer exists. That
+                happens when an account is removed, and also when two duplicate
+                accounts are merged into one — in which case your details,
+                bookings and CCA memberships are all safe on the account that
+                was kept.
+              </p>
+              <p className="mt-3 text-gray-600">
+                Signing out and signing back in with the same NUS address picks
+                up the current account. If you are still shown this page
+                afterwards, the account really was removed — speak to the JCRC.
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="mb-2 text-2xl font-bold text-gray-900">
+                NUS account required
+              </h1>
+              <p className="text-gray-600">
+                The RH App is only available to Raffles Hall residents signing
+                in with their NUS student account — an address ending in{" "}
+                <span className="font-semibold text-gray-900">@u.nus.edu</span>.
+              </p>
+              <p className="mt-3 text-gray-600">
+                You are signed in with a different address. Bookings and posts
+                made from this account cannot be linked back to you, so it can
+                no longer use the rest of the app. Sign in with your NUS student
+                account and everything works normally.
+              </p>
+            </>
+          )}
         </div>
 
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
           className="w-full rounded-xl bg-emerald-600 px-4 py-3 font-semibold text-white shadow-lg transition-all duration-200 hover:bg-emerald-700"
         >
-          Log out and sign in with NUS
+          {accountMissing
+            ? "Log out and sign in again"
+            : "Log out and sign in with NUS"}
         </button>
 
-        <p className="mt-4 text-center text-sm text-gray-500">
-          Already using an @u.nus.edu address? Log out and back in — your
-          session predates this requirement.
-        </p>
+        {!accountMissing && (
+          <p className="mt-4 text-center text-sm text-gray-500">
+            Already using an @u.nus.edu address? Log out and back in — your
+            session predates this requirement.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -8,6 +8,7 @@ import { ccaAdminRouter } from "./routers/ccaAdmin";
 import { ccaApplicationsRouter } from "./routers/ccaApplications";
 import { ccaApplicationsHeadRouter } from "./routers/ccaApplicationsHead";
 import { eventRouter } from "./routers/event";
+import { userAdminRouter } from "./routers/userAdmin";
 
 /**
  * This is the primary router for your server.
@@ -19,6 +20,14 @@ export const appRouter = createTRPCRouter({
   bookings: facilityBookingRouter,
   user: userRouter,
   admin: adminRouter,
+  /**
+   * Admin CRUD over user DETAILS (the /admin/users detail dialog). Read/update:
+   * admin + jcrc, behind the manageUserProfiles capability and the G3 target
+   * guard. Delete: admin only, behind deleteUsers AND the default-off
+   * admin.userDelete.enabled switch. EMAIL IS IMMUTABLE and ROLES ARE NOT
+   * WRITTEN here — admin.setUserRoles / grantCcaHead own them (I-14).
+   */
+  userAdmin: userAdminRouter,
   /** Object-scoped CCA reads. Guarded per-ccaID, not per-role — see cca.ts. */
   cca: ccaRouter,
   /** Admin-only CCA management, behind the cca.management.enabled switch. */

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -8,8 +8,15 @@ import {
   MATRIC_RE,
   type ProfileCompletionField,
 } from "~/lib/schemas/profile";
-import type { PrismaClient } from "@prisma/client";
 import { getUserRoles } from "../services/access";
+// THE shared profile writers. MOVED out of this file (not copied) when the
+// admin user-detail surface gained a profile edit — see the header of
+// services/profile.ts for why a second matric writer is the specific hazard.
+import {
+  assertMatricUnclaimed,
+  clearable,
+  writeMatric,
+} from "../services/profile";
 import { isDisplayNameValid } from "~/lib/profileCompleteness";
 
 // Matric number: "A" + 7 digits + an uppercase letter, e.g. A0234567X. The
@@ -37,125 +44,17 @@ export type ProfileCCA = {
 type RawUserCcaDoc = { userCCA?: unknown; userID?: unknown };
 
 /* -------------------------------------------------------------------------- */
-/* D-5: how a cleared optional String is persisted                             */
+/* D-5 / THE matric writer — now in services/profile.ts                        */
 /* -------------------------------------------------------------------------- */
-
-/**
- * OPEN QUESTION — the user must run the step-0 $jsonSchema dump before this is
- * settled. The `User` collection is $jsonSchema-guarded, and `String?` in the
- * Prisma schema means "optional/absent", NOT "null-accepting": Prisma infers
- * nullability from a missing key, not from the validator. No existing write path
- * has ever produced a null here (register/route.ts writes concrete values after
- * a presence check; the old updateUserData always wrote strings), so the
- * validator may well declare `bsonType: "string"` and reject the first
- * "clear my handle" save at the database.
- *
- * Until the dump is read, clearing is routed through this ONE helper so the
- * answer is a one-line flip rather than a hunt:
- *
- *   Branch A — bsonType is an array including "null"  ->  CLEAR_MODE = "null"
- *   Branch B — bsonType excludes null (bare "string") ->  CLEAR_MODE = "unset"
- *   Branch C — the field is in the validator's `required` array -> it cannot be
- *              cleared at all; make it required in updateProfileInput with
- *              `.refine((v) => v !== "")` and drop the clear affordance from the
- *              modal, rather than shipping a UI control that always errors.
- *
- * "unset" is the SAFE-UNDER-BOTH default and is why it is selected here: Prisma
- * Mongo's `{ unset: true }` removes the key, which every branch-A validator also
- * accepts (an optional field is satisfied by absence), whereas writing `null`
- * under branch B is rejected. Reads are identical either way — an absent key
- * deserialises as `null` — so no client code depends on this choice.
- *
- * If the dump comes back branch A and you prefer a literal null on disk, flip
- * the constant. If it comes back branch C, take the branch-C action above; this
- * helper cannot save you there, because the write itself is illegal.
- *
- * scripts/remediation/normalize-telegram-handles.mjs makes the SAME decision and
- * must be flipped in the same commit ($unset vs $set: null).
+/*
+ * `clearable` (with the whole D-5 branch-A/B/C note), `writeMatric` and
+ * `assertMatricUnclaimed` were MOVED to `../services/profile`, unchanged, when
+ * `routers/userAdmin.ts` gained an admin-side profile edit. Nothing about their
+ * behaviour changed and the call order below is identical; they live one level
+ * down so that BOTH routers share one matric writer and one CLEAR_MODE constant.
+ * Do not re-declare a local copy here — read the header of services/profile.ts
+ * first if you are tempted.
  */
-const CLEAR_MODE: "null" | "unset" = "unset";
-
-type ClearableString = string | null | { unset: true };
-
-/** "" from the shared schema means "clear it"; anything else is a literal set. */
-function clearable(value: string): ClearableString {
-  if (value !== "") return value;
-  return CLEAR_MODE === "unset" ? { unset: true } : null;
-}
-
-/* -------------------------------------------------------------------------- */
-/* THE matric writer                                                           */
-/* -------------------------------------------------------------------------- */
-
-/**
- * The ONE path that writes UserMatric. `setMatric` (the matric onboarding page)
- * and `completeProfile` (the post-merge form) both go through here, so there is
- * exactly one place that decides how a matric is keyed and persisted.
- *
- * Extracted rather than copied: a second upsert would be a second chance to key
- * it on `session.user.id` (the Mongo _id) instead of the canonical `userID`,
- * which is the mis-keying that produced the duplicate rows this whole feature
- * exists to clean up after. The `userID` parameter is typed non-null, so the
- * ""-key hazard (I-8d) cannot reach this function without a caller's guard
- * having run first — callers guard, this function assumes.
- */
-async function writeMatric(
-  db: PrismaClient,
-  userID: string,
-  matric: string,
-): Promise<string> {
-  const record = await db.userMatric.upsert({
-    where: { userID },
-    create: { userID, matric },
-    update: { matric },
-  });
-  return record.matric;
-}
-
-/**
- * Refuse a matric that a DIFFERENT canonical userID already holds.
- *
- * Why this is a check and not a `@unique` index: `UserMatric.matric` is
- * deliberately non-unique in schema.prisma because the legacy data ALREADY
- * contains duplicate matrics, and bulk resolution needs to READ those rows and
- * report them as AMBIGUOUS rather than have the database refuse to hold them.
- * Adding a unique index would break that remediation path (and could not be
- * created against the live collection anyway while the duplicates exist).
- *
- * But "we must be able to read pre-existing duplicates" is not "a user may
- * newly claim someone else's number". Matric is an identity key in the bulk
- * import: if two accounts hold one matric, an import row can resolve to the
- * wrong person, which is an impersonation primitive, not a display bug. So the
- * WRITE path refuses new collisions while the SCHEMA stays permissive enough to
- * represent the old ones.
- *
- * This is a read-then-write check and is therefore TOCTOU-racy in principle;
- * two users would have to submit the same matric within the same few
- * milliseconds to slip through, and the result is the pre-existing AMBIGUOUS
- * state that bulk resolution already handles rather than a new failure mode.
- *
- * Applied in `setMatric` (self-service) only. `completeProfile` resolves a
- * post-merge flag against a matric the merge itself derived, and hard-failing
- * there would strand a user in a form they cannot clear.
- */
-async function assertMatricUnclaimed(
-  db: PrismaClient,
-  userID: string,
-  matric: string,
-): Promise<void> {
-  const claimedByAnother = await db.userMatric.findFirst({
-    where: { matric, userID: { not: userID } },
-    select: { id: true },
-  });
-
-  if (claimedByAnother) {
-    throw new TRPCError({
-      code: "CONFLICT",
-      message:
-        "That matriculation number is already registered to another account. If you think that is wrong, contact the JCRC.",
-    });
-  }
-}
 
 export const userRouter = createTRPCRouter({
   getCurrentUserData: protectedProcedure.query(async ({ ctx }) => {

--- a/src/server/api/routers/userAdmin.ts
+++ b/src/server/api/routers/userAdmin.ts
@@ -1,0 +1,1244 @@
+import { randomUUID } from "node:crypto";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, roleManagerProcedure } from "~/server/api/trpc";
+import { getUserRoles } from "~/server/api/services/access";
+import {
+  ADMIN_ROLE,
+  computeCapabilities,
+  type Capabilities,
+} from "~/server/api/services/roles";
+import { writeAudit } from "~/server/api/routers/admin";
+import {
+  assertMatricUnclaimed,
+  clearable,
+  writeMatric,
+} from "~/server/api/services/profile";
+import {
+  assertMayManageUserProfileOf,
+  assertUserDeleteEnabled,
+  computeDeleteRefusals,
+  countUserFootprint,
+  deleteUserAccountCascade,
+  findCanonicalIdCollisions,
+  isUserDeleteEnabled,
+  loadAdminUserTarget,
+} from "~/server/api/services/userAdmin";
+import {
+  REQUIRED_PROFILE_FIELDS,
+  computeProfileGaps,
+  isDisplayNameValid,
+  type ProfileField,
+} from "~/lib/profileCompleteness";
+import {
+  BIO_MAX,
+  BLOCKS,
+  DISPLAY_NAME_MAX,
+  MATRIC_RE,
+  TELEGRAM_RE,
+  sanitizeName,
+} from "~/lib/schemas/profile";
+
+/**
+ * ADMIN CRUD OVER USER DETAILS — the /admin/users detail dialog.
+ *
+ * READ, UPDATE, DELETE. There is deliberately no CREATE: signup and
+ * PendingRoleGrant already own onboarding, and a hand-minted User row would be
+ * an account with no password, no verified NUS provenance and no session path.
+ *
+ * EMAIL IS IMMUTABLE HERE. Identity is derived from the email localpart
+ * (`canonicalUserID`, src/lib/identity.ts), so changing an email re-keys a
+ * human's ENTIRE identity — roles, matric, CCA memberships, bookings — and
+ * leaves the old key's rows attached to nobody. That is the exact defect that
+ * produced two duplicate accounts this week (see
+ * scripts/remediation/fix-claresta-duplicate.mjs and fix-lgd-duplicate.mjs).
+ * The protection here is STRUCTURAL, not a check: no input schema below carries
+ * an `email` key, the update schema is `.strict()` so a payload containing one
+ * 400s loudly rather than being silently stripped, and the target is named by
+ * `User` ObjectId with the canonical key DERIVED server-side from the stored
+ * row. There is nothing to change an email WITH.
+ *
+ * ROLES ARE NOT WRITTEN HERE EITHER. admin.setUserRoles / grantCcaHead /
+ * revokeCcaHead / transferCcaHead own them, and I-14 reserves the `cca_head`
+ * string for `writeCcaHeadString` on the CCA path. `delete` REMOVES the whole
+ * `UserRole` document inside the cascade transaction; it never writes a role
+ * SET, so it is not a second writer of `UserRole.roles` and cannot drop
+ * `resident` from anyone (I-8c). Nothing else in this file touches UserRole
+ * except a read.
+ *
+ * THE TARGET IS ALWAYS A `User` ObjectId, never a client-supplied userID.
+ * `User.userID` is NOT the identity: it holds an A-format matric on ~515 rows
+ * and, on the split-identity rows, another live human's canonical key. Taking
+ * `userID: userIDSchema` the way setUserRoles does would re-open that wrong-row
+ * hazard AND, because that schema is /^E\d{7}$/, would make G.S_SAMUEL and
+ * CHUAMINGYUAN unreachable (lockout mode L-27). Same call ccaAdmin.ts made.
+ *
+ * TO ARM THE DELETE (no redeploy needed; env vars are snapshotted per Vercel
+ * deployment, a SystemFlag row is not):
+ *   db.systemFlag.upsert({ where: { key: "admin.userDelete.enabled" },
+ *     create: { key: "admin.userDelete.enabled", value: "on" },
+ *     update: { value: "on" } })
+ * It takes effect within the 15s per-lambda cache in services/userAdmin.ts.
+ * Update has no switch — it is reversible and carries no privilege.
+ *
+ * Separate file rather than more of admin.ts, which is already past 2700 lines.
+ * The gate class (roleManagerProcedure) is the same, so these could have lived
+ * there; ccaAdmin.ts made the same split for the same reason.
+ */
+
+/* ========================================================================== */
+/* Capability assertion                                                       */
+/* ========================================================================== */
+
+/**
+ * Re-stated from admin.ts rather than imported: the copy there is module-local
+ * (not exported) and could not move to roles.ts anyway, because roles.ts is
+ * deliberately runtime-pure so client components can import the vocabulary and
+ * this needs TRPCError. Identical semantics, identical message shape
+ * (`CAPABILITY_REQUIRED:<key>`), so the client's error map covers both files.
+ *
+ * The procedure middleware answers "may you reach this surface"; this answers
+ * "may you do this thing". Both are required — roleManagerProcedure admits
+ * every jcrc, and `deleteUsers` is admin-only.
+ */
+function requireCapability<K extends keyof Capabilities>(
+  c: Capabilities,
+  key: K,
+): void {
+  const v = c[key];
+  if (v === false || (Array.isArray(v) && v.length === 0)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `CAPABILITY_REQUIRED:${String(key)}`,
+    });
+  }
+}
+
+const caps = (roles: readonly string[] | undefined) =>
+  computeCapabilities(roles ?? []);
+
+/* ========================================================================== */
+/* Input schemas                                                              */
+/* ========================================================================== */
+
+/**
+ * The target. A Mongo ObjectId hex string as the users table already hands it
+ * back (`AdminUserRow.id`).
+ *
+ * THE HEX SHAPE IS CHECKED HERE, not left to the loader. `findUnique({ where:
+ * { id } })` on Prisma's Mongo connector does NOT return null for a malformed
+ * id — it throws P2023 ("Malformed ObjectID"), which tRPC wraps as
+ * INTERNAL_SERVER_ERROR, `sanitizeErrors` rewrites to "Something went wrong."
+ * and the dialog then renders as "That didn't save. Try again.", pointing the
+ * operator at a retry that can never succeed. A stale link or a hand-typed id
+ * must read as NOT_FOUND, and the only way to keep that promise is to refuse
+ * the shape before it reaches Prisma.
+ *
+ * A well-formed id that is not a `User._id` (a `UserRole._id`, say) still falls
+ * through to `loadAdminUserTarget`'s NOT_FOUND, which is correct — that is a
+ * genuine miss, not a malformed request.
+ */
+const objectIdSchema = z.string().regex(/^[0-9a-fA-F]{24}$/, "NO_SUCH_USER");
+
+const targetSchema = z.object({ userObjectId: objectIdSchema });
+
+/** Audit `reason` is operator prose; the same cap ManageRolesDialog imposes. */
+const REASON_MAX = 500;
+
+/**
+ * STRICTER THAN `updateProfileInput` ON PURPOSE — and stricter in exactly one
+ * direction.
+ *
+ * On the self-service path `""` on telegramHandle means "clear it", and
+ * displayName may be empty because NextAuth's Google adapter created rows
+ * without one. Neither is allowed here. The strict profile-completion gate is
+ * ALWAYS ON (no kill switch — `computeProfileGaps` is evaluated in the session
+ * callback and there is no flag that turns it off), so an admin who saves a
+ * blank telegramHandle, displayName, block or matric walls that resident behind
+ * the completion dialog with no way to see who did it or to appeal. A resident
+ * who blanks their own field can immediately un-blank it; the person on the
+ * other end of THIS form cannot.
+ *
+ * The rule, stated once: AN ADMIN EDIT MAY CLOSE A PROFILE GAP; IT MAY NEVER
+ * OPEN ONE. Only `bio` is clearable, because bio is not a gate field.
+ *
+ * WHICH IS WHY EVERY GATE FIELD IS `.optional()`, AND THAT IS NOT A WEAKENING.
+ * An omitted field means "leave the stored value exactly as it is"; a PRESENT
+ * one must satisfy its validator outright. So the only value a gate field can
+ * be moved TO is a valid one, which is the rule above — while an operator who
+ * knows a gated resident's block but not their Telegram handle can still record
+ * the block. Requiring all four to be valid on every save would have made this
+ * form unusable for exactly the cohort it exists to repair (the ones with an
+ * OPEN gap), because the first thing it demands is the value nobody has. The
+ * client omits a field only when the operator left it byte-identical to a
+ * stored value that already fails the gate — see adminProfileFormSchema.
+ *
+ * `.strict()` is load-bearing, not tidiness: it is what makes a payload
+ * carrying `email`, `userID`, `roles` or `role` a LOUD 400 instead of a
+ * silently-stripped key. zod's default strip would make a future widening of
+ * this schema the only thing standing between a client and a role write; a
+ * throwing schema makes the attempt visible in the logs today.
+ *
+ * Every validator is IMPORTED from ~/lib/schemas/profile rather than restated,
+ * so the admin path cannot drift from the resident path — that is why those
+ * validators live in src/lib and not under src/server.
+ */
+const updateSchema = z
+  .object({
+    userObjectId: objectIdSchema,
+
+    // min(1) where updateProfileInput has none. `sanitizeName` still strips
+    // controls / zero-width / bidi-override codepoints — displayName is
+    // rendered to OTHER users on every booking listing, so an unfiltered value
+    // is an impersonation primitive, not a display bug. A name that sanitizes
+    // down to nothing is caught by isDisplayNameValid in the mutation.
+    displayName: z
+      .string()
+      .min(1)
+      .max(DISPLAY_NAME_MAX)
+      .transform(sanitizeName)
+      .optional(),
+
+    // The one clearable field: "" routes through `clearable` (D-5). Bio is not
+    // a gate field, so emptying it cannot lock anyone out.
+    //
+    // `.optional()` like the rest, and for the SAME reason they are: omitted
+    // means "leave the stored value alone". Sending it unconditionally is how
+    // an operator who came to change a block silently reverted a bio the
+    // resident had edited in the meantime — see the note on the audit diff.
+    bio: z
+      .string()
+      .trim()
+      .max(BIO_MAX, `Bio must be ${BIO_MAX} characters or fewer`)
+      .optional(),
+
+    // Stored WITHOUT the leading "@" — one canonical form, the UI renders the
+    // "@". NOTE the missing `v === "" ||` escape hatch that updateProfileInput
+    // carries: that is the whole difference, and it is the gate-field rule.
+    telegramHandle: z
+      .string()
+      .trim()
+      .transform((v) => v.replace(/^@+/, ""))
+      .refine((v) => TELEGRAM_RE.test(v), {
+        message:
+          "Telegram handle must be 5–32 characters: letters, digits or _",
+      })
+      .optional(),
+
+    // BLOCKS is 2..8, a SUBSET of the DB validator's declared int 1..8 range,
+    // so a value that passes here conforms to the collection validator as well.
+    // That matters more than usual: the User validator runs with
+    // validationAction "warn", so a non-conforming write is ACCEPTED SILENTLY
+    // and only logged. Zod is the real gate; the database is not a safety net.
+    block: z
+      .number()
+      .int()
+      .refine((n) => (BLOCKS as readonly number[]).includes(n), "Invalid block")
+      .optional(),
+
+    // Optional because a non-NUS account has no canonical key to store a matric
+    // under, and because the dialog omits it when unchanged. `undefined` means
+    // "leave the UserMatric row alone"; there is no value that means "clear it",
+    // deliberately — matric is a gate field.
+    matric: z
+      .string()
+      .trim()
+      .transform((v) => v.toUpperCase())
+      .refine((v) => MATRIC_RE.test(v), {
+        message:
+          "Matric must be in the format A0234567X (A + 7 digits + a letter).",
+      })
+      .optional(),
+
+    /**
+     * POST-MERGE CONFIRMATION, and the ONLY thing on this payload that is not a
+     * value to store.
+     *
+     * `merge-by-canonical.mjs` writes `ProfileCompletion.needsFields` when the
+     * two merged rows DISAGREED on a value, so an entry means "a stored value
+     * exists and NOBODY KNOWS WHETHER IT IS THIS PERSON'S — ask". Filling the
+     * field answers it; so does an operator who checked the stored value against
+     * a real source and says it is right. NOTHING ELSE DOES, which is why this
+     * key exists rather than the server inferring confirmation from the fact
+     * that a save happened — see WALL 2 in the mutation for what that inference
+     * cost.
+     *
+     * Names are validated against `REQUIRED_PROFILE_FIELDS` rather than a
+     * restated literal union, so widening the gate vocabulary widens this
+     * automatically and the two cannot drift. An unknown name is a LOUD 400 (the
+     * `.strict()` posture applied one level down) — a silently-dropped
+     * confirmation would leave the resident prompted with the operator believing
+     * otherwise, which is the direction that strands people.
+     */
+    confirmFields: z
+      .array(
+        z
+          .string()
+          .refine((f): f is ProfileField =>
+            (REQUIRED_PROFILE_FIELDS as string[]).includes(f),
+          ),
+      )
+      .max(REQUIRED_PROFILE_FIELDS.length)
+      .optional(),
+
+    reason: z.string().trim().max(REASON_MAX).optional(),
+  })
+  .strict();
+
+/* ========================================================================== */
+/* Audit reason helpers                                                       */
+/* ========================================================================== */
+
+/**
+ * The audit row is the ONLY surviving record of what an edit changed — there is
+ * no before-image anywhere else — so the diff is built from the values read
+ * before the write, not from what the client claimed. Truncated because
+ * `reason` is prose, not a payload.
+ */
+const truncate = (s: string): string =>
+  s.length <= REASON_MAX ? s : `${s.slice(0, REASON_MAX - 1)}…`;
+
+const shown = (v: string | number | null | undefined): string =>
+  v === null || v === undefined || v === "" ? "—" : String(v);
+
+function diffLine(
+  label: string,
+  before: string | number | null | undefined,
+  after: string | number | null | undefined,
+): string | null {
+  // Normalised through `shown` so null / undefined / "" compare equal: a Google
+  // row with an absent telegramHandle and one with "" are the same state, and
+  // reporting a change between them would be noise on the audit surface.
+  const a = shown(before);
+  const b = shown(after);
+  return a === b ? null : `${label}: ${a} → ${b}`;
+}
+
+/* ========================================================================== */
+/* The router                                                                 */
+/* ========================================================================== */
+
+export const userAdminRouter = createTRPCRouter({
+  /**
+   * The authoritative detail record for one account.
+   *
+   * Not served from the listUsers projection: that row has no matric, no
+   * telegramHandle and no bio, and its `roles` are REDACTED for a jcrc (D-2).
+   * The dialog needs the real record, so it asks for it.
+   *
+   * AUDITED (`user.detail.read`), which is unusual for a read and is exactly
+   * because of the sentence above — see the block on the writeAudit call.
+   */
+  get: roleManagerProcedure
+    .input(targetSchema)
+    .query(async ({ ctx, input }) => {
+      const actorUserID = ctx.session.user.userID;
+      // I-5: the ACTOR's roles are re-read from the database on every call, never
+      // taken from the session JWT. A JWT minted before a revocation still claims
+      // the revoked role until it refreshes.
+      const actorRoles = await getUserRoles(ctx.db, actorUserID);
+      const c = caps(actorRoles);
+      requireCapability(c, "manageUserProfiles");
+
+      const target = await loadAdminUserTarget(ctx.db, input.userObjectId);
+
+      /* ---- G3 ON THE READ TOO, and why it is worth the oracle --------------
+       * This record is NOT the listUsers row with a couple of extras: it carries
+       * matric, telegramHandle, bio and the profile gaps, none of which is in
+       * that projection. An unguarded read therefore hands any jcrc an ADMIN's
+       * matriculation number and Telegram handle — a bigger disclosure than the
+       * admin-enumeration this guard's own denial pattern creates, and one that
+       * redaction cannot close (blanking exactly those fields for admin targets
+       * is the same oracle one field over). The full argument, including what
+       * was given up, is on assertMayManageUserProfileOf.
+       *
+       * D-2's `admin` redaction below still applies on top: it is what keeps a
+       * manager reading a NON-admin's record from learning who holds admin.
+       */
+      await assertMayManageUserProfileOf(
+        ctx.db,
+        actorUserID,
+        actorRoles,
+        target,
+        writeAudit,
+      );
+
+      const cid = target.canonicalUserID;
+
+      /* ---- THE READ IS AUDITED, and it is the only read in AUDIT_ACTIONS ----
+       * `explainAccess` set the precedent and the reasoning is identical, only
+       * stronger here: it audits a read "because it is an enumeration primitive
+       * over the whole user base", and it returns strictly LESS than this one
+       * does (a decision plus a role list). This procedure returns matric,
+       * telegramHandle, bio and block, NONE of which is in the `listUsers`
+       * projection — and `listUsers` hands every jcrc the `id` of all ~1382
+       * accounts, so a loop over those ids is a complete export of the hall's
+       * matriculation numbers and contact handles by a student-held role.
+       *
+       * WITHOUT THIS ROW THAT EXPORT IS INVISIBLE. The target guard above audits
+       * DENIALS only — a target holding `admin`, or an unkeyed account — so
+       * every successful read of a non-admin returns 200 and writes nothing, and
+       * /admin/audit shows no row at all. An admin investigating a leak could
+       * not establish which manager did it, nor that a bulk read had happened.
+       * The same PII leaving in bulk is audited by design on the other surface
+       * that emits it (`event.attendees.export`).
+       *
+       * WRITTEN BEFORE THE PAYLOAD IS ASSEMBLED, deliberately: a row for a read
+       * that then faulted is noise, a disclosure with no row is the failure this
+       * exists to prevent, and only one of those two errors is recoverable.
+       * `writeAudit` swallows its own failures (it logs structurally), so this
+       * cannot turn an audit outage into a broken dialog.
+       *
+       * A LIMITER IS NOT A SUBSTITUTE and is deliberately not added alongside.
+       * `previewBulkImport`'s `rateLimit` bounds a harvest; it does not make one
+       * ATTRIBUTABLE, which is the question an audit surface is asked. If the
+       * row-per-dialog-open volume ever becomes a problem, cap `listAuditLog`'s
+       * default view — do not drop the row.
+       *
+       * `?? undefined`, NEVER `?? ""` — the sentinel rule (see writeAudit's
+       * note in updateProfile). For a non-NUS row the email is the only
+       * identification the row can carry, so it is always in `reason`.
+       */
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles,
+        targetUserID: cid ?? undefined,
+        action: "user.detail.read",
+        reason: truncate(`user detail: ${target.email}`),
+      });
+
+      // All four reads are skipped entirely when there is no canonical id.
+      // Neither `findUnique({ where: { userID: null } })` (a type error) nor
+      // `{ userID: "" }` (a stranger's row) is an acceptable stand-in — that is
+      // the sentinel bug class, an ABSENT identity spent as a real one. An
+      // account with no canonical id holds no canonical-keyed rows by
+      // construction, so [] / null is both the safe answer and the true one
+      // (the C9 reasoning in listUsers).
+      const [matricRow, roles, completionRow, collisions] = cid
+        ? await Promise.all([
+            ctx.db.userMatric.findUnique({ where: { userID: cid } }),
+            getUserRoles(ctx.db, cid),
+            ctx.db.profileCompletion.findUnique({ where: { userID: cid } }),
+            // The SAME check computeDeleteRefusals runs, on the read, because
+            // the fields below are read under TWO different keys and the
+            // operator cannot see that from the form: email / displayName /
+            // block / telegramHandle / bio come off THIS `_id`, while matric and
+            // the completion row come off the canonical id — which a second
+            // whitespace-variant User row can share (66 such sets on
+            // 2026-07-19). On a colliding row the matric shown belongs to the
+            // OTHER account, so the dialog must say so before anyone types over
+            // it. See findCanonicalIdCollisions.
+            findCanonicalIdCollisions(ctx.db, cid, target.userObjectId),
+          ])
+        : [null, [] as string[], null, []];
+
+      const matric = matricRow?.matric ?? null;
+
+      return {
+        userObjectId: target.userObjectId,
+        // READ-ONLY on every surface that consumes this. The dialog renders it in
+        // a locked panel; there is no procedure here that accepts it back.
+        email: target.email,
+        canonicalUserID: cid,
+        /** The STORED legacy column — display and mismatch detection only. */
+        legacyUserID: target.legacyUserID,
+        /** admin.listUsers' own flag, computed the same way, so the two agree. */
+        keyMismatch: Boolean(
+          target.legacyUserID && target.legacyUserID !== (cid as string | null),
+        ),
+        displayName: target.displayName,
+        telegramHandle: target.telegramHandle,
+        bio: target.bio,
+        block: target.block,
+        matric,
+        hasMatric: Boolean(matric),
+        /**
+         * ANOTHER live `User` row canonicalises to the same NUSNET id, so the
+         * canonical-keyed half of this record (matric, and the post-merge
+         * completion row) is SHARED with an account the operator did not open.
+         * The dialog refuses the matric input on this and says why; the router
+         * refuses the write regardless (a disabled control is cosmetic).
+         * Row-local fields stay editable — they are keyed on `_id` and reach
+         * only the account that was clicked.
+         */
+        sharedCanonicalID: collisions.length > 0,
+        /**
+         * DISPLAY ONLY (I-5). Nothing here authorises anything on the client.
+         *
+         * REDACTED exactly as admin.listUsers redacts, and by the same rule, so
+         * the two surfaces agree: without `seeAdminIdentities` the `admin`
+         * string is stripped. This is what lets the read succeed for every
+         * manager without the procedure becoming an admin oracle — see the note
+         * above the target guard.
+         */
+        roles: (c.seeAdminIdentities
+          ? roles
+          : roles.filter((r) => r !== ADMIN_ROLE)) as string[],
+        /**
+         * WALL 1 — the strict profile gate. What is currently walling this
+         * resident behind /profile. Computed with the SAME function the session
+         * callback gates on, so the admin sees exactly the gaps the user is
+         * being held on — not a second opinion that could disagree with the
+         * gate.
+         */
+        profileGaps: computeProfileGaps({
+          displayName: target.displayName,
+          telegramHandle: target.telegramHandle,
+          block: target.block,
+          matric,
+        }),
+        /**
+         * WALL 2 — the post-merge completion flag, and a SEPARATE one.
+         * MatricGate checks `needsProfileCompletion` (this row) BEFORE
+         * `profileIncomplete` (profileGaps above) and routes to
+         * /onboarding/complete-profile, so a resident with an outstanding row is
+         * still walled even when every gap above is closed. Reported here
+         * because an operator who cannot see this wall will fill the form,
+         * watch the amber panel clear, and conclude they fixed something they
+         * did not — which is how the 18 residents in
+         * scripts/remediation/unstick-profile-completion.mjs got stranded.
+         *
+         * A row whose `resolvedAt` is set is history, not a live prompt, and
+         * reads as [] — the same rule the session callback applies.
+         */
+        profileNeedsFields:
+          completionRow && completionRow.resolvedAt == null
+            ? completionRow.needsFields
+            : [],
+      };
+    }),
+
+  /**
+   * Edit someone else's profile fields.
+   *
+   * WHAT THIS CAN AND CANNOT REACH: displayName, block, telegramHandle, bio and
+   * the UserMatric row. Not email (immutable — see the file header), not
+   * User.userID (the legacy column; rewriting it is the split-identity defect
+   * itself), not roles (admin.setUserRoles owns them), not passwordHash.
+   */
+  updateProfile: roleManagerProcedure
+    .input(updateSchema)
+    .mutation(async ({ ctx, input }) => {
+      const actorUserID = ctx.session.user.userID;
+      const actorRoles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireCapability(caps(actorRoles), "manageUserProfiles");
+
+      const target = await loadAdminUserTarget(ctx.db, input.userObjectId);
+      await assertMayManageUserProfileOf(
+        ctx.db,
+        actorUserID,
+        actorRoles,
+        target,
+        writeAudit,
+      );
+
+      // The same rule user.updateUserData applies on EVERY save, for the same
+      // reason: otherwise a name can be "fixed" back to a NUSNET id and the
+      // gate loops forever. Asserted after `sanitizeName` has run, so a name
+      // made entirely of zero-width characters is caught here as too short.
+      // Same message as the self-service path — one rule, one wording.
+      //
+      // Only when a name was SUBMITTED. An omitted displayName leaves whatever
+      // is stored — including a still-invalid one — exactly as it was, which is
+      // the "never open one, never widen one" half of the rule; rejecting the
+      // whole save because of a field nobody touched is what made partial
+      // repair impossible.
+      if (
+        input.displayName !== undefined &&
+        !isDisplayNameValid(input.displayName)
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Enter your real name — not your NUSNET ID.",
+        });
+      }
+
+      const cid = target.canonicalUserID;
+
+      /* ---- IS THE CANONICAL KEY EXCLUSIVE TO THIS ROW? ---------------------
+       * THIS SAVE WRITES UNDER TWO DIFFERENT KEYS and only one of them is the
+       * row the operator clicked:
+       *   - displayName / block / telegramHandle / bio -> `User._id`
+       *   - the UserMatric row and the ProfileCompletion row -> the CANONICAL id
+       * `email_unique_ci` folds case but not WHITESPACE, so
+       * "e0425010@u.nus.edu " and "e0425010@u.nus.edu" are two User rows and ONE
+       * canonical id — the 2026-07-19 census counted 66 such sets, and
+       * `computeDeleteRefusals` already refuses a DELETE on exactly this state
+       * (SHARED_CANONICAL_ID) because the key must be EXCLUSIVE, not merely
+       * complete. The same proof is required here and was missing.
+       *
+       * Without it, an operator opening the whitespace variant sees the LIVE
+       * account's matric (read under the shared key), corrects it, and
+       * overwrites the live account's UserMatric row — while the profile fields
+       * they typed land on the shadow row. The two halves of one "save" go to
+       * two different humans, the dialog says "Saved.", and the audit row can
+       * only name the shared canonical id, so it cannot even say which row was
+       * edited. `assertMatricUnclaimed` does not catch it (it excludes
+       * `userID: cid`, which IS the shared key) and LEGACY_KEY_MISMATCH does not
+       * either (on these rows `User.userID` is null or already equal to cid).
+       *
+       * ROW-LOCAL FIELDS ARE STILL WRITTEN. They are keyed on `_id` and reach
+       * only the account that was opened, and refusing them would leave the
+       * junk half of a duplicate pair uneditable for no safety gain. It is the
+       * CANONICAL-keyed half that is refused, and only that half.
+       */
+      const sharedCanonicalID =
+        cid !== null &&
+        (await findCanonicalIdCollisions(ctx.db, cid, target.userObjectId))
+          .length > 0;
+
+      if (sharedCanonicalID && input.matric !== undefined) {
+        // Audited as a denial, the shape `delete` uses for its refusal set: this
+        // is a safety refusal on a privileged surface, not a field-validation
+        // error, and repeated attempts on a duplicate pair are worth seeing.
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: cid ?? undefined,
+          action: "denied",
+          ok: false,
+          denyReason: "SHARED_CANONICAL_ID",
+          reason: truncate(`user profile matric: ${target.email}`),
+        });
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "SHARED_CANONICAL_ID",
+        });
+      }
+
+      /* ---- matric FIRST, and why ------------------------------------------
+       * UserMatric is a different collection from User, so these two writes are
+       * not atomic with each other. Matric goes first ON PURPOSE: the only
+       * failure expected in normal operation is the matric CONFLICT (someone
+       * else already holds that number), and running it first means that
+       * expected failure leaves NOTHING written at all. The reverse order would
+       * save the profile and then reject, which reads to the operator as "it
+       * didn't save" while half of it did.
+       *
+       * The residue in the other direction (matric written, User.update then
+       * fails) is benign and self-repairing: re-submitting the same form
+       * re-applies both, and the matric that landed is the one the gate most
+       * often needs. A $transaction across the two would buy atomicity for a
+       * pair of independent, idempotent, re-appliable writes — not worth the
+       * interactive transaction.
+       */
+      let matricBefore: string | null = null;
+      if (input.matric !== undefined) {
+        // UserMatric is CANONICAL-KEYED. There is no key to write under for a
+        // non-NUS account, and "" is not a key — it is the absent identity, and
+        // spending it here would attach this matric to a ""-keyed row that any
+        // other identity-less account would then read back as its own.
+        if (cid === null) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "NO_CANONICAL_IDENTITY",
+          });
+        }
+
+        matricBefore =
+          (await ctx.db.userMatric.findUnique({ where: { userID: cid } }))
+            ?.matric ?? null;
+
+        // An admin writing on someone's behalf must not be the SOFTER door: the
+        // same duplicate check the resident's own path runs, and then THE
+        // matric writer from services/profile.ts. Never a local upsert here —
+        // a second upsert is a second chance to key a matric on the Mongo _id
+        // instead of the canonical userID, which is the mis-keying that
+        // produced the duplicate rows the remediation scripts clean up after.
+        await assertMatricUnclaimed(ctx.db, cid, input.matric);
+        await writeMatric(ctx.db, cid, input.matric);
+      }
+
+      /* ---- the User write, and why it is wrapped ---------------------------
+       * If the matric landed and THIS throws (the row deleted underneath us by
+       * a concurrent userAdmin.delete — Prisma P2025 — or a transient Atlas
+       * fault), the mutation rejects with no audit row, leaving a CHANGED
+       * matric on a live account and nothing on the audit surface naming who
+       * changed it. An unaudited admin mutation is a bug outright, so the
+       * partial write is recorded before the error is re-thrown — the same
+       * shape the delete's own failure path uses (I-15: written on ctx.db,
+       * after the failure, never inside a transaction the throw would roll
+       * back).
+       *
+       * SKIPPED ENTIRELY WHEN NO ROW-LOCAL FIELD WAS SUBMITTED, and that is not
+       * an optimisation. Since the dialog sends only what changed, "open the
+       * record, tick `matric` as confirmed, Save" — the flow that clears a
+       * post-merge `needsFields: ["matric"]` — reaches here with every one of
+       * these four undefined and only `confirmFields` populated. Prisma would
+       * then build an update document with no operators and Mongo rejects an
+       * empty one, so the mutation would fail on exactly the case WALL 2 below
+       * exists to serve. The pre-image stands in as the "after" state: nothing
+       * was asked for, so nothing changed, and the diff below correctly reports
+       * no field changed.
+       */
+      let updated: {
+        id: string;
+        displayName: string | null;
+        telegramHandle: string | null;
+        bio: string | null;
+        block: number | null;
+      };
+      const rowLocalSubmitted =
+        input.displayName !== undefined ||
+        input.telegramHandle !== undefined ||
+        input.bio !== undefined ||
+        input.block !== undefined;
+      const preImage = {
+        id: target.userObjectId,
+        displayName: target.displayName,
+        telegramHandle: target.telegramHandle,
+        bio: target.bio,
+        block: target.block,
+      };
+      try {
+        updated = rowLocalSubmitted
+          ? await ctx.db.user.update({
+              where: { id: input.userObjectId }, // by _id (I-1), never by userID
+              data: {
+                // `undefined` is Prisma's "leave this field alone" — the exact
+                // semantics the optional schema promises, with no branch to get
+                // wrong. It is NOT the same as null (which would clear it).
+                displayName: input.displayName,
+                // "" clears. Routed through the ONE D-5 helper in
+                // services/profile.ts so the $unset-vs-null branch stays a
+                // one-line flip in one file. `undefined` is checked BEFORE
+                // `clearable`, which cannot see the difference: it maps "" to
+                // the clear operation, and an omitted bio must leave the stored
+                // one alone rather than erase it.
+                bio: input.bio === undefined ? undefined : clearable(input.bio),
+                // NOT clearable: "" cannot reach here (the schema refuses it),
+                // and a blank handle is a gate field the resident cannot
+                // restore.
+                telegramHandle: input.telegramHandle,
+                // Written through Prisma's Int mapping, byte-identical to what
+                // user.updateUserData and src/app/api/register/route.ts already
+                // produce. This matters: the User collection's $jsonSchema
+                // declares block as bsonType "int" with validationAction "warn",
+                // so a write of the wrong BSON type is ACCEPTED SILENTLY and
+                // only logged — the database will not catch a mistake here.
+                // Matching the existing writer exactly is the only way this path
+                // cannot produce a document shape the app does not already
+                // produce. (Counter-evidence that this is not theoretical:
+                // services/ccaMembers.ts had to drop to a raw insert because
+                // Prisma's Mongo connector sent an Int as a 64-bit long and
+                // UserCCA's int32 validator rejected it with code 121 — there
+                // the validator was "error", here it is "warn".)
+                // scripts/remediation/verify-user-admin-safety.mjs reports the
+                // observed $type distribution of this field, read-only.
+                block: input.block,
+              },
+              // Mirrors the read path's select. #9: passwordHash must never
+              // reach the client or the React Query cache. I-2: Prisma 6 throws
+              // deserializing a Google-adapter row that lacks it. userID and
+              // email are deliberately absent — this result is merged into the
+              // cached record client-side and User.userID holds an A-format
+              // matric on ~515 rows, so returning it would clobber the derived
+              // canonical id (I-1).
+              select: {
+                id: true,
+                displayName: true,
+                telegramHandle: true,
+                bio: true,
+                block: true,
+              },
+            })
+          : preImage;
+      } catch (err) {
+        if (input.matric !== undefined && matricBefore !== input.matric) {
+          await writeAudit(ctx.db, {
+            actorUserID,
+            actorRoles,
+            targetUserID: cid ?? undefined,
+            action: "user.profile.update",
+            reason: truncate(
+              [
+                target.email,
+                diffLine("matric", matricBefore, input.matric),
+                "profile write FAILED after the matric was written",
+                input.reason ? `— ${input.reason}` : "",
+              ]
+                .filter(Boolean)
+                .join(" | "),
+            ),
+          });
+        }
+        throw err;
+      }
+
+      /* ---- NO optimistic-concurrency check, and what stands in for it ------
+       * applyRoleChange does a compare-and-set on the pre-image because a
+       * concurrent role write can silently undo a revocation — losing a write
+       * there means a privilege survives that someone believed they removed.
+       * Nothing on this document carries privilege, and a compare-and-set here
+       * would fail loudly on the common case of two people fixing the same
+       * onboarding record.
+       *
+       * WHAT MAKES THAT SAFE IS THE OMISSION RULE, NOT last-write-wins. "The
+       * second operator's value stands" is only a reasonable outcome for a field
+       * the second operator actually typed. The client sends a field ONLY when
+       * it differs from what it loaded (UserDetailDialog's dirty check), and
+       * `undefined` here means "leave the stored value alone" — so a save that
+       * changed one Block cannot carry a stale telegramHandle back over the
+       * resident's own newer edit. If a future caller starts sending the whole
+       * record again, that reversal comes back and the audit diff is the only
+       * place it would ever show up.
+       */
+
+      // The diff is built from the pre-image loaded at the top of this
+      // procedure, so the row records what actually changed rather than what
+      // was submitted. Field-level, because "profile updated" on the audit
+      // surface answers none of the questions an audit surface is asked.
+      const changes = [
+        diffLine("displayName", target.displayName, updated.displayName),
+        diffLine("block", target.block, updated.block),
+        diffLine(
+          "telegramHandle",
+          target.telegramHandle,
+          updated.telegramHandle,
+        ),
+        diffLine("bio", target.bio, updated.bio),
+        input.matric !== undefined
+          ? diffLine("matric", matricBefore, input.matric)
+          : null,
+        // RECORDED EVEN THOUGH IT CHANGES NO FIELD. A tick can take down WALL 2
+        // on a save whose diff is empty, and "no field changed | [matric] →
+        // resolved" would leave the audit surface unable to say who vouched for
+        // the number or that anyone did. Named here, so the row states the act
+        // rather than only its effect.
+        input.confirmFields?.length
+          ? `confirmed: ${input.confirmFields.join(",")}`
+          : null,
+      ].filter((l): l is string => l !== null);
+
+      /* ---- WALL 2: clear what this edit just satisfied ---------------------
+       * THERE ARE TWO INDEPENDENT WALLS and writing the User row only takes
+       * down one of them. MatricGate checks `needsProfileCompletion` (an
+       * unresolved ProfileCompletion row) BEFORE the strict gate's
+       * `profileIncomplete`, and routes to /onboarding/complete-profile. So
+       * without this block an operator could fill every gap, watch the amber
+       * panel clear, and leave the resident redirected on every request — with
+       * `getProfileCompletion` filtering displayName/block out of its
+       * vocabulary and rendering a form with NO inputs and "Nothing to save."
+       * on submit. That is the exact trap
+       * scripts/remediation/unstick-profile-completion.mjs was written to
+       * release 18 residents from; this feature must not re-create it one
+       * resident at a time.
+       *
+       * AN ENTRY IS CLEARED ONLY WHEN THIS SAVE BOTH FILLED THE FIELD AND SPOKE
+       * TO IT. Two conditions, and BOTH are load-bearing:
+       *
+       *   1. `computeProfileGaps` — the SAME function WALL 1 and the session
+       *      callback gate on — reports no gap for it in the state AFTER this
+       *      write. This is what stops the two walls disagreeing about whether a
+       *      field is filled: resolving an entry whose value is still empty
+       *      takes down the prompt and leaves WALL 1 holding the resident.
+       *   2. THE OPERATOR SUPPLIED IT (`input.X !== undefined`) OR TICKED ITS
+       *      CONFIRM BOX (`input.confirmFields`).
+       *
+       * CONDITION 2 IS THE ONE THAT IS EASY TO ARGUE AWAY, so here is what
+       * happens without it. This block ran on the resulting state ALONE for
+       * exactly that reason — "an admin save is the confirmation" — and it is
+       * wrong about what these entries MEAN. merge-by-canonical writes
+       * `needsFields: ["matric"]` when two merged rows DISAGREED on a matric: a
+       * UserMatric row already exists, it is one of the two candidates, and the
+       * open question is WHICH. Condition 1 alone is satisfied by that row's mere
+       * existence. So a JCRC who opened the record to correct a Block — or who
+       * opened it, typed nothing and clicked Save, which reaches here with every
+       * row-local field undefined — silently stamped `resolvedAt`, the resident
+       * was never asked again, and the wrong number became permanent on the field
+       * `assertMatricUnclaimed`'s own comment calls an impersonation primitive
+       * because the bulk import resolves identities on it. The audit row read
+       * `no field changed | profileCompletion: [matric] → resolved`: a wall came
+       * down on a save that changed nothing.
+       *
+       * "Confirm an unchanged matric" still works, and now it is an ACT rather
+       * than a side effect — the dialog renders a tick box per flagged field and
+       * says so. That also makes the resident's path and this one consistent
+       * rather than merely similar: `user.completeProfile` resolves `matric` on a
+       * re-submitted identical value because the RESIDENT re-submitted it, which
+       * is an answer to the question; an admin's Save is not, unless they say it
+       * is.
+       *
+       * PRESERVE ANY NAME OUTSIDE THE VOCABULARY (a value a future deploy
+       * understands must survive one that does not), and stamp `resolvedAt` only
+       * once the list truly empties — a partial save must leave the row live and
+       * the resident still prompted for the rest. That is user.completeProfile's
+       * rule, unchanged.
+       *
+       * SKIPPED ENTIRELY ON A SHARED CANONICAL ID. The row is keyed on the
+       * canonical id, so on a whitespace-variant pair it is the OTHER, live
+       * account's post-merge prompt — resolving it from values typed against
+       * this row is how the one wall that was pointing at the real problem gets
+       * silently cleared. Named on the audit row so the operator's save is not
+       * recorded as having done something it refused to do.
+       */
+      /* THE WHOLE STEP IS WRAPPED, for the same reason the User write above is,
+       * and it must NOT re-throw. It runs AFTER that write has landed and BEFORE
+       * the audit row, so an unhandled fault here — a P2025 from the row being
+       * removed underneath us by unstick-profile-completion.mjs or by a
+       * concurrent userAdmin.delete (which deletes ProfileCompletion in its step
+       * 5), or a transient Atlas error on any of the three queries — would
+       * reject the mutation with the profile change already persisted and
+       * NOTHING on the audit surface naming who made it. An unaudited admin
+       * mutation is a bug outright.
+       *
+       * Re-throwing after auditing (what the User write does) is wrong HERE:
+       * there the operator's main action failed, so a retry is the right advice;
+       * here it succeeded, and telling them "that didn't save" would have them
+       * re-apply a save that already landed. So the failure is recorded on the
+       * audit row and the mutation reports success for what actually succeeded.
+       * The resident simply stays prompted — over-prompt, never lock out, the
+       * same degrade direction the session callback takes.
+       */
+      let completionLine: string | null = null;
+      if (cid !== null) {
+        try {
+          const row = await ctx.db.profileCompletion.findUnique({
+            where: { userID: cid },
+          });
+          // A row whose `resolvedAt` is set is history, not a live prompt — the
+          // same rule the session callback and `get` apply.
+          const live =
+            row && row.resolvedAt == null && row.needsFields.length > 0
+              ? row
+              : null;
+
+          if (live && sharedCanonicalID) {
+            // Read, reported, NOT written. See the note above.
+            completionLine = `profileCompletion [${live.needsFields.join(
+              ",",
+            )}] NOT cleared — another account shares this NUSNET id`;
+          } else if (live) {
+            // The stored matric AFTER this write. Re-read only when the row is
+            // actually waiting on one and this save did not supply it — the
+            // common case costs no extra query.
+            const matricNow =
+              input.matric ??
+              (live.needsFields.includes("matric")
+                ? ((
+                    await ctx.db.userMatric.findUnique({
+                      where: { userID: cid },
+                    })
+                  )?.matric ?? null)
+                : null);
+
+            const stillGapped = new Set<string>(
+              computeProfileGaps({
+                displayName: updated.displayName,
+                telegramHandle: updated.telegramHandle,
+                block: updated.block,
+                matric: matricNow,
+              }),
+            );
+            // Anything the gate vocabulary does not name is KEPT: this deploy
+            // cannot judge a field it does not understand.
+            const known = new Set<string>(REQUIRED_PROFILE_FIELDS);
+
+            /* WHAT THIS SAVE SPOKE TO — condition 2 above. A field is answered
+             * by a value the operator SUPPLIED, or by an explicit tick against
+             * the flagged entry. Nothing else counts, and in particular the mere
+             * fact that a save happened does not: `needsFields` asks "is the
+             * stored value this person's", and only an operator can answer it.
+             *
+             * Built from `input`, NOT from the diff: an operator who retypes the
+             * value that is already stored has still confirmed it, and a diff
+             * would report no change and drop the confirmation on the floor.
+             */
+            const acted = new Set<string>(input.confirmFields ?? []);
+            if (input.displayName !== undefined) acted.add("displayName");
+            if (input.telegramHandle !== undefined) acted.add("telegramHandle");
+            if (input.block !== undefined) acted.add("block");
+            if (input.matric !== undefined) acted.add("matric");
+
+            const remaining = live.needsFields.filter(
+              (f) => stillGapped.has(f) || !known.has(f) || !acted.has(f),
+            );
+            if (remaining.length !== live.needsFields.length) {
+              await ctx.db.profileCompletion.update({
+                where: { userID: cid },
+                data: {
+                  needsFields: remaining,
+                  ...(remaining.length === 0 ? { resolvedAt: new Date() } : {}),
+                },
+              });
+              completionLine = `profileCompletion: [${live.needsFields.join(",")}] → ${
+                remaining.length === 0 ? "resolved" : `[${remaining.join(",")}]`
+              }`;
+            }
+          }
+        } catch {
+          completionLine = "profileCompletion step FAILED — row left unchanged";
+        }
+      }
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles,
+        // `?? undefined`, NEVER `?? ""`. writeAudit stores undefined as a
+        // literal null; "" would be an absent identity recorded as a real one,
+        // and every later filter on targetUserID would match it (the sentinel
+        // rule). For a non-NUS account the email in `reason` is the only
+        // identification the row can carry, which is why it is always included.
+        targetUserID: cid ?? undefined,
+        action: "user.profile.update",
+        // No rolesBefore / rolesAfter: no role changed. Leaving them empty is
+        // the true statement; filling them with the current set would make the
+        // audit surface read as though this endpoint touched roles.
+        reason: truncate(
+          [
+            target.email,
+            changes.length ? changes.join("; ") : "no field changed",
+            completionLine,
+            input.reason ? `— ${input.reason}` : "",
+          ]
+            .filter(Boolean)
+            .join(" | "),
+        ),
+      });
+
+      // `matricWritten`, NOT `matric`: it is null when the field was not
+      // submitted, which is NOT the same statement as "this account has no
+      // matric". A field named `matric` returning null on an unrelated save
+      // would be merged into the cached record and blank a matric that is
+      // still there. The dialog invalidates `userAdmin.get` for the truth.
+      return { ...updated, matricWritten: input.matric ?? null };
+    }),
+
+  /**
+   * PREFLIGHT for the delete: what it would destroy, and every reason it would
+   * refuse — as DATA.
+   *
+   * WRITES NO AUDIT ROW. A preview is not an attempt; emitting denial rows for
+   * a hypothetical is the inverse of I-15 and is the reason `DryRunDenied`
+   * exists on the bulk path. `computeDeleteRefusals` is the SAME implementation
+   * the mutation runs, shared rather than mirrored — two copies of a refusal
+   * list is how the preview starts saying yes to something the mutation
+   * refuses.
+   *
+   * Gated on `deleteUsers` (admin only) rather than `manageUserProfiles`, so a
+   * jcrc gets FORBIDDEN instead of a detailed footprint of an account they
+   * could never delete.
+   */
+  getDeletionImpact: roleManagerProcedure
+    .input(targetSchema)
+    .query(async ({ ctx, input }) => {
+      const actorUserID = ctx.session.user.userID;
+      const actorRoles = await getUserRoles(ctx.db, actorUserID); // I-5
+      requireCapability(caps(actorRoles), "deleteUsers");
+
+      const target = await loadAdminUserTarget(ctx.db, input.userObjectId);
+      await assertMayManageUserProfileOf(
+        ctx.db,
+        actorUserID,
+        actorRoles,
+        target,
+        writeAudit,
+      );
+
+      const [footprint, refusals, enabled] = await Promise.all([
+        countUserFootprint(ctx.db, target),
+        computeDeleteRefusals(ctx.db, actorUserID, target),
+        // The switch state ships WITH the payload, the ccaAdmin.listAll
+        // pattern, so the dialog can disable its button without a second round
+        // trip and without the default-off flag reading as a broken button. The
+        // mutation asserts it again — a disabled control is cosmetic, the
+        // procedure is the boundary.
+        isUserDeleteEnabled(ctx.db),
+      ]);
+
+      return {
+        enabled,
+        email: target.email,
+        canonicalUserID: target.canonicalUserID,
+        counts: footprint.counts,
+        headOfCcaIDs: footprint.headOfCcaIDs,
+        /**
+         * Bookings of theirs the cascade KEEPS, because a published event or a
+         * live interview slot is standing on them. Rendered under "what
+         * survives", never added to `counts.bookings` — the destroyed count
+         * must be exactly what will be destroyed.
+         */
+        retainedBookings: footprint.retainedBookings,
+        refusals,
+      };
+    }),
+
+  /**
+   * DELETE an account and everything keyed on its canonical identity.
+   *
+   * THE ONLY IRREVERSIBLE WRITE IN THE ADMIN SURFACE. Admin-only
+   * (`deleteUsers`), and additionally behind the default-off
+   * `admin.userDelete.enabled` SystemFlag.
+   *
+   * THIS IS THE ONLY PATH IN THE APP THAT REMOVES A `UserRole` DOCUMENT, and it
+   * is still NOT a second writer of `UserRole.roles` (I-14 / I-8c): it writes no
+   * role set at all. The document is removed WHOLE, in the same transaction as
+   * the CcaHead rows, so CH-1 ("holds the cca_head string IFF >= 1 CcaHead
+   * row") holds vacuously afterwards — no string, no rows.
+   *
+   * ORDER OF OPERATIONS BELOW IS LOAD-BEARING. Read the letters.
+   */
+  delete: roleManagerProcedure
+    .input(
+      z
+        .object({
+          userObjectId: objectIdSchema,
+          /** Typed by the operator; compared to the STORED email server-side. */
+          confirmEmail: z.string().trim().min(1),
+          reason: z.string().trim().max(REASON_MAX).optional(),
+        })
+        .strict(),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // (a) THE KILL SWITCH, FIRST — before the capability check, before the
+      // load, before anything. The page-level check is cosmetic; this is the
+      // boundary. It fails CLOSED on an unreachable flag.
+      await assertUserDeleteEnabled(ctx.db);
+
+      // (b) I-5 live re-read of the ACTOR's roles, then the capability.
+      const actorUserID = ctx.session.user.userID;
+      const actorRoles = await getUserRoles(ctx.db, actorUserID);
+      requireCapability(caps(actorRoles), "deleteUsers");
+
+      // (c) Resolve the target and apply G3. Audits its own denial.
+      const target = await loadAdminUserTarget(ctx.db, input.userObjectId);
+      await assertMayManageUserProfileOf(
+        ctx.db,
+        actorUserID,
+        actorRoles,
+        target,
+        writeAudit,
+      );
+
+      const cid = target.canonicalUserID;
+
+      // (d) The typed-email confirmation, CHECKED ON THE SERVER against the
+      // stored address. A `confirmed: true` boolean from the client is not
+      // evidence — the same reasoning the bulk plan tokens are built on. The
+      // client's own comparison is a courtesy; this one is the control.
+      // Case-insensitive because the operator reads the address off a table
+      // that may render it in any case, and email localparts are treated
+      // case-insensitively everywhere else in this codebase.
+      if (
+        input.confirmEmail.trim().toLowerCase() !==
+        target.email.trim().toLowerCase()
+      ) {
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: cid ?? undefined,
+          action: "denied",
+          ok: false,
+          denyReason: "CONFIRM_EMAIL_MISMATCH",
+          reason: truncate(`user delete: ${target.email}`),
+        });
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "CONFIRM_EMAIL_MISMATCH",
+        });
+      }
+
+      // (e) The refusal set. ONE denial row for the whole set rather than one
+      // per reason, so the audit surface shows one refused attempt, not four.
+      const refusals = await computeDeleteRefusals(ctx.db, actorUserID, target);
+      if (refusals.length > 0) {
+        const joined = refusals.join("+");
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: cid ?? undefined,
+          action: "denied",
+          ok: false,
+          denyReason: truncate(joined),
+          reason: truncate(`user delete: ${target.email}`),
+        });
+        throw new TRPCError({ code: "PRECONDITION_FAILED", message: joined });
+      }
+
+      // (f) CAPTURE THE BEFORE-IMAGE. After the cascade there is nothing left
+      // to read: the audit row is the only surviving record of this account,
+      // and `rolesBefore` is the record of what privilege the delete destroyed.
+      // Read here rather than inside the cascade because writeAudit runs
+      // outside the transaction and cannot see anything the transaction held.
+      const [rolesBefore, footprint] = await Promise.all([
+        cid ? getUserRoles(ctx.db, cid) : Promise.resolve([] as string[]),
+        countUserFootprint(ctx.db, target),
+      ]);
+
+      // (g) The cascade. batchId is minted here, so the denial row a failed
+      // commit writes and the success row a good one writes are findable under
+      // the same batch — the two-sided pattern grantCcaHead / transferCcaHead
+      // established.
+      const batchId = randomUUID();
+      let result: { deleted: Record<string, number>; retainedBookings: number };
+      try {
+        result = await deleteUserAccountCascade(ctx.db, target, actorUserID);
+      } catch (err) {
+        // The transaction rolled back, so NOTHING was destroyed. What this row
+        // records is that an attempt reached commit and lost a race: the
+        // in-transaction re-checks (sole head of a CCA, target granted admin,
+        // actor deleting themselves) re-evaluate state that the preflight read
+        // seconds earlier in OPERATOR time. Written on ctx.db, AFTER the
+        // rollback (I-15) — a row written inside would have been rolled back by
+        // the very failure it documents.
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: cid ?? undefined,
+          action: "denied",
+          ok: false,
+          denyReason:
+            err instanceof TRPCError ? truncate(err.message) : "CASCADE_FAILED",
+          reason: truncate(`user delete: ${target.email}`),
+          batchId,
+        });
+        throw err;
+      }
+
+      // (h) The success row. OUTSIDE the transaction (I-15) and AFTER it: an
+      // audit row written inside would be rolled back by the very failure it
+      // documents. This row deliberately OUTLIVES its subject — RoleAuditLog is
+      // append-only by code contract and the cascade does not touch it.
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles,
+        targetUserID: cid ?? undefined,
+        action: "user.delete",
+        rolesBefore,
+        // Empty because the role document is gone, not because no role was
+        // held. `rolesBefore` above is where the destroyed privilege is
+        // recorded; the pair reads as "held these, now holds nothing".
+        rolesAfter: [],
+        batchId,
+        reason: truncate(
+          [
+            target.email,
+            cid ? `id ${cid}` : "no canonical id",
+            Object.entries(result.deleted)
+              .filter(([, n]) => n > 0)
+              .map(([k, n]) => `${k}=${n}`)
+              .join(","),
+            // Named on the row because it is the one place the cascade did NOT
+            // do what "delete everything of theirs" would suggest, and the
+            // audit row is the only surviving record of the account.
+            result.retainedBookings > 0
+              ? `kept ${result.retainedBookings} booking(s) held for a CCA record`
+              : "",
+            input.reason ? `— ${input.reason}` : "",
+          ]
+            .filter(Boolean)
+            .join(" | "),
+        ),
+      });
+
+      return {
+        deleted: result.deleted,
+        // The preflight counts as the operator last saw them, echoed back so
+        // the dialog can report what went without re-querying a user that no
+        // longer exists.
+        footprint: footprint.counts,
+        email: target.email,
+      };
+    }),
+});

--- a/src/server/api/services/cascade.ts
+++ b/src/server/api/services/cascade.ts
@@ -54,6 +54,25 @@ export async function deleteCcaCascade(db: PrismaClient, ccaID: number) {
   });
 }
 
+/**
+ * NOT THE ACCOUNT-DELETION PATH. /admin/users deletes through
+ * `deleteUserAccountCascade` in services/userAdmin.ts.
+ *
+ * This one keys the final delete on the STORED `User.userID` column — a column
+ * holding an A-format matric on ~515 rows and, on the split-identity rows,
+ * ANOTHER LIVE HUMAN'S canonical key — and `user.deleteMany` on a non-unique
+ * scalar can therefore match TWO people. It also leaves UserRole, CcaHead,
+ * UserMatric, ProfileCompletion, CcaApplication and PendingRoleGrant behind; an
+ * orphaned UserRole is inherited by whoever next signs in on that address
+ * (05-verification.md §613) and an orphaned CcaHead keeps a dead `cca_head`
+ * string alive forever (GUARD 2 above).
+ *
+ * See scripts/remediation/fix-claresta-duplicate.mjs and fix-lgd-duplicate.mjs,
+ * both of which carry banner comments refusing to call it for exactly that
+ * reason. It has NO CALLER in src/ and is kept, unchanged, only so those
+ * scripts' warnings still name a real function. Do not "fix" it in place — that
+ * would make four scripts' documented reasoning wrong.
+ */
 export async function deleteUserCascade(db: PrismaClient, userID: string) {
   return db.$transaction(async (tx) => {
     await tx.bookings.deleteMany({ where: { userID } });

--- a/src/server/api/services/profile.ts
+++ b/src/server/api/services/profile.ts
@@ -1,0 +1,158 @@
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * THE shared profile writers.
+ *
+ * WHY THIS FILE EXISTS. These three functions lived in
+ * `src/server/api/routers/user.ts` and were MOVED here — not copied — when the
+ * admin user-detail surface (`routers/userAdmin.ts`) gained the ability to edit
+ * someone else's profile. `writeMatric`'s own comment already states the rule:
+ * a second upsert is a second chance to key a matric on the Mongo `_id` instead
+ * of the canonical `userID`, which is the mis-keying that produced the duplicate
+ * rows the remediation scripts exist to clean up after. An admin matric writer
+ * copied into a second router IS that second chance.
+ *
+ * `CLEAR_MODE` is here for the same reason from the other direction: it encodes
+ * an OPEN branch decision (D-5) whose resolution must remain a one-line flip in
+ * exactly one file.
+ *
+ * SERVER-ONLY BY DESIGN. It imports `@trpc/server` and takes a `PrismaClient`,
+ * so — unlike `src/lib/schemas/profile.ts`, which the client value-imports for
+ * its mirrored `safeParse` — nothing under `src/app/**` may import this. The
+ * split between the two files is that one: VALIDATORS in src/lib (shared with
+ * the browser), WRITERS here.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* D-5: how a cleared optional String is persisted                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * OPEN QUESTION — the user must run the step-0 $jsonSchema dump before this is
+ * settled. The `User` collection is $jsonSchema-guarded, and `String?` in the
+ * Prisma schema means "optional/absent", NOT "null-accepting": Prisma infers
+ * nullability from a missing key, not from the validator. No existing write path
+ * has ever produced a null here (register/route.ts writes concrete values after
+ * a presence check; the old updateUserData always wrote strings), so the
+ * validator may well declare `bsonType: "string"` and reject the first
+ * "clear my handle" save at the database.
+ *
+ * Until the dump is read, clearing is routed through this ONE helper so the
+ * answer is a one-line flip rather than a hunt:
+ *
+ *   Branch A — bsonType is an array including "null"  ->  CLEAR_MODE = "null"
+ *   Branch B — bsonType excludes null (bare "string") ->  CLEAR_MODE = "unset"
+ *   Branch C — the field is in the validator's `required` array -> it cannot be
+ *              cleared at all; make it required in updateProfileInput with
+ *              `.refine((v) => v !== "")` and drop the clear affordance from the
+ *              modal, rather than shipping a UI control that always errors.
+ *
+ * "unset" is the SAFE-UNDER-BOTH default and is why it is selected here: Prisma
+ * Mongo's `{ unset: true }` removes the key, which every branch-A validator also
+ * accepts (an optional field is satisfied by absence), whereas writing `null`
+ * under branch B is rejected. Reads are identical either way — an absent key
+ * deserialises as `null` — so no client code depends on this choice.
+ *
+ * If the dump comes back branch A and you prefer a literal null on disk, flip
+ * the constant. If it comes back branch C, take the branch-C action above; this
+ * helper cannot save you there, because the write itself is illegal.
+ *
+ * Both the resident's own edit (user.updateUserData) and the admin edit
+ * (userAdmin.updateProfile) route through here, so the branch flip stays a
+ * one-line change.
+ *
+ * scripts/remediation/normalize-telegram-handles.mjs makes the SAME decision and
+ * must be flipped in the same commit ($unset vs $set: null).
+ */
+const CLEAR_MODE: "null" | "unset" = "unset";
+
+type ClearableString = string | null | { unset: true };
+
+/** "" from the shared schema means "clear it"; anything else is a literal set. */
+export function clearable(value: string): ClearableString {
+  if (value !== "") return value;
+  return CLEAR_MODE === "unset" ? { unset: true } : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* THE matric writer                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The ONE path that writes UserMatric. `user.setMatric` (the matric onboarding
+ * page), `user.completeProfile` (the post-merge form) and
+ * `userAdmin.updateProfile` (an admin correcting someone's record) all go
+ * through here, so there is exactly one place that decides how a matric is keyed
+ * and persisted.
+ *
+ * Extracted rather than copied: a second upsert would be a second chance to key
+ * it on `session.user.id` (the Mongo _id) instead of the canonical `userID`,
+ * which is the mis-keying that produced the duplicate rows this whole feature
+ * exists to clean up after. The admin path makes that hazard sharper, not
+ * softer — there the "obvious" key is the `User.id` the operator clicked, and
+ * `User.userID` holds an A-format matric on ~515 rows. The `userID` parameter is
+ * typed non-null, so the ""-key hazard (I-8d) cannot reach this function without
+ * a caller's guard having run first — callers guard, this function assumes.
+ */
+export async function writeMatric(
+  db: PrismaClient,
+  userID: string,
+  matric: string,
+): Promise<string> {
+  const record = await db.userMatric.upsert({
+    where: { userID },
+    create: { userID, matric },
+    update: { matric },
+  });
+  return record.matric;
+}
+
+/**
+ * Refuse a matric that a DIFFERENT canonical userID already holds.
+ *
+ * Why this is a check and not a `@unique` index: `UserMatric.matric` is
+ * deliberately non-unique in schema.prisma because the legacy data ALREADY
+ * contains duplicate matrics, and bulk resolution needs to READ those rows and
+ * report them as AMBIGUOUS rather than have the database refuse to hold them.
+ * Adding a unique index would break that remediation path (and could not be
+ * created against the live collection anyway while the duplicates exist).
+ *
+ * But "we must be able to read pre-existing duplicates" is not "a user may
+ * newly claim someone else's number". Matric is an identity key in the bulk
+ * import: if two accounts hold one matric, an import row can resolve to the
+ * wrong person, which is an impersonation primitive, not a display bug. So the
+ * WRITE path refuses new collisions while the SCHEMA stays permissive enough to
+ * represent the old ones.
+ *
+ * This is a read-then-write check and is therefore TOCTOU-racy in principle;
+ * two users would have to submit the same matric within the same few
+ * milliseconds to slip through, and the result is the pre-existing AMBIGUOUS
+ * state that bulk resolution already handles rather than a new failure mode.
+ *
+ * Applied in `user.setMatric` (self-service), in `user.completeProfile`, and in
+ * `userAdmin.updateProfile` (an admin writing on someone's behalf must not be
+ * the softer door).
+ *
+ * The message is deliberately worded for a RESIDENT, because that is who reads
+ * it on two of the three paths. The admin UI maps the CONFLICT code to its own
+ * copy rather than re-wording the server — do not change this string.
+ */
+export async function assertMatricUnclaimed(
+  db: PrismaClient,
+  userID: string,
+  matric: string,
+): Promise<void> {
+  const claimedByAnother = await db.userMatric.findFirst({
+    where: { matric, userID: { not: userID } },
+    select: { id: true },
+  });
+
+  if (claimedByAnother) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message:
+        "That matriculation number is already registered to another account. If you think that is wrong, contact the JCRC.",
+    });
+  }
+}

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -151,6 +151,30 @@ export const AUDIT_ACTIONS = [
   "event.publish",
   "event.cancel",
   "event.attendees.export",
+  // Admin CRUD over USER DETAILS (/admin/users detail dialog). NOTE what is
+  // absent: no "user.create" (signup + PendingRoleGrant own onboarding) and no
+  // role action — these endpoints are NOT a second writer of UserRole.roles
+  // (I-14). `user.delete` REMOVES the whole UserRole document rather than
+  // writing a role set, and its row carries the deleted user's rolesBefore so
+  // the privilege that was destroyed stays on the record.
+  //
+  // `user.detail.read` is the ONLY read in this list, and it is here for the
+  // same reason `explainAccess` audits: it is a per-target disclosure primitive
+  // over the whole user base, reachable by every jcrc. `userAdmin.get` returns
+  // matric, telegramHandle and bio — none of which is in the listUsers
+  // projection — so a loop over the ids listUsers already hands out exfiltrates
+  // the hall's matriculation numbers and Telegram handles. The target guard
+  // audits only DENIALS (target holds admin / unkeyed row), so without this row
+  // every successful read of a non-admin is silent and an admin investigating a
+  // leak cannot say who read what, or that a bulk read happened at all. The
+  // same PII exported in bulk is already audited by `event.attendees.export`.
+  //
+  // All three names are under the 32-character cap that admin.listAuditLog's
+  // `action: z.string().max(32)` filter imposes — keep any future addition
+  // under it too, or the filter silently cannot select it.
+  "user.detail.read",
+  "user.profile.update",
+  "user.delete",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
@@ -792,7 +816,20 @@ export type Capabilities = {
    * Deliberately NOT a licence to delete: no surface deletes a CCA.
    */
   manageCcas: boolean;
-  /** May act on a user who holds `admin` at all. D-2: admin only. */
+  /**
+   * May act on a user who holds `admin` at all. D-2: admin only.
+   *
+   * ALSO covers a target whose authority cannot be EVALUATED, which is the same
+   * question asked of a row this deploy cannot key: an account with no canonical
+   * id may still carry a pre-cutover `UserRole` holding `admin`, filed under the
+   * unanchored derivation auth.ts used before the eligibility cutover. That is
+   * why assertMayManageUserProfileOf refuses every non-admin actor on such a
+   * target (CANNOT_MODIFY_AN_UNKEYED_ACCOUNT) — read that function for the full
+   * argument — and why UserRoleTable disables its Details button on this
+   * capability for those rows rather than letting a jcrc click into a FORBIDDEN
+   * that also writes a `denied` audit row. One tier, one statement: unevaluable
+   * authority is treated as admin authority.
+   */
   modifyAdmins: boolean;
   /** May see WHO holds admin (counts and identities). D-2: admin only. */
   seeAdminIdentities: boolean;
@@ -812,6 +849,30 @@ export type Capabilities = {
    * assertHeadsCca, not this.
    */
   reviewEvents: boolean;
+  /**
+   * May open a user's detail record and EDIT their profile fields
+   * (displayName / block / telegramHandle / bio / matric). Manager-level:
+   * fixing a resident's onboarding data is JCRC work. It is NOT a licence to
+   * reach any target — assertMayManageUserProfileOf (G3) is applied by EVERY
+   * procedure in routers/userAdmin.ts, the `get` read included, so a jcrc
+   * cannot open an admin's record. That read carries matric, telegramHandle
+   * and bio, none of which is in the listUsers projection, which is why the
+   * guard is on the read and not only on the writes; the enumeration cost that
+   * buys, and why it was accepted, is argued once on
+   * assertMayManageUserProfileOf. Do not restate it here — and do not describe
+   * this capability's reach from memory, read that function.
+   *
+   * Deliberately NOT a role-editing capability: roles stay behind
+   * setUserRoles / grantCcaHead and their own guards.
+   */
+  manageUserProfiles: boolean;
+  /**
+   * May DELETE an account. Admin only, and additionally behind the
+   * admin.userDelete.enabled kill switch checked in the procedure. Joins
+   * manageFacilityAccess / readAuditLog / manageCcas in the admin-only tier
+   * because it is the only irreversible write in the admin surface.
+   */
+  deleteUsers: boolean;
 };
 
 export function computeCapabilities(roles: readonly string[]): Capabilities {
@@ -842,5 +903,7 @@ export function computeCapabilities(roles: readonly string[]): Capabilities {
     viewSystemHealthDetail: admin,
     manageEnforcementFlag: admin,
     reviewEvents: manager,
+    manageUserProfiles: manager,
+    deleteUsers: admin,
   };
 }

--- a/src/server/api/services/userAdmin.ts
+++ b/src/server/api/services/userAdmin.ts
@@ -1,0 +1,1185 @@
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+import { canonicalUserID, type CanonicalUserID } from "~/lib/identity";
+import { getUserRoles } from "./access";
+import { ADMIN_ROLE } from "./roles";
+
+/**
+ * SERVICE LAYER for admin CRUD over USER DETAILS (/admin/users detail dialog).
+ *
+ * Everything here is keyed on the `User` ObjectId the operator clicked, and the
+ * canonical identity is DERIVED server-side from the stored email. There is no
+ * client-supplied userID anywhere in this file, on purpose:
+ *
+ *   `User.userID` IS NOT THE IDENTITY. It holds an A-format matric on ~515 rows
+ *   and, on the split-identity rows, ANOTHER LIVE HUMAN'S canonical key —
+ *   scripts/remediation/fix-claresta-duplicate.mjs documents an account whose
+ *   stored userID is E1156816, which is a different person's key. Keying a
+ *   cascade on that column is how you delete a stranger's 25 bookings.
+ *
+ * The same pattern services/ccaMembers.ts already establishes for
+ * `removeCcaMember`: the caller hands us the User.id the table deduped on, and
+ * we recompute the key set from the User document.
+ *
+ * ROLES ARE NOT WRITTEN HERE. `deleteUserAccountCascade` REMOVES the whole
+ * `UserRole` document; it never writes a role set, so I-14 ("cca_head is
+ * written only by the CCA path") and I-8c ("resident cannot be stripped by a
+ * role write") are untouched — there is no role write to get wrong.
+ *
+ * NO AUDIT ROW IS WRITTEN FROM THIS FILE except by the target guard, which
+ * takes its writer as a PARAMETER (see AuditWriter below). Every other audit
+ * row is the router's job, AFTER the transaction returns (I-15).
+ */
+
+/* ========================================================================== */
+/* 1. THE KILL SWITCH                                                         */
+/* ========================================================================== */
+
+/**
+ * `admin.userDelete.enabled` -> "on" | anything else.
+ *
+ * Same shape and the same reasoning as `cca.management.enabled` in ccaScope.ts,
+ * and DIFFERENT from the three enforcement switches in access.ts. Those gate
+ * whether NEW enforcement applies to an EXISTING path, so they fail OPEN —
+ * "behave as the app did yesterday". Behave as yesterday for a surface that did
+ * not exist yesterday means DISABLED. An absent row and an unreachable flag both
+ * return false.
+ *
+ * This is the only irreversible write in the admin surface, against a
+ * production database of ~1382 real accounts, and the SystemFlag row is the only
+ * brake that does not need a Vercel redeploy (env vars are snapshotted per
+ * deployment — see the SystemFlag model comment). To arm the feature:
+ *   db.systemFlag.upsert({ where: { key: "admin.userDelete.enabled" },
+ *     create: { key: "admin.userDelete.enabled", value: "on" },
+ *     update: { value: "on" } })
+ * It takes effect within FLAG_TTL_MS on each lambda; no redeploy.
+ */
+const DELETE_FLAG_KEY = "admin.userDelete.enabled";
+const FLAG_TTL_MS = 15_000;
+
+let deleteFlagCache: { at: number; on: boolean } | null = null;
+
+export async function isUserDeleteEnabled(db: PrismaClient): Promise<boolean> {
+  if (deleteFlagCache && Date.now() - deleteFlagCache.at < FLAG_TTL_MS) {
+    return deleteFlagCache.on;
+  }
+  try {
+    const row = await db.systemFlag.findUnique({
+      where: { key: DELETE_FLAG_KEY },
+    });
+    const on = row?.value === "on";
+    deleteFlagCache = { at: Date.now(), on };
+    return on;
+  } catch {
+    // Fail CLOSED, and deliberately NOT cached — the next request retries
+    // rather than pinning "disabled" for 15s on a transient Atlas hiccup.
+    return false;
+  }
+}
+
+/** Test/ops seam: drop the per-lambda cache so the next read hits the row. */
+export function resetUserDeleteCache(): void {
+  deleteFlagCache = null;
+}
+
+/**
+ * Assert the switch is on. Called at the TOP of the delete mutation, before
+ * anything else — the page-level check is cosmetic, this one is the boundary.
+ */
+export async function assertUserDeleteEnabled(db: PrismaClient): Promise<void> {
+  if (!(await isUserDeleteEnabled(db))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "USER_DELETE_DISABLED",
+    });
+  }
+}
+
+/* ========================================================================== */
+/* 2. THE RESOLVED TARGET                                                     */
+/* ========================================================================== */
+
+/**
+ * One user, resolved from an ObjectId. This is the ONLY way any procedure in
+ * the admin user-detail surface learns who it is acting on.
+ */
+export type AdminUserTarget = {
+  userObjectId: string;
+  email: string;
+  /** DERIVED from the email, never client-supplied. null for a non-NUS row. */
+  canonicalUserID: CanonicalUserID | null;
+  /** The STORED legacy column. Display + mismatch detection ONLY. */
+  legacyUserID: string | null;
+  displayName: string | null;
+  telegramHandle: string | null;
+  bio: string | null;
+  block: number | null;
+};
+
+/**
+ * Load the target by `User._id`.
+ *
+ * THE SELECT IS A SECURITY CONTROL, not tidiness — the same one
+ * user.getCurrentUserData carries. #9: passwordHash must never reach the client
+ * or the React Query cache. I-2: schema.prisma declares passwordHash optional
+ * precisely because PrismaAdapter-created (Google) rows may lack it, and Prisma
+ * 6's Mongo connector throws when it deserializes a document missing a required
+ * non-list scalar — an explicit select keeps this path off the field entirely.
+ * Never replace this with a bare `findUnique`.
+ */
+export async function loadAdminUserTarget(
+  db: PrismaClient,
+  userObjectId: string,
+): Promise<AdminUserTarget> {
+  const row = await db.user.findUnique({
+    where: { id: userObjectId },
+    select: {
+      id: true,
+      email: true,
+      userID: true,
+      displayName: true,
+      telegramHandle: true,
+      bio: true,
+      block: true,
+    },
+  });
+
+  if (!row) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_USER" });
+  }
+
+  return {
+    userObjectId: row.id,
+    email: row.email,
+    // I-1. Derived here and nowhere else. `row.userID` is NOT consulted for
+    // this — it is carried alongside, for display and for the mismatch check.
+    canonicalUserID: canonicalUserID(row.email),
+    legacyUserID: row.userID,
+    displayName: row.displayName,
+    telegramHandle: row.telegramHandle,
+    bio: row.bio,
+    block: row.block,
+  };
+}
+
+/* ========================================================================== */
+/* 3. THE TARGET GUARD — G3 restated for this path                            */
+/* ========================================================================== */
+
+/**
+ * The audit entry shape this module needs. Structurally a subset of admin.ts's
+ * `AuditEntry`, so `writeAudit` is directly assignable to `AuditWriter`.
+ *
+ * NOTE `targetUserID?: string` — NOT `string | null`. The absent identity must
+ * be spent as `undefined` (which writeAudit turns into a stored null), never as
+ * `""`. That is the sentinel bug class, and the type is what stops it here.
+ */
+export type AdminAuditEntry = {
+  actorUserID: string;
+  actorRoles?: string[];
+  targetUserID?: string;
+  action: string;
+  rolesBefore?: string[];
+  rolesAfter?: string[];
+  reason?: string;
+  ok?: boolean;
+  denyReason?: string;
+  batchId?: string;
+};
+
+/**
+ * The audit writer, INJECTED rather than imported.
+ *
+ * `writeAudit` lives in routers/admin.ts, which pulls in `node:crypto` and
+ * `~/env`. ccaAdmin.ts imports it across that boundary and that is acceptable;
+ * this module takes it as a parameter instead, deliberately, so that
+ * `services/` never depends on `routers/` — the same reason redeemPendingGrants
+ * keeps its own local writer. Pick one per module and say which; this one is
+ * injection.
+ */
+export type AuditWriter = (
+  db: PrismaClient,
+  entry: AdminAuditEntry,
+) => Promise<void>;
+
+/**
+ * G3 for the user-detail path. The generic role guards are not reachable from
+ * here, so the target guard is re-stated: a jcrc must not be able to reach an
+ * admin's document through the profile-edit endpoints either.
+ *
+ * APPLIED ON EVERY PROCEDURE IN THIS SURFACE, READ INCLUDED — `get`,
+ * `updateProfile`, `getDeletionImpact`, `delete`.
+ *
+ * `get` was exempt at first, to avoid an admin-enumeration oracle: for a target
+ * WITH a canonical id this guard denies if and only if that target holds admin,
+ * so one click per table row separates the admins from everyone else — the exact
+ * enumeration D-2's
+ * `listUsers` redaction (routers/admin.ts, "a jcrc must not be handed an
+ * enumeration of who holds admin") goes to the trouble of hiding, and each probe
+ * writes a `denied` row on the highest-signal action this system records.
+ *
+ * That reasoning was real, but it bought the wrong thing. `get` returns matric,
+ * telegramHandle, bio and the profile gaps, and NONE of those is in the
+ * `listUsers` projection — so leaving the read open handed every jcrc any
+ * admin's matriculation number and contact handle. Redaction does not rescue it
+ * either: blanking exactly those fields for admin targets IS the same oracle one
+ * field over, and blanking them for all targets would remove the data the
+ * surface exists to repair.
+ *
+ * So the enumeration is the ACCEPTED cost, and it is the cheaper of the two: it
+ * was already reachable by attempting one SAVE per row (the write-shaped oracle
+ * the house accepts in assertMayManageCcaHeadOf and deletePendingGrant), the
+ * `denied` rows make a jcrc paging the table visible rather than silent, and
+ * "a jcrc must never reach an admin's document" is the stated rule for this
+ * surface. `get` still applies D-2's `admin` redaction on top, so a manager
+ * reading a NON-admin's record still never learns who else holds admin.
+ *
+ * THERE ARE TWO DENIALS, not one. `CANNOT_MODIFY_AN_ADMIN` is the target-holds-
+ * admin case above; `CANNOT_MODIFY_AN_UNKEYED_ACCOUNT` refuses a non-admin actor
+ * on a target with no canonical id at all, where the target's authority cannot be
+ * evaluated in either direction. The full argument is on the branch itself. That
+ * second denial adds NO oracle: the address is already in the table's email
+ * column, so a jcrc can see which rows are not @u.nus.edu without clicking.
+ *
+ * Modelled on assertMayManageCcaHeadOf (routers/admin.ts). Denials are audited
+ * on `db`, OUTSIDE any transaction (I-15) — a denial row written inside the
+ * transaction it is denying is rolled back by the throw, which erases exactly
+ * the event that most needs a trail.
+ *
+ * THERE IS DELIBERATELY NO E-FORMAT TEST HERE. `g.s_samuel@u.nus.edu` ->
+ * G.S_SAMUEL and `chuamingyuan@u.nus.edu` -> CHUAMINGYUAN are real accounts
+ * (L-27). E_FORMAT is a validation rule for GRANT TARGETS only (guard G7);
+ * applying it here would make those residents' records unreachable.
+ */
+export async function assertMayManageUserProfileOf(
+  db: PrismaClient,
+  actorUserID: string,
+  actorRoles: readonly string[],
+  target: AdminUserTarget,
+  writeAudit: AuditWriter,
+): Promise<void> {
+  const deny = async (reason: string): Promise<never> => {
+    await writeAudit(db, {
+      actorUserID,
+      actorRoles: [...actorRoles],
+      // undefined, never "" — see AdminAuditEntry.
+      targetUserID: target.canonicalUserID ?? undefined,
+      action: "denied",
+      ok: false,
+      denyReason: reason,
+      reason: `user detail: ${target.email}`,
+    });
+    throw new TRPCError({ code: "FORBIDDEN", message: reason });
+  };
+
+  /* ---- NO CANONICAL ID: ADMIN ONLY, and this branch used to PASS -------------
+   * It passed on the premise that "an account with no canonical id holds NO
+   * stored roles by construction — UserRole is canonical-keyed, so there is no
+   * key under which such a row could have been written". THAT PREMISE IS FALSE,
+   * and it is refuted by the ABSENT_CANONICAL_ID note in this very file: before
+   * the eligibility cutover src/server/auth.ts derived a key from ANY address
+   * with an unanchored replace, so `alice@gmail.com` became "ALICE@GMAIL.COM",
+   * and rows written in that era are still filed under it. `UserRole` is in
+   * rbac-doctor.mjs's OWNED_BY_USERID list precisely so `--nonnus` can enumerate
+   * them. So a cid-less row CAN carry a `UserRole` holding `admin` — under a key
+   * this deploy can no longer derive.
+   *
+   * IT IS UNEVALUABLE AUTHORITY, NOT ABSENT AUTHORITY, and the two get opposite
+   * treatment. `getUserRoles` keys on the canonical id, so such a string is inert
+   * everywhere in the live app and no privilege is reachable through it — but
+   * "this account's roles cannot be read" is not a licence for a lesser role to
+   * open its record. `get` returns matric, telegramHandle and bio (none of which
+   * is in the listUsers projection) and `updateProfile` rewrites the displayName
+   * that renders to other users on every booking listing. The stated rule for
+   * this surface is that a jcrc never reaches a document whose authority they
+   * cannot be shown not to hold; failing OPEN on the one population whose
+   * authority cannot be evaluated at all inverts it.
+   *
+   * SO: admin passes, everyone else is denied and audited. The refusal is worth
+   * the friction — these accounts are among the messiest in the collection, and
+   * the edit form is nearly inert for them anyway (matric disabled, WALL 1
+   * suppressed, "correcting the address needs a developer"), while `delete`
+   * already refuses every one of them with ABSENT_CANONICAL_ID.
+   *
+   * STILL NO `getUserRoles(db, null)`. The decision is made from the actor's
+   * roles alone, so no absent id reaches a `where: { userID }` clause — the
+   * sentinel rule is intact, and getUserRoles' own `if (!userID) return []`
+   * remains a guard rather than a licence.
+   *
+   * NAMED `CANNOT_MODIFY_AN_UNKEYED_ACCOUNT`, not `NO_CANONICAL_IDENTITY`: that
+   * second string is already updateProfile's matric refusal in the client's
+   * shared error map (src/app/admin/_lib/userDetail.ts), and reusing it would
+   * print "this account has no matric record" as the reason a jcrc was refused
+   * the whole dialog. Same call ABSENT_CANONICAL_ID's own naming note makes.
+   */
+  if (target.canonicalUserID === null) {
+    if (!actorRoles.includes(ADMIN_ROLE)) {
+      await deny("CANNOT_MODIFY_AN_UNKEYED_ACCOUNT");
+    }
+    return;
+  }
+
+  if (!actorRoles.includes(ADMIN_ROLE)) {
+    // I-5: the TARGET's roles are re-read from the database, never taken from
+    // any session or from a list projection. A stale copy here is a jcrc
+    // reaching a freshly-promoted admin's record.
+    const targetRoles = await getUserRoles(db, target.canonicalUserID);
+    if (targetRoles.includes(ADMIN_ROLE)) await deny("CANNOT_MODIFY_AN_ADMIN");
+  }
+}
+
+/* ========================================================================== */
+/* 4. THE REFUSAL SET — one implementation, used by preview AND commit         */
+/* ========================================================================== */
+
+/**
+ * Why a delete is refused. Returned as DATA so the preview and the mutation can
+ * share ONE implementation; two copies of a refusal list is how the preview
+ * starts saying yes to something the mutation refuses.
+ */
+export type DeleteRefusal =
+  | "CANNOT_DELETE_SELF"
+  | "CANNOT_DELETE_AN_ADMIN"
+  | "ABSENT_CANONICAL_ID"
+  | "LEGACY_KEY_MISMATCH"
+  | "SHARED_CANONICAL_ID"
+  | `SOLE_HEAD_OF_CCA:${number}`;
+
+/**
+ * Every OTHER live `User` row whose email canonicalises to the same key.
+ *
+ * WHY THIS EXISTS — and why LEGACY_KEY_MISMATCH does not already cover it.
+ * That refusal proves the canonical key is COMPLETE for this row: nothing of
+ * theirs is filed under some other id. It does NOT prove the key is EXCLUSIVE
+ * to it, and the cascade needs BOTH. `deleteUserAccountCascade` removes ONE
+ * User document by `_id` but cleans thirteen collections with
+ * `deleteMany({ where: { userID: cid } })`. If a second User row canonicalises
+ * to the same cid, every one of those deleteManys takes the OTHER account's
+ * rows — its UserRole, its CcaHead scopes, its matric, its bookings — while its
+ * User row survives untouched. The survivor is then a LIVE account stripped of
+ * everything but a self-healed `resident` (auth.ts is explicit that `jcrc` and
+ * `cca_head` have no self-heal path: nothing puts them back), and because the
+ * rows were DELETED rather than orphaned, no orphan check afterwards can see
+ * that it happened. It is the same destruction LEGACY_KEY_MISMATCH exists to
+ * prevent, reached through a different door.
+ *
+ * THE POPULATION IS MEASURED, NOT HYPOTHETICAL. `email_unique_ci` folds CASE
+ * but not WHITESPACE, while `canonicalUserID` trims — so `"e0425010@u.nus.edu "`
+ * and `"e0425010@u.nus.edu"` are two rows to the index and ONE identity to the
+ * app. Neither trips LEGACY_KEY_MISMATCH, because that compares the STORED
+ * `User.userID` column against cid and on these rows it is null or already
+ * equal. scripts/remediation/merge-by-canonical.mjs exists to merge exactly
+ * these sets, and the 2026-07-19 census counted 66 of them.
+ *
+ * THE QUERY IS DELIBERATELY OVER-BROAD, THEN FILTERED IN MEMORY BY THE ONE
+ * DERIVATION. `contains` + `mode: "insensitive"` compiles to a regex on the
+ * Mongo connector, so a localpart containing `.` or `%` matches MORE rows than
+ * it should — which is safe, because `canonicalUserID` is the decider here and
+ * it is the same function the cascade keys on. Never narrow this to an equality
+ * on `${cid}@u.nus.edu`: the whitespace variant is precisely what it must catch.
+ */
+export async function findCanonicalIdCollisions(
+  db: Omit<PrismaClient, `$${string}`>,
+  cid: CanonicalUserID,
+  selfObjectId: string,
+): Promise<{ id: string; email: string }[]> {
+  const candidates = await db.user.findMany({
+    where: { email: { contains: cid, mode: "insensitive" } },
+    select: { id: true, email: true },
+  });
+  return candidates.filter(
+    (u) => u.id !== selfObjectId && canonicalUserID(u.email) === cid,
+  );
+}
+
+/**
+ * Compute every reason this account may not be deleted.
+ *
+ * NEVER AUDITS AND NEVER THROWS. It is called by the preview as well as by the
+ * mutation, and a preview must not emit denial rows for a hypothetical — the
+ * DryRunDenied precedent in routers/admin.ts. The mutation writes ONE denial row
+ * itself when this returns a non-empty list.
+ */
+export async function computeDeleteRefusals(
+  db: PrismaClient,
+  actorUserID: string,
+  target: AdminUserTarget,
+): Promise<DeleteRefusal[]> {
+  const out: DeleteRefusal[] = [];
+  const cid = target.canonicalUserID;
+
+  // --- there is no canonical key at all -------------------------------------
+  // THE SAME CLASS AS LEGACY_KEY_MISMATCH, one step further along: there the key
+  // is not provably COMPLETE, here there is no key to prove anything about.
+  // `canonicalUserID` returns null for every address that is not @u.nus.edu, and
+  // `deleteUserAccountCascade` therefore cleans NOTHING for such a row — every
+  // dependent delete sits inside `if (cid !== null)`, so the transaction removes
+  // the `User` document alone.
+  //
+  // "NO CANONICAL KEY" IS NOT THE SAME STATEMENT AS "OWNS NOTHING", and this
+  // function used to imply it was (see the corollary further down, and the
+  // preview panel that printed "Nothing else is attached to it" off the all-zero
+  // footprint). Before the eligibility cutover src/server/auth.ts derived a key
+  // from ANY address with an unanchored replace — `alice@gmail.com` became
+  // "ALICE@GMAIL.COM" — and rows written in that era are still filed under it.
+  // The population is real enough to have its own report:
+  // `node scripts/remediation/rbac-doctor.mjs --nonnus` step [2] exists to
+  // enumerate "rows owned under the legacy key" for exactly these accounts.
+  // Destroying the owning `User` row on top of them leaves Bookings holding
+  // facility slots on the calendar under a key no live account resolves to, which
+  // no user-facing cancel path can reach and no orphan sweep can attribute.
+  //
+  // COUNTING THEM INSTEAD OF REFUSING WAS THE OTHER OPTION, AND IT IS WORSE. It
+  // needs the pre-cutover derivation restated in src/ — a second identity
+  // derivation, which I-12 forbids and which
+  // scripts/remediation/verify-identity-parity.mjs enforces by sweeping
+  // src/**/*.ts for precisely that — and the cascade still could not clean what
+  // it found, so the blast-radius panel would be reporting rows that SURVIVE the
+  // delete. The remedy is the hand-audited script, same as LEGACY_KEY_MISMATCH.
+  //
+  // NAMED `ABSENT_CANONICAL_ID`, NOT `NO_CANONICAL_IDENTITY`. That second string
+  // is already in the client's shared error map (src/app/admin/_lib/userDetail.ts)
+  // as `updateProfile`'s matric refusal, and `friendlyError` serves BOTH dialogs —
+  // reusing it would print "this account has no matric record" as the reason a
+  // delete was refused.
+  if (cid === null) out.push("ABSENT_CANONICAL_ID");
+
+  // --- self -----------------------------------------------------------------
+  // Without this an admin can delete themselves straight out of the last-admin
+  // guard: that guard lives inside applyRoleChange's transaction and cannot see
+  // a deletion, and there is deliberately no in-app path to mint the first
+  // admin. (Subsumed by CANNOT_DELETE_AN_ADMIN for an admin actor, but stated
+  // separately so the UI can say "you can't delete your own account" and so it
+  // still holds if the capability tier is ever widened.)
+  if (cid !== null && cid === actorUserID) out.push("CANNOT_DELETE_SELF");
+
+  // --- the target holds admin ----------------------------------------------
+  // Applies to EVERY actor, admins included. Removing an admin is a two-step:
+  // revoke `admin` via admin.setUserRoles (which DOES hold the transactional
+  // last-admin guard), then delete. A blanket refusal is trivially provable; a
+  // remaining-admin count inside the delete transaction would be a second copy
+  // of a guard that already exists, and the second copy is the one that rots.
+  if (cid !== null) {
+    const targetRoles = await getUserRoles(db, cid);
+    if (targetRoles.includes(ADMIN_ROLE)) out.push("CANNOT_DELETE_AN_ADMIN");
+  }
+
+  // --- split identity -------------------------------------------------------
+  // This is exactly admin.listUsers' `keyMismatch` flag. Those rows are the
+  // split identities the one-off scripts exist for —
+  // fix-claresta-duplicate.mjs documents an account whose stored userID is
+  // ANOTHER LIVE USER'S canonical key. Cleaning dependents under a key that is
+  // not provably this row's is how you delete a stranger's 25 bookings. Refuse;
+  // the operator uses a hand-audited script.
+  //
+  // For every OTHER row `userID` is either null or equal to the canonical id, so
+  // cleaning under the canonical key alone is provably complete — that is what
+  // this refusal buys the cascade below.
+  //
+  // COROLLARY, AND THE FALSE CONCLUSION IT USED TO CARRY: when cid is null any
+  // non-empty stored value differs from null and refuses here too. That is now
+  // belt-and-braces — ABSENT_CANONICAL_ID above refuses every cid-less row —
+  // and it is stated this way deliberately, because the sentence it used to
+  // justify ("so a non-NUS junk account is deletable and simply has no keyed
+  // dependents") was wrong. No CANONICAL-keyed dependents is not "no
+  // dependents"; see ABSENT_CANONICAL_ID for what such a row can still own.
+  if (
+    typeof target.legacyUserID === "string" &&
+    target.legacyUserID.length > 0 &&
+    target.legacyUserID !== (cid as string | null)
+  ) {
+    out.push("LEGACY_KEY_MISMATCH");
+  }
+
+  // --- a SECOND User row resolves to the same canonical id ------------------
+  // The other half of the proof LEGACY_KEY_MISMATCH only half-supplies: that
+  // key must be EXCLUSIVE to this row, not merely complete for it. Without
+  // this, deleting the junk half of a whitespace-variant pair silently strips
+  // the live half of its roles, headships, matric and bookings while leaving
+  // its User row standing. See findCanonicalIdCollisions for the full argument
+  // and for why the query is over-broad and then filtered.
+  if (cid !== null) {
+    const collisions = await findCanonicalIdCollisions(
+      db,
+      cid,
+      target.userObjectId,
+    );
+    if (collisions.length > 0) out.push("SHARED_CANONICAL_ID");
+  }
+
+  // --- sole head of a CCA ---------------------------------------------------
+  // setCcaHeads: "a headless CCA is the unrecoverable state". Transfer with
+  // admin.transferCcaHead first. Counted per ccaID rather than in aggregate,
+  // because a head of three CCAs may be the only head of exactly one of them.
+  if (cid !== null) {
+    const heads = await db.ccaHead.findMany({
+      where: { userID: cid },
+      select: { ccaID: true },
+    });
+    for (const { ccaID } of heads) {
+      const total = await db.ccaHead.count({ where: { ccaID } });
+      if (total === 1) out.push(`SOLE_HEAD_OF_CCA:${ccaID}`);
+    }
+  }
+
+  return out;
+}
+
+/* ========================================================================== */
+/* 5. THE IMPACT COUNTS (preview)                                             */
+/* ========================================================================== */
+
+/**
+ * The collections `deleteUserAccountCascade` removes, in report order.
+ *
+ * `bookings` is the ONE partial entry: the count here is what will actually be
+ * destroyed, which excludes the reservations a live Event or CcaInterviewSlot is
+ * standing on. Those are reported apart, as `UserFootprint.retainedBookings`,
+ * and rendered under "what survives" — a blast-radius panel that over-reports is
+ * as misleading as one that under-reports.
+ *
+ * `order` IS DELIBERATELY ABSENT, and was here until the supper domain was taken
+ * out of the cascade entirely — see the residue block at the foot of this file.
+ * A count promising to destroy rows the cascade no longer touches is the same
+ * defect as an absent count, pointing the other way.
+ */
+export const FOOTPRINT_COLLECTIONS = [
+  "ccaHead",
+  "userRole",
+  "pendingRoleGrant",
+  "userMatric",
+  "profileCompletion",
+  "eventSignup",
+  "ccaInterviewNote",
+  "ccaApplication",
+  "userCCA",
+  "bookings",
+  "posts",
+  "gym",
+] as const;
+
+export type FootprintCollection = (typeof FOOTPRINT_COLLECTIONS)[number];
+
+export type UserFootprint = {
+  counts: Record<FootprintCollection, number>;
+  /** The CCAs this user heads — the UI resolves names for its copy. */
+  headOfCcaIDs: number[];
+  /**
+   * Bookings of theirs that the cascade KEEPS because a CCA record depends on
+   * them. Reported separately from `counts.bookings` (which is what will
+   * actually be destroyed) and rendered under "What survives", not under "What
+   * will be destroyed". See findInstitutionalBookings.
+   */
+  retainedBookings: number;
+};
+
+/**
+ * Of a user's own Bookings rows, the ones that are somebody ELSE's reservation.
+ *
+ * WHY THIS EXISTS. A Bookings row is not always the personal reservation it
+ * looks like. `event.ts` auto-books the room for an APPROVED event with
+ * `userID: event.createdBy` and stores the `bookingID` back on the Event;
+ * `ccaApplicationsHead.ts` does the same for a batch of interview slots and
+ * stores it on every CcaInterviewSlot in the batch. Those two records are
+ * DELIBERATELY KEPT by this cascade — see the residue block at the foot of this
+ * file, "an event belongs to the CCA, not to the head who filed it" — so
+ * deleting the Bookings row underneath them leaves a published event and live
+ * interview slots whose room is silently free again: `findFacilityConflict`
+ * sees nothing, another CCA books over the top, and `autoBookFailed` stays
+ * false so the CCA's own UI still reports the room as held. Nothing surfaces
+ * the loss, which is what makes it worse than a refusal.
+ *
+ * A canceled event or a canceled slot is NOT holding anything, so its booking
+ * is the departing person's to take with them.
+ */
+export async function findInstitutionalBookings(
+  db: Omit<PrismaClient, `$${string}`>,
+  bookingIDs: number[],
+): Promise<Set<number>> {
+  const held = new Set<number>();
+  if (bookingIDs.length === 0) return held;
+
+  const [events, slots] = await Promise.all([
+    db.event.findMany({
+      // `not` compiles to $ne, which also matches a null/absent status — the
+      // right answer here, since only an explicit "canceled" releases the room.
+      where: { bookingID: { in: bookingIDs }, status: { not: "canceled" } },
+      select: { bookingID: true },
+    }),
+    db.ccaInterviewSlot.findMany({
+      where: { bookingID: { in: bookingIDs }, canceledAt: null },
+      select: { bookingID: true },
+    }),
+  ]);
+  for (const e of events) if (e.bookingID !== null) held.add(e.bookingID);
+  for (const s of slots) if (s.bookingID !== null) held.add(s.bookingID);
+  return held;
+}
+
+const ZERO_FOOTPRINT = (): Record<FootprintCollection, number> =>
+  Object.fromEntries(FOOTPRINT_COLLECTIONS.map((k) => [k, 0])) as Record<
+    FootprintCollection,
+    number
+  >;
+
+/**
+ * What a delete would destroy, per collection. Read-only.
+ *
+ * The operator must see the blast radius before typing anything; a confirmation
+ * over an unknown quantity is theatre.
+ *
+ * When the canonical id is absent, this returns all zeros WITHOUT querying.
+ * `where: { userID: null }` would be a Prisma type error and `where: { userID:
+ * "" }` would count a ""-keyed stranger's rows as this account's — the sentinel
+ * bug class, and the reason the count is not merely "skipped" but structurally
+ * unreachable.
+ *
+ * THOSE ZEROS MEAN "NO CANONICAL-KEYED ROWS", NOT "NOTHING IS ATTACHED", and
+ * they must never be rendered as the second statement. A pre-cutover account can
+ * still own rows under the legacy derivation this app no longer computes (see
+ * ABSENT_CANONICAL_ID on computeDeleteRefusals), and nothing here looks for them.
+ * What keeps the zeros honest is that the delete REFUSES on this state, so the
+ * panel showing them is describing an operation that will not run.
+ */
+export async function countUserFootprint(
+  db: PrismaClient,
+  target: AdminUserTarget,
+): Promise<UserFootprint> {
+  const cid = target.canonicalUserID;
+  if (cid === null)
+    return { counts: ZERO_FOOTPRINT(), headOfCcaIDs: [], retainedBookings: 0 };
+
+  const where = { userID: cid };
+
+  // CcaApplication is read (not just counted) because CcaInterviewNote is
+  // reachable ONLY through applicationID — the same reason the cascade reads it
+  // before deleting. See the note there on why authorUserID is not the key.
+  const apps = await db.ccaApplication.findMany({
+    where,
+    select: { applicationID: true },
+  });
+  const applicationIDs = apps.map((a) => a.applicationID);
+
+  const heads = await db.ccaHead.findMany({ where, select: { ccaID: true } });
+
+  // Bookings are READ rather than counted, for the same reason CcaApplication
+  // is: the count the operator must see is what will be DESTROYED, and the
+  // reservations held for a live event or interview batch are not destroyed.
+  const bookingRows = await db.bookings.findMany({
+    where,
+    select: { bookingID: true },
+  });
+  const heldBookings = await findInstitutionalBookings(
+    db,
+    bookingRows.map((b) => b.bookingID),
+  );
+
+  const [
+    userRole,
+    pendingRoleGrant,
+    userMatric,
+    profileCompletion,
+    eventSignup,
+    ccaInterviewNote,
+    userCCA,
+    posts,
+    gym,
+  ] = await Promise.all([
+    db.userRole.count({ where }),
+    db.pendingRoleGrant.count({ where }),
+    db.userMatric.count({ where }),
+    db.profileCompletion.count({ where }),
+    db.eventSignup.count({ where }),
+    applicationIDs.length
+      ? db.ccaInterviewNote.count({
+          where: { applicationID: { in: applicationIDs } },
+        })
+      : Promise.resolve(0),
+    db.userCCA.count({ where }),
+    db.posts.count({ where }),
+    db.gym.count({ where }),
+  ]);
+
+  return {
+    counts: {
+      ccaHead: heads.length,
+      userRole,
+      pendingRoleGrant,
+      userMatric,
+      profileCompletion,
+      eventSignup,
+      ccaInterviewNote,
+      ccaApplication: apps.length,
+      userCCA,
+      bookings: bookingRows.length - heldBookings.size,
+      posts,
+      gym,
+    },
+    headOfCcaIDs: heads.map((h) => h.ccaID),
+    retainedBookings: heldBookings.size,
+  };
+}
+
+/* ========================================================================== */
+/* 6. THE CASCADE                                                             */
+/* ========================================================================== */
+
+/**
+ * EXPLICIT, because Prisma's defaults are twelve times tighter than the limit
+ * the cascade below reasons about. `$transaction(fn)` with no options is
+ * `{ maxWait: 2000, timeout: 5000 }`, and src/server/db.ts sets no
+ * `transactionOptions` — so the binding cap was 5 SECONDS, not Mongo's 60s
+ * `transactionLifetimeLimitSeconds`. See the note on deleteUserAccountCascade
+ * for what crossing it looks like from the operator's side.
+ *
+ * A NAMED CONSTANT rather than an inline object literal, so the options can be
+ * passed after the transaction body without prettier re-wrapping 190 lines.
+ */
+const CASCADE_TX_OPTIONS = { maxWait: 10_000, timeout: 30_000 } as const;
+
+/**
+ * Delete one account and everything keyed on its canonical identity.
+ *
+ * NOT deleteUserCascade. That helper takes a userID STRING and ends in
+ * `user.deleteMany({ where: { userID } })`, which matches the STORED legacy
+ * column — a column holding an A-format matric on ~515 rows and another live
+ * human's canonical key on the split-identity rows. It also leaves UserRole,
+ * CcaHead, UserMatric, ProfileCompletion, CcaApplication and PendingRoleGrant
+ * behind. An orphaned UserRole is INHERITED by whoever next signs in on that NUS
+ * address (docs/plans/rbac/05-verification.md §613): escalation reachable with
+ * zero privilege. An orphaned CcaHead keeps a dead `cca_head` string alive
+ * forever, because revokeCcaHead drops the string only when `remaining === 0`
+ * and that count never reaches zero (cascade.ts GUARD 2).
+ *
+ * ORDER MATTERS — PRIVILEGE ROWS FIRST, THE User ROW LAST. A crash mid-way must
+ * leave a survivor with LESS privilege and intact data, which re-running
+ * repairs. The reverse order leaves a live grant with no owner, which is the
+ * escalation residue above. Do not reorder for tidiness.
+ *
+ * CH-1 ("a user holds the `cca_head` string IFF they have >= 1 CcaHead row") is
+ * preserved in BOTH directions because the string — carried on the UserRole
+ * document — and every CcaHead row disappear in the SAME transaction. Afterwards
+ * the invariant holds vacuously: no string, no rows.
+ *
+ * THIS DOES NOT BY ITSELF REVOKE A LIVE SESSION. Auth is `strategy: "jwt"` with
+ * a 30-day maxAge and there is no server-side session store to delete, so the
+ * departing person's browser still holds a valid token after this returns. What
+ * closes that window is src/server/auth.ts's session callback: it reads the
+ * `User` row by `_id` on every request and, when that read PROVABLY returns no
+ * row (as opposed to faulting), returns early — skipping `ensureBaseline`,
+ * without which the very next request would upsert a fresh
+ * `UserRole { roles: ["resident"] }` under this canonical id and re-create the
+ * orphan this cascade deletes in step 2. If that branch is ever removed, this
+ * function stops being a delete.
+ *
+ * NOTE that the branch leaves `eligible` alone when another live row
+ * canonicalises to the same id, because the same "row is gone" state is produced
+ * by an account MERGE deleting the losing row — see the branch itself. That
+ * probe FAILS CLOSED: an unproven collision revokes, because both outcomes land
+ * on /onboarding/ineligible and both are resolved by signing out, so a timed-out
+ * collection scan must not be a way for a deleted account to keep its authority.
+ * The early return, and therefore the anti-resurrection guarantee above, applies
+ * in both cases; only `eligible` is conditional.
+ *
+ * THE BINDING TIMEOUT IS PRISMA'S, NOT MONGO'S, and the two differ by twelve
+ * times. Mongo aborts an interactive transaction at 60s
+ * (`transactionLifetimeLimitSeconds`), but Prisma's own default for
+ * `$transaction(fn)` is `{ maxWait: 2000, timeout: 5000 }` and src/server/db.ts
+ * sets no `transactionOptions`, so WITHOUT the explicit options below this body
+ * had 5 seconds. That is not academic: the common path is ~20 sequential round
+ * trips and the institutional-booking loop below adds one more PER held booking,
+ * so a departing CCA head with a batch of interview slots and several events is
+ * comfortably past 5s on a Vercel lambda that is not co-located with the
+ * cluster. The failure mode is P2028, which is a Prisma error rather than a
+ * TRPCError, so `sanitizeErrors` rewrites it to "Something went wrong." and the
+ * dialog tells the operator to retry something that will fail identically —
+ * the heaviest accounts become undeletable through the UI. 30s leaves a wide
+ * margin under Mongo's 60s while still bounding a wedged transaction.
+ *
+ * IF IT EVER TIMES OUT ANYWAY the fix is NOT to drop the transaction. Split it
+ * at the PRIVILEGE BOUNDARY — steps 1-3 in one transaction, the rest in a
+ * second — because the guarantee that matters is "privilege rows die first,
+ * atomically". Un-atomicising the guard is the one change that turns a slow
+ * delete into a security defect. Every delete below is a deleteMany on an
+ * indexed field, and the only reads inside the transaction beyond the re-checks
+ * are the applicationID list, the bookings list and ONE successor lookup for the
+ * whole booking loop (see there — it was per-booking, which made the round-trip
+ * count scale with the number of rooms the departing head had reserved).
+ */
+export async function deleteUserAccountCascade(
+  db: PrismaClient,
+  target: AdminUserTarget,
+  actorUserID: string,
+): Promise<{ deleted: Record<string, number>; retainedBookings: number }> {
+  const cid = target.canonicalUserID;
+  const deleted: Record<string, number> = {};
+  let retainedBookings = 0;
+
+  /* THE SECOND BOUNDARY ON ABSENT_CANONICAL_ID — not a duplicate of the first.
+   * computeDeleteRefusals is the refusal SET, evaluated by the router and
+   * rendered by the preview; this is the property that makes "remove the User
+   * row and clean nothing" structurally unreachable rather than dependent on
+   * every caller remembering to consult that list. Every dependent delete below
+   * is inside `if (cid !== null)`, so without this a cid-less target would run
+   * the whole transaction, skip all of them, and destroy the account anyway —
+   * orphaning whatever it owns under the pre-cutover legacy key (rbac-doctor
+   * --nonnus step [2] is the report that enumerates those rows).
+   *
+   * BEFORE the transaction opens, deliberately: there is nothing to roll back,
+   * and a refusal does not need 30 seconds of interactive-transaction budget.
+   */
+  if (cid === null) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "ABSENT_CANONICAL_ID",
+    });
+  }
+
+  await db.$transaction(async (tx) => {
+    /* ---- (a) RE-CHECK INSIDE THE TRANSACTION -------------------------------
+     * Exactly the pattern applyRoleChange uses for its last-admin count:
+     * read-then-write outside a transaction is not enough. The preflight ran
+     * seconds ago in OPERATOR time; a concurrent revokeCcaHead on the co-head,
+     * or a concurrent setUserRoles granting admin, lands comfortably inside
+     * that window. The worst case here is a PRECONDITION_FAILED at commit time
+     * instead of a bad delete.
+     *
+     * WHAT "INSIDE THE TRANSACTION" DOES AND DOES NOT BUY, because the four
+     * checks below are not equally strong and reading them as one guarantee is
+     * how the weak one gets trusted. Mongo gives snapshot isolation and detects
+     * conflicts ONLY on documents two transactions both WRITE — there is no
+     * predicate or gap locking, so a count read in here is not stable against a
+     * concurrent transaction that has not yet committed. A re-check is therefore
+     * airtight exactly when the row that would falsify it is a row THIS
+     * transaction goes on to write:
+     *
+     *   CANNOT_DELETE_AN_ADMIN — AIRTIGHT. A concurrent setUserRoles writes the
+     *     very UserRole document step 2 below deletes, so one of the two aborts.
+     *   CANNOT_DELETE_SELF — AIRTIGHT; it compares two values, not stored state.
+     *   SHARED_CANONICAL_ID — narrows the window to the transaction rather than
+     *     closing it: a signup committing between this read and our commit is
+     *     invisible here and writes a User row we never touch. It is still worth
+     *     running, because the operator-time window it removes is seconds long
+     *     and this one is milliseconds.
+     *   SOLE_HEAD_OF_CCA — the WEAK one. See the loop.
+     */
+    if (cid !== null) {
+      if (cid === actorUserID) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "CANNOT_DELETE_SELF",
+        });
+      }
+
+      const roleRow = await tx.userRole.findUnique({ where: { userID: cid } });
+      const stored = roleRow?.roles?.length
+        ? roleRow.roles
+        : roleRow?.role
+          ? [roleRow.role]
+          : [];
+      if (stored.includes(ADMIN_ROLE)) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "CANNOT_DELETE_AN_ADMIN",
+        });
+      }
+
+      // Re-checked here for the SAME reason as the two above, and with a
+      // sharper race: a signup on the whitespace variant of this address —
+      // which `email_unique_ci` does NOT prevent, because it folds case and not
+      // whitespace — can land in the operator's confirmation window and turn a
+      // safe delete into one that strips the new account. Everything below this
+      // point deletes by `where: { userID: cid }`, so this is the last moment
+      // the key can be proved exclusive.
+      const collisions = await findCanonicalIdCollisions(
+        tx,
+        cid,
+        target.userObjectId,
+      );
+      if (collisions.length > 0) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "SHARED_CANONICAL_ID",
+        });
+      }
+
+      /* THE RESIDUAL RACE, STATED RATHER THAN CLAIMED CLOSED. Two concurrent
+       * deletes of the two co-heads of one CCA both read `total === 2` in their
+       * own snapshots and each deletes only ITS OWN CcaHead document. The
+       * conflicting row is the CO-HEAD's, which this transaction never writes,
+       * so Mongo sees no write conflict, both commit, and the CCA ends headless
+       * — the state setCcaHeads calls unrecoverable. Being inside the
+       * transaction does not fix this; see the taxonomy in (a).
+       *
+       * WHY IT IS NOT FORCED TO CONFLICT. The mechanical fix is to make both
+       * transactions write one shared document (bump a per-CCA row, or touch the
+       * sibling CcaHead rows) so one aborts. Every version of it costs more than
+       * it buys HERE:
+       *   - a no-op touch is not reliable — Mongo skips a $set that changes
+       *     nothing, so no write intent is registered and no conflict occurs;
+       *   - a real bump needs a field or a row that does not exist, i.e. a
+       *     migration, on a collection whose $jsonSchema validators reject
+       *     undeclared fields at write time (see CcaProfile in schema.prisma);
+       *   - withCcaLock is an advisory lock taken OUTSIDE a transaction, on the
+       *     `ccaApp:` keyspace that serialises the applications workflow, and
+       *     locking one CCA per headship means ordered multi-lock acquisition
+       *     inside the app's only irreversible write.
+       * And none of them would deliver the invariant anyway, because
+       * admin.revokeCcaHead has NO sole-head guard at all: it will remove the
+       * last head of a CCA on its own, today, with no race required. A headless
+       * CCA is therefore a repairable state this codebase already permits —
+       * grantCcaHead and setCcaHeads both accept a CCA with zero heads — not one
+       * this check can promise to prevent.
+       *
+       * SO WHAT THIS CHECK IS FOR: the OPERATOR-time window, which is the one
+       * that actually happens. The preview was rendered, read and confirmed by a
+       * human; seconds to minutes passed; a co-head may have been revoked in
+       * them. Same posture as assertMatricUnclaimed — racy in principle, and the
+       * residue is a state the system can already be talked into rather than a
+       * new failure mode. Do not upgrade the wording of this comment without
+       * upgrading the mechanism.
+       */
+      const heads = await tx.ccaHead.findMany({
+        where: { userID: cid },
+        select: { ccaID: true },
+      });
+      for (const { ccaID } of heads) {
+        const total = await tx.ccaHead.count({ where: { ccaID } });
+        if (total === 1) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: `SOLE_HEAD_OF_CCA:${ccaID}`,
+          });
+        }
+      }
+    }
+
+    /* ---- (b)/(c) the keyed dependents --------------------------------------
+     * The WHOLE block is guarded on a non-null canonical id. A
+     * `where: { userID: "" }` (or a null laundered into one) here would delete a
+     * ""-keyed stranger's rows: the sentinel bug class, spending an ABSENT
+     * identity as a real one.
+     *
+     * A cid-less row therefore falls straight through to (d) and this function
+     * deletes ONLY the `User` document for it — which is why such a row is
+     * refused outright at the top of this function and by
+     * computeDeleteRefusals' ABSENT_CANONICAL_ID. It is NOT true that a non-NUS
+     * account has no dependents; it has no CANONICAL-keyed ones, and the
+     * pre-cutover legacy key it may own rows under is not derivable here.
+     */
+    if (cid !== null) {
+      const where = { userID: cid };
+
+      // 1. CcaHead — the scope rows. First, with UserRole, so a crash cannot
+      //    leave a head row pointing at a deleted user.
+      deleted.ccaHead = (await tx.ccaHead.deleteMany({ where })).count;
+
+      // 2. UserRole — THE escalation-critical row. An orphan here is inherited
+      //    by whoever next signs in on this NUS address.
+      deleted.userRole = (await tx.userRole.deleteMany({ where })).count;
+
+      // 3. PendingRoleGrant — a bearer credential for this exact address. Left
+      //    behind, it is redeemed by whoever next controls it.
+      deleted.pendingRoleGrant = (
+        await tx.pendingRoleGrant.deleteMany({ where })
+      ).count;
+
+      /* ---- privilege boundary. Everything below is DATA, not authority. ---- */
+
+      deleted.userMatric = (await tx.userMatric.deleteMany({ where })).count;
+      deleted.profileCompletion = (
+        await tx.profileCompletion.deleteMany({ where })
+      ).count;
+      deleted.eventSignup = (await tx.eventSignup.deleteMany({ where })).count;
+
+      // CcaInterviewNote BEFORE CcaApplication. ORDER MATTERS: a note is
+      // reachable only through `applicationID`, so deleting the applications
+      // first orphans every note attached to them with no way left to find it.
+      //
+      // NOT `where: { authorUserID: cid }` — a note AUTHORED by this user is a
+      // record ABOUT SOMEONE ELSE's interview and belongs to that CCA. Deleting
+      // by author destroys another CCA's interview record.
+      const apps = await tx.ccaApplication.findMany({
+        where,
+        select: { applicationID: true },
+      });
+      const applicationIDs = apps.map((a) => a.applicationID);
+      deleted.ccaInterviewNote = applicationIDs.length
+        ? (
+            await tx.ccaInterviewNote.deleteMany({
+              where: { applicationID: { in: applicationIDs } },
+            })
+          ).count
+        : 0;
+      deleted.ccaApplication = (
+        await tx.ccaApplication.deleteMany({ where })
+      ).count;
+
+      deleted.userCCA = (await tx.userCCA.deleteMany({ where })).count;
+
+      /* ---- Bookings: NOT a blanket deleteMany ----------------------------
+       * Their PERSONAL reservations go. The ones an Event or a live
+       * CcaInterviewSlot is standing on do NOT — see
+       * findInstitutionalBookings for why deleting those silently frees a room
+       * that a published event still claims.
+       *
+       * ORDER MATTERS: this runs AFTER step 1 removed their CcaHead rows, so the
+       * successor lookup below can only return a head who actually survives. A
+       * reservation with no surviving head of its CCA is KEPT anyway, still
+       * keyed on the departed id: an inert row that holds a room is strictly
+       * better than a live event whose room is quietly available again.
+       */
+      const ownBookings = await tx.bookings.findMany({
+        where,
+        select: { bookingID: true, ccaID: true },
+      });
+      const held = await findInstitutionalBookings(
+        tx,
+        ownBookings.map((b) => b.bookingID),
+      );
+      /* ONE successor lookup for the whole loop, not one per booking. This ran
+       * inside the loop and made the transaction's round-trip count scale with
+       * the number of rooms a departing head had reserved — a head with a batch
+       * of interview slots plus a few events added two round trips each, which
+       * is how this body reached the interactive-transaction timeout on the
+       * heaviest (and most likely) accounts. The lookup is per CCA, and the
+       * number of CCAs one person heads is single digits, so a findMany over the
+       * affected ccaIDs answers every iteration in one query.
+       *
+       * ORDER STILL MATTERS: this reads AFTER step 1 removed their CcaHead rows,
+       * so a returned head is one who actually survives. `userID: { not: cid }`
+       * is kept as belt-and-braces for the same reason it was there before.
+       */
+      const heldCcaIDs = [
+        ...new Set(
+          ownBookings.filter((b) => held.has(b.bookingID)).map((b) => b.ccaID),
+        ),
+      ];
+      const successors = new Map<number, string>();
+      if (heldCcaIDs.length > 0) {
+        const rows = await tx.ccaHead.findMany({
+          where: { ccaID: { in: heldCcaIDs }, userID: { not: cid } },
+          select: { ccaID: true, userID: true },
+        });
+        // First writer wins, matching the previous `findFirst`: any surviving
+        // head is an equally valid custodian of the reservation.
+        for (const r of rows) {
+          if (!successors.has(r.ccaID)) successors.set(r.ccaID, r.userID);
+        }
+      }
+      for (const b of ownBookings) {
+        if (!held.has(b.bookingID)) continue;
+        const successor = successors.get(b.ccaID);
+        // A reservation with no surviving head of its CCA is KEPT anyway, still
+        // keyed on the departed id: an inert row that holds a room is strictly
+        // better than a live event whose room is quietly available again.
+        if (!successor) continue;
+        await tx.bookings.update({
+          where: { bookingID: b.bookingID },
+          data: { userID: successor },
+        });
+      }
+      retainedBookings = held.size;
+      // `notIn: []` is a legal no-op filter, but spelling the empty case out
+      // keeps the common path a plain indexed deleteMany.
+      deleted.bookings = (
+        await tx.bookings.deleteMany({
+          where:
+            held.size === 0
+              ? where
+              : { userID: cid, bookingID: { notIn: [...held] } },
+        })
+      ).count;
+
+      deleted.posts = (await tx.posts.deleteMany({ where })).count;
+      // NO `tx.order.deleteMany` HERE. The supper domain is left whole, on
+      // purpose and as a unit — see the residue block below for the argument.
+      deleted.gym = (await tx.gym.deleteMany({ where })).count;
+    }
+
+    /* ---- (d) the User row, LAST and BY ObjectId ---------------------------
+     * By _id, never `deleteMany({ where: { userID } })`: that column is not
+     * unique and is wrong on ~515 rows, so a deleteMany can match TWO people.
+     * `delete` by _id also lets Prisma's native `onDelete: Cascade` take
+     * Session / Account / Authenticator with it, which a deleteMany on a
+     * non-unique scalar does not reliably express.
+     *
+     * The explicit `select` is the same #9 / I-2 control loadAdminUserTarget
+     * carries: a bare delete deserialises the whole row, including passwordHash,
+     * and throws on a Google-adapter row that lacks it.
+     */
+    await tx.user.delete({
+      where: { id: target.userObjectId },
+      select: { id: true },
+    });
+    deleted.user = 1;
+  }, CASCADE_TX_OPTIONS);
+
+  return { deleted, retainedBookings };
+}
+
+/* --------------------------------------------------------------------------
+ * DELIBERATELY NOT DELETED, and why. Each of these mentions the departing user
+ * somewhere; none of them is theirs to take. A blanket "delete every row
+ * mentioning this userID" reads tidy and quietly destroys other people's data.
+ *
+ *   RoleAuditLog          Append-only by code contract (schema.prisma:
+ *                         "There is no update or delete path in any router, and
+ *                         none may be added"). The delete's OWN audit row must
+ *                         outlive its subject — it is the only surviving record
+ *                         of what privilege was destroyed.
+ *   BookingLogs           A log. Same class as the above.
+ *   Event.createdBy       An event belongs to the CCA, not to the head who filed
+ *                         it. Deleting a departing head's account must not erase
+ *                         the CCA's published events.
+ *   CcaInterviewSlot      .createdBy is provenance; other applicants hold seats
+ *                         on that slot.
+ *   Bookings              ...the ones those two records STAND ON. Keeping the
+ *                         Event and dropping its auto-booked room would leave a
+ *                         published event whose facility is silently free —
+ *                         findFacilityConflict sees nothing, another CCA books
+ *                         over it, and `autoBookFailed` stays false so the CCA's
+ *                         own UI still says the room is held. The coupling is
+ *                         Event.bookingID / CcaInterviewSlot.bookingID; see
+ *                         findInstitutionalBookings. Their PERSONAL bookings do
+ *                         go.
+ *   CcaProfile.updatedBy  A provenance string, not a reference.
+ *   CcaInterviewNote      ...where authorUserID is this user: see the note in
+ *                         the cascade. Their notes about OTHER applicants belong
+ *                         to those applications.
+ *   Order, SupperGroup,   THE WHOLE SUPPER DOMAIN, and it is left whole ON
+ *   FoodOrder             PURPOSE. `Order` used to be deleted here while
+ *                         SupperGroup and FoodOrder were listed as residue, and
+ *                         that pairing was incoherent in both of its possible
+ *                         outcomes. If `Order.userID` really is the canonical
+ *                         key, the deleteMany removed a member's order from a
+ *                         still-open group whose DENORMALIZED aggregates —
+ *                         numOrders, userIdList, totalPrice, currentFoodCost —
+ *                         still counted it, and orphaned the FoodOrder documents
+ *                         that order's `foodIds` was the only pointer to (nothing
+ *                         else references them: deleteSupperGroupCascade deletes
+ *                         Orders by supperGroupId and never reads foodIds, so
+ *                         they are unreachable forever). If it is NOT the
+ *                         canonical key — which is exactly what "UNRESOLVED" in
+ *                         the old comment meant — the deleteMany matched nothing
+ *                         and the blast-radius panel reported "0 supper orders"
+ *                         for an account that has some. The operator could not
+ *                         tell those two apart from the panel.
+ *
+ *                         So the domain goes or stays as a UNIT, and it stays:
+ *                         no router in this app touches SupperGroup or Order
+ *                         (grep — cascade.ts is the only other reference), the
+ *                         key format is still unresolved (rbac-doctor --nonnus
+ *                         reports which format those collections actually use),
+ *                         and repairing a group's aggregates means recomputing
+ *                         `totalPrice` / `currentFoodCost`, which are Json
+ *                         columns holding a mix of Float and Int in production.
+ *                         `order` is out of FOOTPRINT_COLLECTIONS to match, so
+ *                         the panel no longer promises it. Raise it with the
+ *                         owner rather than guessing at the key.
+ *
+ * None of these is a privilege row, so none is an escalation vector. That is the
+ * line being drawn: authority dies with the account; other people's records do
+ * not.
+ * -------------------------------------------------------------------------- */

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -32,6 +32,11 @@ import {
   getAuthEnforcement,
   isMatricRequired,
 } from "~/server/api/services/access";
+// The ONE derivation of "does another live User row resolve to this NUSNET id".
+// Imported rather than restated: a second copy is a second chance to write the
+// equality-on-email version, which misses the whitespace variants that are
+// precisely the rows the merge scripts delete. See the deleted-row branch below.
+import { findCanonicalIdCollisions } from "~/server/api/services/userAdmin";
 
 /**
  * D-7 + I-12. THE eligibility predicate for sign-in, and the only one. The
@@ -179,6 +184,31 @@ declare module "next-auth" {
        * again, one layer down.
        */
       hasIdentity: boolean;
+      /**
+       * The `User` row this session was minted against (`session.user.id`, the
+       * Mongo `_id` frozen into the JWT at sign-in) NO LONGER EXISTS.
+       *
+       * A SEPARATE FACT FROM `eligible`, and it has to be, because two very
+       * different things produce it and only one of them is a revocation:
+       *   - `userAdmin.delete` removed the account. The human is gone;
+       *     `eligible` goes false with this.
+       *   - an account MERGE removed the LOSING row (merge-by-canonical.mjs and
+       *     the four one-off fix-*.mjs scripts all end in
+       *     `db.user.delete({ where: { id } })`). The human is fine, their
+       *     surviving row and every canonical-keyed record of theirs are intact,
+       *     and `eligible` must NOT move — marking them ineligible would 403
+       *     every request they make for up to the 30-day JWT lifetime for having
+       *     been on the wrong half of a duplicate pair.
+       *
+       * RENDER-LAYER ONLY, like `hasIdentity`. It exists so MatricGate has
+       * somewhere to send these sessions: in both cases the token points at a
+       * row that is gone and the only action that resolves it is signing out and
+       * back in. Without it the deleted case renders the whole app shell with
+       * every tRPC call failing FORBIDDEN and no explanation, because
+       * `hasIdentity` is still true (the email still canonicalises) and every
+       * other gate flag was set to its non-blocking value.
+       */
+      accountMissing: boolean;
       /**
        * Live role list, re-read from the database on EVERY session read
        * (invariant I-4 — never baked into the 30-day JWT).
@@ -397,6 +427,10 @@ export const authOptions = {
         // it is line 302's value, named). Deliberately NOT flag-aware: unlike
         // `eligible` below it does not move when a kill switch moves.
         session.user.hasIdentity = userID !== null;
+        // Default for every path below. Only the deleted-account branch raises
+        // it, and it must be a boolean on every branch — MatricGate reads it
+        // first, and `undefined` there would be a silent "everything is fine".
+        session.user.accountMissing = false;
         // I-11. `eligible` is the D-7 DECISION, so it follows the switch: with
         // the flag "off" nobody is marked ineligible and protectedProcedure's
         // backstop never fires, which is what keeps deploy day inert for
@@ -474,7 +508,7 @@ export const authOptions = {
         // user. The two lookups beside it predate that rule; a NEW promise here
         // must not widen the blast radius, so a ProfileCompletion fault degrades
         // to "not flagged" (no prompt) rather than to "logged out".
-        const [record, roleRow, matricRequired, completionRow, userDoc] =
+        const [record, roleRow, matricRequired, completionRow, userRead] =
           await Promise.all([
             db.userMatric.findUnique({ where: { userID } }),
             db.userRole.findUnique({ where: { userID } }),
@@ -487,13 +521,132 @@ export const authOptions = {
             // bare read throws on a passwordHash-less Google row (I-2), and the
             // `.catch` upholds rule 1 (this callback must never throw): a fault
             // degrades to "no profile data" -> not gated, never logged out.
+            //
+            // WRAPPED IN A TAG rather than collapsed to `null`. "The read
+            // faulted" and "the row is not there" are DIFFERENT FACTS and the
+            // branch below acts on only one of them; `.catch(() => null)` erases
+            // the distinction, and acting on the merged value would log users
+            // out on a transient Atlas hiccup. `ok` is the discriminator.
             db.user
               .findUnique({
                 where: { id: session.user.id },
-                select: { displayName: true, telegramHandle: true, block: true },
+                select: {
+                  displayName: true,
+                  telegramHandle: true,
+                  block: true,
+                },
               })
-              .catch(() => null),
+              .then((row) => ({ ok: true as const, row }))
+              .catch(() => ({ ok: false as const, row: null })),
           ]);
+
+        const userDoc = userRead.row;
+
+        /* ---- THE User ROW THIS TOKEN NAMES IS GONE -------------------------
+         * Sessions are JWTs with a 30-day maxAge and there is NO server-side
+         * session store to delete, so `userAdmin.delete` cannot revoke a token
+         * that is already in a browser. Without this branch the delete is not a
+         * delete: the very next request from that browser reaches the I-8b
+         * self-heal below, `stored` is [] (the cascade removed the UserRole
+         * document), and `ensureBaseline` UPSERTS a fresh
+         * `UserRole { roles: ["resident"] }` under the departed canonical id —
+         * re-creating exactly the orphaned role row that 05-verification.md
+         * §613 names as escalation residue and that the cascade deletes in its
+         * step 2. From there `user.setMatric` (a plain protectedProcedure)
+         * re-admits them through matricProcedure and they can write Bookings and
+         * Posts keyed to a userID with no User row, for up to a month.
+         *
+         * ONLY on a PROVABLY absent row (`ok` and no row). A faulted read keeps
+         * the old degrade-safely behaviour — over-prompt, never log out.
+         *
+         * "THE ROW IS GONE" IS NOT "THE ACCOUNT WAS DELETED", and conflating the
+         * two was a lockout. `session.user.id` is the `_id` frozen into the JWT
+         * at sign-in, and FIVE remediation scripts delete `User` rows as their
+         * NORMAL operation — merge-by-canonical.mjs, fix-claresta-duplicate.mjs,
+         * fix-lgd-duplicate.mjs, merge-mingyuan-duplicate.mjs, dedupe-users.mjs
+         * all end in `db.user.delete({ where: { id } })` for the LOSING row of a
+         * duplicate pair. A resident who was signed in on that row keeps a
+         * 30-day token pointing at a dead `_id` while their canonical identity,
+         * their surviving `User` row and every canonical-keyed record of theirs
+         * are intact. Marking them ineligible would make every
+         * protectedProcedure throw NUS_ACCOUNT_REQUIRED — bookings, profile,
+         * CCA, everything — for having been merged.
+         *
+         * So EXISTENCE IS DECIDED ON THE IDENTITY, NOT ON THE `_id`: if any
+         * other live row canonicalises to the same NUSNET id, this was a merge
+         * and `eligible` does not move. Only when nothing of theirs survives is
+         * the session's authority revoked. The probe reuses
+         * `findCanonicalIdCollisions` — the same over-broad-then-filtered
+         * derivation the delete refusal uses — rather than an equality on the
+         * email, which would MISS the whitespace variants that are exactly the
+         * rows the merge scripts delete. It costs a query only on this branch,
+         * which is unreachable in steady state, so rule 2 above still holds. It
+         * cannot throw (rule 1).
+         *
+         * IT FAILS CLOSED — `.catch(() => false)`, i.e. toward REVOKING, and
+         * that is the opposite of this file's usual degrade direction because
+         * here the two outcomes do NOT have different remedies. The usual
+         * argument ("over-prompt, never lock out") assumes a wrongly-gated user
+         * loses something; on THIS branch they do not. `accountMissing` is set
+         * to true on BOTH sides of the probe, and MatricGate checks it FIRST and
+         * routes both cases to /onboarding/ineligible, whose only action is sign
+         * out — which is also the remedy for a merged user (signing back in
+         * mints a JWT against the surviving row). So a merged user misclassified
+         * as "not merged" loses nothing they were not already being redirected
+         * away from, while a DELETED user misclassified as "merged" keeps
+         * `eligible: true` from line 440 and with it full protectedProcedure
+         * authority for up to 30 days — `user.setMatric` is a plain
+         * protectedProcedure and would write a UserMatric row under a canonical
+         * id with no owning User row, and `evaluateBooking`'s repair-on-deny
+         * calls `ensureBaseline`, re-creating the very orphaned UserRole this
+         * branch's early return exists to prevent.
+         *
+         * The asymmetry is why the fault matters at all: this is the single
+         * most timeout-prone query in this callback (an unindexed
+         * `contains` + `mode: "insensitive"` regex, i.e. a collection scan over
+         * ~1382 rows), and it sits in the same Promise.all as an indexed
+         * findUnique that can succeed while it faults. "One collection scan
+         * timed out" must not be a way to keep a deleted account's authority.
+         *
+         * BOTH CASES STILL RETURN EARLY, and that is the security half. There is
+         * deliberately no self-heal and no pending-grant redemption on this
+         * path: `ensureBaseline` would UPSERT a fresh
+         * `UserRole { roles: ["resident"] }` under this canonical id — the
+         * orphaned role row 05-verification.md §613 names as escalation residue
+         * and that the cascade deletes in its step 2 — and it would do so for a
+         * token naming a row nobody can point at. Skipping it closes that in
+         * both cases, whether or not `eligible` moved.
+         *
+         * `accountMissing` is what routes the browser (MatricGate). Without it
+         * this branch left `hasIdentity` true and every other flag non-blocking,
+         * so nothing redirected: the app shell rendered with every tRPC call
+         * failing FORBIDDEN, no explanation and no sign-out prompt, for up to
+         * the 30-day JWT lifetime.
+         */
+        if (userRead.ok && userRead.row === null) {
+          const mergedAway = await findCanonicalIdCollisions(
+            db,
+            userID,
+            session.user.id,
+          )
+            .then((rows) => rows.length > 0)
+            // UNPROVEN COLLISION => NOT MERGED => authority revoked. See the
+            // "fails closed" paragraph above before changing this to `true`.
+            .catch(() => false);
+
+          session.user.accountMissing = true;
+          // Authority is revoked ONLY when nothing of theirs survives.
+          if (!mergedAway) session.user.eligible = false;
+          session.user.matric = null;
+          session.user.hasMatric = false;
+          session.user.matricRequired = false;
+          session.user.profileNeedsFields = [];
+          session.user.profileIncomplete = false;
+          session.user.profileMissingFields = [];
+          session.user.roles = [];
+          session.user.isAdmin = false;
+          return session;
+        }
 
         session.user.matric = record?.matric ?? null;
         session.user.hasMatric = Boolean(record?.matric);


### PR DESCRIPTION
Adds an admin surface over user details — read, edit, delete — off the existing `/admin/users` table. Two commits, each of which typechecks on its own, because the second one touches sign-in and should be reviewable (and revertable) independently.

## What it does

| | |
|---|---|
| **Read + update** | new `manageUserProfiles` capability — admin **and** jcrc, behind the G3 admin-target guard |
| **Delete** | new `deleteUsers` capability — admin only, behind the default-off `admin.userDelete.enabled` SystemFlag |
| **Editable fields** | `displayName`, `block`, `telegramHandle`, `bio`, and the `UserMatric.matric` row |
| **Migration** | **none** — the only `schema.prisma` edit is the `RoleAuditLog` doc comment |

The delete path is **inert until armed**: no `admin.userDelete.enabled` row has been written, and an absent flag means off.

## The load-bearing decisions

**Targets are `User` ObjectIds, never a client-supplied `userID`.** The canonical key is derived server-side from the stored email. `User.userID` holds an A-format matric on **482 of 1387 rows** and, in split-identity cases, another live person's key — keying a cascade on it is how you delete a stranger's bookings.

**Email is immutable.** It *is* the identity (`canonicalUserID` derives from the localpart), so editing it re-keys the human and splits them into two accounts. Surfaced read-only with that explanation.

**Roles are out of scope.** The existing grant/revoke/set and CCA paths remain the only writers of `UserRole` — no second escalation path.

**`deleteUserCascade` is left untouched and unused.** Its `userID`-keyed `user.deleteMany` can match two people, and four remediation scripts document that as the reason they avoid it. The new `deleteUserAccountCascade` also clears `UserRole`, `CcaHead`, `UserMatric`, `ProfileCompletion`, `PendingRoleGrant`, `CcaApplication` and its interview notes; deletes the `User` row by `_id`; and orders privilege rows **first**, so a crash leaves an under-privileged survivor rather than an orphaned role row for the next signup on that address to inherit. It refuses on self, on any admin holder, on the sole head of a CCA, and on a stored-userID mismatch — all four re-checked **inside** the transaction.

**The admin edit is stricter than the resident's own**: it cannot blank `displayName`, `telegramHandle`, `block` or `matric`, because the always-on profile gate would then wall the user in.

## Why commit 2 touches `src/server/auth.ts`

Sessions are 30-day JWTs with no server-side store, so a delete cannot revoke a token already in a browser. Without that commit the delete **is not a delete**: the next request hits the self-heal, `ensureBaseline` re-creates a `resident` role row under the departed canonical id, and `user.setMatric` re-admits them for up to a month.

It deliberately distinguishes a *deleted* account from a *merge-deleted* row — five remediation scripts delete the losing half of a duplicate pair as normal operation, and that person is fine. Existence is decided on the **identity**, not the `_id`.

## Two things for the reviewer

1. **`auth.ts:635` fails closed** (`.catch(() => false)`): a query fault revokes a merged user's authority for that request rather than letting a deleted account through. It self-corrects on the next successful session read. The opposite choice is defensible, it is one character, and it was flipped late in review — it deserves a human decision rather than inheriting mine.
2. **482 accounts (35%) cannot be deleted through this UI** by design (`LEGACY_KEY_MISMATCH`); they still need a hand-audited script.

## Verification

- `npx tsc --noEmit` — clean, on the branch tip **and** on the first commit alone
- `npm run lint` — 0 errors
- `scripts/remediation/verify-user-admin-safety.mjs` (read-only, added here) — all gating lines green against production
- No database writes were made building this.

Built with a planner → three implementation layers → five adversarial review rounds. Findings per round went 14 → 13 → 4 → 5 → 6: the first rounds removed real defects, the later ones plateaued on cosmetics. **The loop never returned a clean round, and round 5's fixes were not re-reviewed** — so this wants human eyes, particularly on commit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PipUz8NSWLy4tbTuEwdHDm
