### PR TITLE
Put each resident's Telegram handle on the slot roster

### DIFF
--- a/src/app/cca/_components/InterviewSlots.tsx
+++ b/src/app/cca/_components/InterviewSlots.tsx
@@ -6,6 +6,7 @@ import {
   MapPin,
   Pencil,
   Plus,
+  Send,
   Trash2,
   Users,
   X,
@@ -1112,7 +1113,8 @@ function SlotCard({ ccaID, slot }: { ccaID: number; slot: Slot }) {
  * The card can only ever be a summary — it is one of up to a dozen in a
  * three-column grid, and capacity goes to 20 — so the full roster lives here,
  * where there is room to give each person a line of their own with the matric
- * and email the head needs to actually identify them.
+ * and email the head needs to identify them, and the Telegram handle they need
+ * to reach them.
  *
  * Rendered per card rather than once for the day: Radix only mounts the
  * content while `open`, so the closed ones cost nothing.
@@ -1197,6 +1199,27 @@ function SlotOccupantsDialog({
                       <span className="block break-words text-xs text-gray-500">
                         {sub}
                       </span>
+                      {/* Its own line, and a link: reaching the room is what a
+                          head opens this roster to do — a session moves, or
+                          somebody is next — and a handle buried in the `sub`
+                          run would be one more string to copy out by hand. A
+                          handle that was never set SAYS so, so "unreachable"
+                          is distinguishable from "I misread the row". */}
+                      {o.applicant.telegramHandle ? (
+                        <a
+                          href={`https://t.me/${o.applicant.telegramHandle}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-0.5 inline-flex items-center gap-1 break-all text-xs font-medium text-emerald-700 hover:underline"
+                        >
+                          <Send className="h-3 w-3 shrink-0" />@
+                          {o.applicant.telegramHandle}
+                        </a>
+                      ) : (
+                        <span className="mt-0.5 block text-xs text-gray-400">
+                          No Telegram handle
+                        </span>
+                      )}
                     </span>
                     {meta && (
                       <span


### PR DESCRIPTION
Follow-up to #87 (the slot roster dialog). The dialog identified everyone booked on a slot — name, matric, email, status — but gave the head no way to reach them, which is most of why the roster gets opened: a session slips, somebody is next, the room moved. The handle was one tab away on the run-sheet, so the real workflow was read a name here, find the same name there, copy the handle by hand.

## What changed

Each roster row now carries the resident's Telegram handle on its own line, linked to `t.me`.

- **Render only, no new read.** `listSlots` already returns it — `resolveApplicants` selects `telegramHandle` and the head's occupant rows carry the whole `applicant` object. Nothing new is exposed: the procedure is head-gated by `assertHeadsCca`, and the same field already shows on the run-sheet and the applications tab via `ApplicantDetails`.
- **A link, on its own line** rather than appended to the `matric · email` run. The handle is the one field on the row that is a destination; it should behave like one, particularly on a phone.
- **A missing handle says so** — "No Telegram handle" rather than nothing. Absence means unreachable, which the head has to notice and act on; a blank space reads as a row that failed to render. Matches the rule the rest of the head surfaces follow (missing fields render as "—", never vanish).

## Testing

`tsc --noEmit` and `eslint` clean. Not exercised in a browser — the row grows by one line, worth an eyeball on a capacity-20 slot where the list already scrolls at `max-h-[55vh]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JabtzPUGjgKRhKoKpHu2z2