### PR TITLE
SCRC (Hall Office) role + the EXT: allowlist that keys it

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -263,6 +263,11 @@ model BookingLock {
 /// null, never "user".
 model UserRole {
   id               String    @id @default(auto()) @map("_id") @db.ObjectId
+  /// THE authorization key. Normally a canonical NUSNET id derived from an
+  /// @u.nus.edu address (I-1). It may ALSO hold an `EXT:` allowlist pin — an
+  /// admin-provisioned principal with no NUS address (see AuthAllowlist). The
+  /// two namespaces are provably disjoint (':' is excluded from
+  /// canonicalUserID's capture class), so nothing here is ambiguous.
   userID           String    @unique
   roles            String[]  @default([])
   /// LEGACY mirror, dual-written for the rollback window only. Dropped in
@@ -289,7 +294,7 @@ model UserRole {
 /// There is no "open to everyone" state any more. Every facility is given an
 /// explicit row by seed-roles-v2.mjs so that "configured as a normal room" is
 /// distinguishable from "never configured" (see rbac-doctor's UNCONFIGURED
-/// line). Allowed values: resident | jcrc | cca_head.
+/// line). Allowed values: resident | jcrc | cca_head | scrc.
 ///
 /// Same I-2 no-required-scalar invariant as UserRole.
 model FacilityAccess {
@@ -330,7 +335,16 @@ model RoleAuditLog {
   /// ccaHead.grant | ccaHead.revoke | ccaHead.transfer |
   /// event.approve | event.reject | event.publish | event.cancel |
   /// event.attendees.export |
-  /// user.detail.read | user.profile.update | user.delete
+  /// user.detail.read | user.profile.update | user.delete |
+  /// scrc.candidate.read |
+  /// authAllowlist.add | authAllowlist.remove
+  ///
+  /// authAllowlist.add / authAllowlist.remove are the D-7 break-glass pin
+  /// surface (adminProcedure only). `targetUserID` carries the EXT pin and
+  /// `reason` carries the pinned address, so "who was handed an identity, by
+  /// whom, when" is one query on this collection. A denied attempt is written
+  /// as `denied` with denyReason EMAIL_IS_CANONICAL / PIN_ALREADY_HAS_ROLES /
+  /// EMAIL_ALREADY_PINNED / PIN_ALREADY_USED / PIN_STILL_HOLDS_ROLES.
   ///
   /// user.detail.read / user.profile.update / user.delete are the /admin/users
   /// detail dialog. user.detail.read is a READ — the only one in this list —
@@ -343,6 +357,11 @@ model RoleAuditLog {
   /// delete's row carries rolesBefore, because it is the only surviving record
   /// of the privilege that was destroyed — which is why this collection stays
   /// append-only and is NOT touched by deleteUserAccountCascade.
+  /// scrc.candidate.read is the same kind of read as user.detail.read: a
+  /// per-target disclosure (identifier in, a named person out) reachable by
+  /// every hall-office holder via admin.resolveJcrcCandidate, recorded here
+  /// because without it a scrc holder could probe who exists, email by email,
+  /// and leave no trace unless they then act.
   action           String
   rolesBefore      String[] @default([])
   rolesAfter       String[] @default([])
@@ -414,6 +433,52 @@ model SystemFlag {
   value     String
   updatedAt DateTime?
   updatedBy String?
+}
+
+/// D-7 break-glass, the COLLECTION variant (08-userid-keydrift.md §3 Branch C).
+/// Resolves the contradiction 05-verification.md:164 and rbac-doctor.mjs name:
+/// the collection variant wins; the AUTH_EMAIL_ALLOWLIST env var survives as
+/// break-glass for an outage in which the DATABASE is the broken thing, and it
+/// confers SIGN-IN ONLY (it mints no identity — see resolvePrincipalID).
+///
+/// One row = one non-@u.nus.edu address that may sign in, PINNED to a stable
+/// identity key in the `EXT:` namespace.
+///
+/// SECURITY — read src/server/api/services/authAllowlist.ts before touching
+/// this. `pinnedUserID` is @unique AND is re-validated against
+/// /^EXT:[A-Z0-9_]{3,32}$/ AT EVERY READ. The ':' is load-bearing:
+/// canonicalUserID's capture class is [A-Z0-9._%-], which excludes ':', so an
+/// EXT id can never equal any NUSNET id this app can derive. A row pinning a
+/// non-EXT value therefore mints NO identity — it is dropped at the read
+/// boundary, not merely discouraged at the write. That is what makes
+/// { email: "attacker@gmail.com", pinnedUserID: "E1633673" } — a row that would
+/// otherwise hand an admin's authorization key to a stranger with no grant path
+/// and therefore no escalation guard firing — unrepresentable rather than
+/// merely refused.
+///
+/// NEITHER INDEX EXISTS UNTIL scripts/remediation/create-auth-allowlist.mjs
+/// RUNS. A Prisma @unique on Mongo is a client-side type assertion, not an
+/// index. Do NOT `prisma db push` to get them — it drops User.email_unique_ci
+/// (see the User model), which is the duplicate-account guard.
+///
+/// EXT identities receive NO `resident` baseline (I-8d, 08 §3.4) — and
+/// mechanically, not conventionally: ensureBaseline takes an EMAIL and
+/// canonicalizes internally, so it returns false before issuing any query.
+///
+/// Brand-new collection: no $jsonSchema validator (confirm with
+/// scripts/remediation/preflight-scrc-validators.mjs before the first insert).
+model AuthAllowlist {
+  id           String   @id @default(auto()) @map("_id") @db.ObjectId
+  /// normalizeEmail()'d: trimmed, lowercased. Must match User.email byte for
+  /// byte — email_unique_ci folds CASE but not WHITESPACE.
+  email        String   @unique
+  /// EXT:<SLUG>. Immutable — there is deliberately no update path, only create
+  /// + delete, so re-aiming a key at a different human is two audit rows.
+  pinnedUserID String   @unique
+  /// Why this address exists. Rendered on the admin surface.
+  note         String?
+  addedBy      String
+  addedAt      DateTime @default(now())
 }
 
 /// Which CCA(s) a user heads. `cca_head` CANNOT be derived from existing data:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -337,7 +337,7 @@ model RoleAuditLog {
   /// event.attendees.export |
   /// user.detail.read | user.profile.update | user.delete |
   /// scrc.candidate.read |
-  /// authAllowlist.add | authAllowlist.remove
+  /// authAllowlist.add | authAllowlist.remove | identity.rekey
   ///
   /// authAllowlist.add / authAllowlist.remove are the D-7 break-glass pin
   /// surface (adminProcedure only). `targetUserID` carries the EXT pin and
@@ -345,6 +345,14 @@ model RoleAuditLog {
   /// whom, when" is one query on this collection. A denied attempt is written
   /// as `denied` with denyReason EMAIL_IS_CANONICAL / PIN_ALREADY_HAS_ROLES /
   /// EMAIL_ALREADY_PINNED / PIN_ALREADY_USED / PIN_STILL_HOLDS_ROLES.
+  ///
+  /// identity.rekey moves an existing account from a legacy identity key to an
+  /// EXT pin. THIS COLLECTION IS NOT RE-KEYED BY IT — every row here states
+  /// what was true when it was written, and an updateMany would make the log
+  /// assert history that did not happen (see the append-only note below). So a
+  /// migrated account's trail is SPLIT across two keys, and the identity.rekey
+  /// row is the join between them: rolesBefore holds the old key, rolesAfter
+  /// the pin. Query both when auditing such an account.
   ///
   /// user.detail.read / user.profile.update / user.delete are the /admin/users
   /// detail dialog. user.detail.read is a READ — the only one in this list —

--- a/scripts/remediation/add-scrc-to-facilities.mjs
+++ b/scripts/remediation/add-scrc-to-facilities.mjs
@@ -1,0 +1,520 @@
+/**
+ * Adds "scrc" to EVERY facility's `FacilityAccess.requiredRoles`, so the hall
+ * office can book every room.
+ *
+ *   node scripts/remediation/add-scrc-to-facilities.mjs --actor E1633673
+ *   node scripts/remediation/add-scrc-to-facilities.mjs --actor E1633673 --commit
+ *
+ * Dry run by DEFAULT. It prints a full before/after table for all 47 rows, and
+ * it exits 1 without writing anything if ANY row fails the refusals below.
+ *
+ * ===========================================================================
+ * READ THIS BEFORE YOU CHANGE ANY LINE OF IT. THE ONE-WAY DOOR.
+ * ===========================================================================
+ *
+ * `requiredRoles: []` — an EMPTY ARRAY, or an absent field — IS NOT "no
+ * restriction to preserve". It is a DISTINCT STATE with two different meanings
+ * depending on the enforcement mode, and BOTH of them are destroyed by writing
+ * ["scrc"] over it:
+ *
+ *   - `canBookLegacy` (services/access.ts:315) opens with
+ *         if (rawRequiredRoles.length === 0) return true;
+ *     i.e. in mode `off`, an empty array means OPEN TO EVERYONE — the pre-D-1
+ *     behaviour. Writing ["scrc"] there converts an open room into an
+ *     scrc-ONLY room.
+ *   - `getFacilityRequiredRoles` (access.ts:272) and `canBookWithRoles` (:294)
+ *     re-default an empty array to ["resident"], i.e. in `permissive` and
+ *     `enforce` an empty array means EVERY RESIDENT. Writing ["scrc"] there
+ *     converts a resident room into an scrc-ONLY room.
+ *
+ * In other words: on an empty array, this operation is not an ADDITION. IT IS A
+ * REMOVAL OF EVERYONE ELSE. The same is true of CREATING a row where none
+ * exists, because a facility with no FacilityAccess row defaults to
+ * ["resident"] (access.ts:272) — so a freshly created ["scrc"] row silently
+ * takes that room away from every resident in the hall.
+ *
+ * There is no signal when this goes wrong. No error, no audit anomaly, no
+ * denial in the logs the operator is watching: residents simply stop seeing the
+ * room in the picker (`getBookableFacilityMap` uses the same predicate) and
+ * start being denied at booking time, and the cause looks like a bug in the
+ * booking code rather than a row somebody rewrote. This is the single most
+ * destructive mistake available in this phase.
+ *
+ * So this script REFUSES — it does not "fix", it does not "default", it does
+ * not skip-and-continue. One bad row aborts the whole run, because a partial
+ * run over 47 facilities is harder to reason about than no run at all.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS (each aborts the entire run, before any write)
+ * ---------------------------------------------------------------------------
+ *   EMPTY_REQUIRED_ROLES   a FacilityAccess row whose requiredRoles is empty or
+ *                          absent. See above — the write would be a removal.
+ *   NO_ACCESS_ROW          a Facilities row (excluding the -1 sentinel) with no
+ *                          FacilityAccess row. Creating one is the same trap.
+ *   DUPLICATE_ACCESS_ROW   two FacilityAccess rows for one facilityID. The
+ *                          `where: { facilityID }` update is then ambiguous and
+ *                          Prisma would refuse anyway — caught here so it is a
+ *                          refusal rather than a mid-run failure with some rows
+ *                          already written.
+ *   NOT_A_SUPERSET         a self-check: the computed `next` is not a superset
+ *                          of `current`. Cannot happen with a union, which is
+ *                          exactly why it is asserted — it turns "this script
+ *                          only ever adds" from a claim into a checked
+ *                          invariant, for every future edit to this file.
+ *   BAD_ACTOR              --actor missing or not a well-shaped identity key.
+ *
+ * Already contains "scrc" is NOT a refusal — it is a SKIP. The script is
+ * idempotent: a second run writes nothing and reports 0 changed.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IT WRITES, AND WHAT IT DELIBERATELY DOES NOT TOUCH
+ * ---------------------------------------------------------------------------
+ *   next = [...new Set([...current.requiredRoles, "scrc"])]
+ *
+ * `update` ONLY — never `create`, never `upsert`. It writes `requiredRoles`,
+ * `updatedAt` and `updatedBy`, which is exactly the UPDATE branch of
+ * `admin.setFacilityAccess` (routers/admin.ts:2702-2731).
+ *
+ * `requiredRole` — the LEGACY SCALAR — is NOT touched, and that matters. The
+ * update branch of setFacilityAccess leaves it alone for a reason: an existing
+ * gated row (the SCRC Room's "jcrc") keeps its real legacy value so that a
+ * revert to the pre-v2 access.ts does not silently UN-GATE the room, while the
+ * 46 rooms keep their "" so a revert restores today's open-by-default. Writing
+ * "scrc" into that scalar would be uninterpretable to the old code and would
+ * demote a jcrc+scrc holder on rollback — the same argument PRECEDENCE in
+ * lib/rbac.mjs makes for leaving "scrc" out of the mirror. `facilityID` is not
+ * touched either; it is the key.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY A SCRIPT AND NOT 47 CLICKS IN /admin/facilities
+ * ---------------------------------------------------------------------------
+ * The UI writes a SET payload: whatever boxes are ticked becomes the whole
+ * array. Forty-seven of those is forty-seven chances to drop `cca_head` from a
+ * room by mis-clicking, silently, with a perfectly clean audit row recording
+ * the mistake as intentional. This computes a UNION, cannot subtract, prints
+ * the whole before/after table before it does anything, and writes the same
+ * `facilityAccess.set` audit row per facility that the UI would.
+ *
+ * ---------------------------------------------------------------------------
+ * "EVERY MODIFIED FACILITY IS AUDITED" — A PROPERTY, NOT A HOPE
+ * ---------------------------------------------------------------------------
+ *
+ * The update and its audit row go through ONE `db.$transaction([...])` PER
+ * FACILITY, so for any given room "the gate changed" and "there is a
+ * RoleAuditLog row saying so" are the same event. They cannot come apart.
+ *
+ * THEY USED TO BE ABLE TO, and the failure was invisible in a way worth
+ * spelling out, because it is why the transaction is here rather than a comment
+ * saying to be careful. The two writes sat in one `try`. If the update landed
+ * and the audit `create` threw, the facility was reported FAILED — while the
+ * row WAS modified and no audit row existed. The verify pass could not see it:
+ * it checks only that `scrc` is present and that no role was lost, and both are
+ * true of an unaudited-but-correct row. And the repair never came, because a
+ * corrective re-run reads `already === true` for that facility and SKIPS it
+ * permanently. An un-audited privilege change that no re-run will ever notice
+ * is precisely the residue this whole phase is written to avoid.
+ *
+ * Since a transaction still has prerequisites (a replica set — Atlas is one —
+ * and both collections existing, which they do since phase 1), the verify pass
+ * ALSO cross-checks the two: any facility reported FAILED whose re-read now
+ * CONTAINS "scrc" is surfaced as MODIFIED BUT POSSIBLY UNAUDITED, with the exact
+ * `RoleAuditLog` document printed as JSON so it can be inserted by hand. That
+ * path exits 1 like every other bad outcome.
+ *
+ * PRE-REQUISITE: "scrc" must be in FACILITY_ROLES in lib/rbac.mjs (it is —
+ * phase 1). Checked below rather than assumed.
+ */
+import { PrismaClient } from "@prisma/client";
+import { isCanonicalResidentID } from "./lib/identity.mjs";
+import {
+  findAll,
+  numify,
+  isCommit,
+  banner,
+  abort,
+  FACILITY_ROLES,
+  SENTINEL_FACILITY_ID,
+} from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+const ROLE = "scrc";
+
+function argOf(flag) {
+  const i = process.argv.indexOf(flag);
+  if (i === -1) return null;
+  const v = process.argv[i + 1];
+  return v === undefined || v.startsWith("--") ? null : v;
+}
+const ACTOR = (argOf("--actor") ?? "").trim();
+
+const refusals = [];
+const refuse = (code, detail) => refusals.push({ code, detail });
+
+async function main() {
+  banner("add-scrc-to-facilities.mjs", COMMIT);
+  console.log(`  actor: ${JSON.stringify(ACTOR)}`);
+
+  // -- 0. preconditions -----------------------------------------------------
+  //
+  // isCanonicalResidentID is a SHAPE test (non-empty, contains no '@'). It is
+  // the right predicate for an actor id precisely because it is NOT an E-format
+  // test: "G.S_SAMUEL" is a real account (L-27) and an EXT pin is a legal
+  // principal key, and refusing either would be the same class of mistake as
+  // gating eligibility on /^E\d{7}$/.
+  if (!isCanonicalResidentID(ACTOR)) {
+    console.log(`\nusage: node scripts/remediation/add-scrc-to-facilities.mjs --actor <userID> [--commit]`);
+    return abort(
+      `--actor is required and must be a well-shaped identity key. It is written to ` +
+        `RoleAuditLog.actorUserID and FacilityAccess.updatedBy for all 47 rows; an audit ` +
+        `trail that names nobody is not an audit trail.`,
+    );
+  }
+  if (!FACILITY_ROLES.includes(ROLE)) {
+    return abort(
+      `"${ROLE}" is not in FACILITY_ROLES (lib/rbac.mjs). Phase 1 has not landed here, and ` +
+        `rbac-doctor.mjs would report every row this script writes as out-of-vocabulary.`,
+    );
+  }
+
+  // -- 1. read --------------------------------------------------------------
+  //
+  // findAll, not a bare `find`: a single raw reply is capped at 101 documents by
+  // default and at 16MB regardless, and a script that reads a PREFIX of
+  // FacilityAccess would silently leave the unread rooms un-gated while
+  // reporting success. findAll pages to exhaustion and cross-checks against an
+  // independent $count.
+  //
+  // numify on facilityID: extended JSON hands back {$numberInt:"17"}, and a
+  // string-vs-number mismatch here would make every row look unmatched.
+  const access = (await findAll(db, "FacilityAccess", { facilityID: 1, requiredRoles: 1, requiredRole: 1 }))
+    .map((a) => ({ ...a, facilityID: numify(a.facilityID) }));
+  const facilities = (await findAll(db, "Facilities", { facilityID: 1, facilityName: 1 }))
+    .map((f) => ({ ...f, facilityID: numify(f.facilityID) }));
+
+  const realFacilities = facilities.filter((f) => f.facilityID !== SENTINEL_FACILITY_ID);
+  const nameOf = new Map(realFacilities.map((f) => [f.facilityID, String(f.facilityName ?? "")]));
+
+  console.log(`\n--- [1] population ---`);
+  console.log(`  Facilities rows (excl. sentinel ${SENTINEL_FACILITY_ID}): ${realFacilities.length}`);
+  console.log(`  FacilityAccess rows:                        ${access.length}`);
+
+  // -- 2. refusal: duplicate FacilityAccess rows ----------------------------
+  const counts = new Map();
+  for (const a of access) counts.set(a.facilityID, (counts.get(a.facilityID) ?? 0) + 1);
+  for (const [fid, n] of counts) {
+    if (n > 1) {
+      refuse(
+        "DUPLICATE_ACCESS_ROW",
+        `facilityID ${fid} has ${n} FacilityAccess rows. \`where: { facilityID }\` is ` +
+          `ambiguous, so the update would fail mid-run with some rows already written. ` +
+          `The @unique index on facilityID should have made this impossible — check it.`,
+      );
+    }
+  }
+
+  // -- 3. refusal: a facility with no FacilityAccess row --------------------
+  const configured = new Set(access.map((a) => a.facilityID));
+  for (const f of realFacilities) {
+    if (!configured.has(f.facilityID)) {
+      refuse(
+        "NO_ACCESS_ROW",
+        `facility ${f.facilityID} (${nameOf.get(f.facilityID)}) has NO FacilityAccess row. ` +
+          `A facility with no row defaults to ["resident"] (access.ts:272), so CREATING one ` +
+          `containing only "${ROLE}" would take this room away from every resident in the ` +
+          `hall. This script never creates. Configure the room through /admin/facilities ` +
+          `first (which writes the full intended role set and an audit row), then re-run.`,
+      );
+    }
+  }
+
+  // -- 4. plan, per row -----------------------------------------------------
+  const plan = [];
+  const sentinelRows = [];
+  for (const a of [...access].sort((x, y) => x.facilityID - y.facilityID)) {
+    // facilityID -1 is the sentinel Calender_v2.tsx filters out. It is not a
+    // room, nobody can book it, and granting a role on it would produce an
+    // audit row about a facility that does not exist. Reported, never written,
+    // and NOT a refusal — its shape says nothing about the real rooms.
+    if (a.facilityID === SENTINEL_FACILITY_ID) {
+      sentinelRows.push(a.facilityID);
+      continue;
+    }
+
+    const current = Array.isArray(a.requiredRoles) ? a.requiredRoles : null;
+
+    // THE ONE-WAY DOOR. Empty or absent -> refuse. Read the header.
+    if (current === null || current.length === 0) {
+      refuse(
+        "EMPTY_REQUIRED_ROLES",
+        `facility ${a.facilityID} (${nameOf.get(a.facilityID) ?? "unknown"}) has ` +
+          `requiredRoles=${JSON.stringify(a.requiredRoles ?? null)}. An empty/absent array is a ` +
+          `DISTINCT STATE: mode "off" reads it as open-to-everyone (access.ts:315) and ` +
+          `"permissive"/"enforce" re-default it to ["resident"] (access.ts:272). Writing ` +
+          `["${ROLE}"] here would not ADD the hall office, it would REMOVE EVERYONE ELSE, ` +
+          `silently. Decide the intended role set for this room and write it through ` +
+          `/admin/facilities, then re-run.`,
+      );
+      continue;
+    }
+
+    // The union. It cannot subtract — and the assertion below is what keeps
+    // that true for whoever edits this next.
+    const next = [...new Set([...current, ROLE])];
+    if (!current.every((r) => next.includes(r))) {
+      refuse(
+        "NOT_A_SUPERSET",
+        `facility ${a.facilityID}: computed ${JSON.stringify(next)} is not a superset of ` +
+          `${JSON.stringify(current)}. This is a self-check on the union above; if it ever ` +
+          `fires, the computation was changed into something that can REMOVE a role.`,
+      );
+      continue;
+    }
+
+    const already = current.includes(ROLE);
+    plan.push({
+      facilityID: a.facilityID,
+      name: nameOf.get(a.facilityID) ?? "(no Facilities row)",
+      legacy: a.requiredRole,
+      current,
+      next,
+      already,
+      orphan: !nameOf.has(a.facilityID),
+    });
+  }
+
+  // -- 5. the table ---------------------------------------------------------
+  console.log(`\n--- [2] before / after (ALL rows, including skips) ---`);
+  console.log(
+    `  ${"fid".padStart(4)}  ${"facility".padEnd(28)} ${"legacy".padEnd(10)} ` +
+      `${"before".padEnd(32)} -> after`,
+  );
+  for (const p of plan) {
+    const mark = p.already ? "=" : COMMIT ? "+" : "~";
+    console.log(
+      `  ${mark} ${String(p.facilityID).padStart(2)}  ${String(p.name).slice(0, 28).padEnd(28)} ` +
+        `${JSON.stringify(p.legacy ?? null).padEnd(10)} ${JSON.stringify(p.current).padEnd(32)} -> ` +
+        `${p.already ? "(unchanged)" : JSON.stringify(p.next)}`,
+    );
+  }
+
+  // Informational, NOT a refusal. A FacilityAccess row whose facilityID has no
+  // Facilities row is a gate on a room that does not exist; adding a role to it
+  // changes nothing for anyone. Reported so it is visible, and included in the
+  // write set so the collection stays uniform.
+  if (sentinelRows.length) {
+    console.log(
+      `\n  note: skipped the facilityID ${SENTINEL_FACILITY_ID} sentinel row — not a room, ` +
+        `not bookable, no audit row written for it.`,
+    );
+  }
+
+  const orphans = plan.filter((p) => p.orphan).map((p) => p.facilityID);
+  if (orphans.length) {
+    console.log(
+      `\n  note: ${orphans.length} FacilityAccess row(s) have no matching Facilities row ` +
+        `[${orphans.join(", ")}]. Gates on rooms that do not exist — harmless, and included ` +
+        `for uniformity. Not a refusal.`,
+    );
+  }
+
+  const toWrite = plan.filter((p) => !p.already);
+  const skipped = plan.length - toWrite.length;
+  console.log(`\n  rows already containing "${ROLE}" (skipped): ${skipped}`);
+  console.log(`  rows to update:                          ${toWrite.length}`);
+
+  // -- 6. verdict -----------------------------------------------------------
+  if (refusals.length) {
+    console.error(`\n--- REFUSED (${refusals.length}) — NOTHING WAS WRITTEN ---`);
+    for (const r of refusals) console.error(`  ${r.code}\n      ${r.detail}\n`);
+    return abort(
+      `the run is aborted in full. A partial pass over 47 facilities is harder to reason ` +
+        `about than none, and every refusal above describes a write that would REMOVE ` +
+        `access rather than add it.`,
+    );
+  }
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing was written. Read the table above line by line, then`);
+    console.log(`re-run with --commit. Every "after" must be a SUPERSET of its "before".`);
+    return;
+  }
+
+  // -- 7. write -------------------------------------------------------------
+  //
+  // actorRoles is read from the database rather than hardcoded: the column
+  // means "the actor's roles AT THE TIME", and stamping a value on faith
+  // records a claim instead of a fact. Falls back to ["admin"] only if the
+  // actor has no UserRole row, which is itself worth seeing in the output.
+  const actorRow = await db.userRole
+    .findUnique({ where: { userID: ACTOR }, select: { roles: true } })
+    .catch(() => null);
+  const actorRoles = actorRow?.roles?.length ? actorRow.roles : ["admin"];
+  console.log(`\n--- [3] writing (actorRoles=${JSON.stringify(actorRoles)}${actorRow ? "" : " — no UserRole row for the actor; using the default"}) ---`);
+
+  /**
+   * The audit document for one facility, built once so the same object can be
+   * WRITTEN and — if a write is ever reported failed over a row that turns out
+   * to be modified — PRINTED for hand insertion.
+   *
+   * Field-for-field identical to writeAudit() in routers/admin.ts, including
+   * the fields it sets to null. `before` is the same expression
+   * admin.setFacilityAccess uses, kept verbatim so a row written here and a row
+   * written by the UI carry the same rolesBefore; the refusals above already
+   * guarantee requiredRoles is non-empty, so in practice it is always the first
+   * branch.
+   */
+  const auditDocFor = (p) => ({
+    actorUserID: ACTOR,
+    actorRoles,
+    targetUserID: null,
+    targetFacilityID: p.facilityID,
+    targetCcaID: null,
+    targetEventID: null,
+    action: "facilityAccess.set",
+    rolesBefore: p.current.length ? p.current : p.legacy ? [p.legacy] : [],
+    rolesAfter: p.next,
+    reason: `script:add-scrc-to-facilities`,
+    ok: true,
+    denyReason: null,
+    batchId: null,
+  });
+
+  let written = 0;
+  const failures = [];
+  const failedIDs = new Set();
+  const auditDocs = new Map();
+  for (const p of toWrite) {
+    auditDocs.set(p.facilityID, auditDocFor(p));
+    try {
+      // ONE TRANSACTION PER FACILITY, so "the gate changed" and "the audit row
+      // exists" are one event. Read the header: with these two writes merely
+      // sequential, an audit failure after a successful update produced a
+      // facility reported FAILED that had in fact been MODIFIED and never
+      // audited — invisible to the verify pass, and skipped forever by any
+      // corrective re-run because `already` is then true.
+      //
+      // Per facility rather than one transaction over all 47: a single
+      // transaction spanning 94 writes would be far past Prisma's default
+      // 5-second budget, and the run is already designed to be resumable
+      // room-by-room (the union is idempotent, so a re-run re-does nothing).
+      //
+      // update, never upsert. If the row vanished between the read and here,
+      // Prisma throws P2025 and this facility is reported as a failure rather
+      // than quietly CREATED — which is the NO_ACCESS_ROW trap by another door.
+      await db.$transaction([
+        db.facilityAccess.update({
+          where: { facilityID: p.facilityID },
+          data: {
+            requiredRoles: p.next,
+            updatedAt: new Date(),
+            updatedBy: ACTOR,
+            // requiredRole is ABSENT from this payload on purpose. See the header.
+          },
+        }),
+        db.roleAuditLog.create({ data: auditDocs.get(p.facilityID) }),
+      ]);
+      written++;
+      console.log(`  + ${String(p.facilityID).padStart(2)}  ${JSON.stringify(p.current)} -> ${JSON.stringify(p.next)}`);
+    } catch (e) {
+      failures.push(`facility ${p.facilityID}: ${String(e?.message ?? e)}`);
+      failedIDs.add(p.facilityID);
+      console.error(`  ! ${String(p.facilityID).padStart(2)}  FAILED: ${String(e?.message ?? e)}`);
+    }
+  }
+
+  // -- 8. verify ------------------------------------------------------------
+  //
+  // Re-read, do not trust the writes. This is the only line that proves the
+  // outcome, and it also catches the case nobody expects: a row that came back
+  // NARROWER than it went in.
+  console.log(`\n=== VERIFY (re-read) ===`);
+  const after = (await findAll(db, "FacilityAccess", { facilityID: 1, requiredRoles: 1 }))
+    .map((a) => ({ ...a, facilityID: numify(a.facilityID) }));
+  const afterMap = new Map(after.map((a) => [a.facilityID, a.requiredRoles ?? []]));
+
+  const bad = [];
+  const unaudited = [];
+  for (const p of plan) {
+    const now = afterMap.get(p.facilityID);
+    if (!now) {
+      bad.push(`facility ${p.facilityID}: FacilityAccess row is GONE`);
+      continue;
+    }
+    if (!now.includes(ROLE)) bad.push(`facility ${p.facilityID}: still lacks "${ROLE}" (${JSON.stringify(now)})`);
+    const lost = p.current.filter((r) => !now.includes(r));
+    if (lost.length) {
+      bad.push(
+        `facility ${p.facilityID}: LOST ${JSON.stringify(lost)} — was ${JSON.stringify(p.current)}, ` +
+          `is now ${JSON.stringify(now)}. THIS IS THE FAILURE THIS SCRIPT EXISTS TO PREVENT.`,
+      );
+    }
+
+    // MODIFIED BUT POSSIBLY UNAUDITED — its OWN outcome, distinct from "failed".
+    //
+    // The per-facility transaction is supposed to make this unreachable, and on
+    // a replica set with both collections present it is. It is checked anyway
+    // because the cost of being wrong is an unaudited privilege change that no
+    // re-run will ever revisit: the next run sees `already === true` and skips
+    // the room forever. A facility this run reported FAILED, whose re-read now
+    // carries "scrc", is exactly that shape.
+    if (failedIDs.has(p.facilityID) && now.includes(ROLE)) {
+      unaudited.push(p.facilityID);
+    }
+  }
+
+  console.log(`  rows updated:        ${written}   (each with its audit row, in one transaction)`);
+  console.log(`  rows skipped:        ${skipped}`);
+  console.log(`  write failures:      ${failures.length}`);
+  console.log(`  modified-but-possibly-unaudited: ${unaudited.length}${unaudited.length ? `  [${unaudited.join(", ")}]` : ""}`);
+  // Sentinel excluded from the denominator so "47 of 47" means what it says.
+  const realAfter = [...afterMap].filter(([fid]) => fid !== SENTINEL_FACILITY_ID);
+  console.log(`  rows now with scrc:  ${realAfter.filter(([, r]) => r.includes(ROLE)).length} of ${realAfter.length}`);
+
+  console.log(`\n================================`);
+
+  // MODIFIED BUT UNAUDITED, reported as its own outcome and BEFORE the generic
+  // failure list, with the exact document to insert. A re-run cannot repair
+  // this: the row now contains "scrc", so the next run computes `already` true
+  // and skips the facility. The repair has to be done here, by hand, now.
+  if (unaudited.length) {
+    console.error(`\n  *** MODIFIED BUT POSSIBLY UNAUDITED — ${unaudited.length} facility(ies) ***\n`);
+    console.error(
+      `  These rows were reported FAILED above, but the re-read shows them carrying\n` +
+        `  "${ROLE}". The gate CHANGED. Whether the matching RoleAuditLog row exists is\n` +
+        `  unknown — the two writes go in one transaction, so it should, but a run that\n` +
+        `  lands here has already violated that assumption once.\n\n` +
+        `  RE-RUNNING THIS SCRIPT WILL NOT FIX IT. The union is idempotent, so the next\n` +
+        `  run sees the role already present and skips the facility permanently.\n\n` +
+        `  For each facility below: query RoleAuditLog for action="facilityAccess.set"\n` +
+        `  with targetFacilityID = that id and reason="script:add-scrc-to-facilities".\n` +
+        `  If there is no such row, insert the document printed under it verbatim\n` +
+        `  (db.RoleAuditLog.insertOne(<doc>), adding the collection's own timestamp\n` +
+        `  field as the model requires).\n`,
+    );
+    for (const fid of unaudited) {
+      console.error(`  --- facility ${fid} ---`);
+      console.error(`  ${JSON.stringify(auditDocs.get(fid))}`);
+    }
+  }
+
+  if (failures.length || bad.length || unaudited.length) {
+    for (const f of failures) console.error(`  FAIL  ${f}`);
+    for (const b of bad) console.error(`  RED   ${b}`);
+    return abort(`the facility gates are NOT in the intended state. Read every line above.`);
+  }
+  console.log(`Every FacilityAccess row now grants "${ROLE}", and no row lost a role.`);
+  console.log(`Every row this run modified was audited in the SAME transaction as the change.`);
+  console.log(`The legacy requiredRole scalar was not touched on any row.`);
+}
+
+main()
+  // Conditional on the exit code: printing "Done." under an ABORT banner is how
+  // an operator skim-reads a refusal as a success.
+  .then(() => console.log(process.exitCode ? "\nAborted — see above." : "\nDone."))
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/create-auth-allowlist.mjs
+++ b/scripts/remediation/create-auth-allowlist.mjs
@@ -1,0 +1,390 @@
+/**
+ * Creates the `AuthAllowlist` collection and its TWO UNIQUE INDEXES.
+ *
+ *   node scripts/remediation/create-auth-allowlist.mjs             # dry run
+ *   node scripts/remediation/create-auth-allowlist.mjs --commit    # apply
+ *
+ * Dry run by default. Under --commit it issues exactly two commands —
+ * `create` and `createIndexes` — and then re-reads `listIndexes` and proves
+ * the result rather than assuming it.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS SCRIPT EXISTS INSTEAD OF `prisma db push`
+ * ---------------------------------------------------------------------------
+ *
+ * `prisma/schema.prisma` now declares `model AuthAllowlist` with `@unique` on
+ * both `email` and `pinnedUserID`. Three separate things follow from that, and
+ * only two of them happen on their own:
+ *
+ *   1. The TYPED CLIENT appears by itself. `package.json`'s
+ *      `"postinstall": "prisma generate"` runs on every Vercel build, and
+ *      `prisma generate` reads the schema file only — it never touches the
+ *      database. So `db.authAllowlist` exists at deploy with no migration.
+ *   2. The COLLECTION appears by itself. MongoDB creates a collection lazily on
+ *      first insert. (This script creates it explicitly anyway — see below.)
+ *   3. THE INDEXES DO NOT APPEAR BY THEMSELVES, AND THIS IS THE WHOLE POINT.
+ *      A Prisma `@unique` on a Mongo model is a CLIENT-SIDE TYPE ASSERTION.
+ *      Until the index exists in the cluster, the database enforces nothing:
+ *      two rows may carry the same `pinnedUserID`, and the `P2002` refusal in
+ *      `admin.addAuthAllowlistEntry` — which is supposed to be how a duplicate
+ *      pin is caught — can never fire, because Mongo never raises it.
+ *
+ * `prisma db push` would create those indexes. It would ALSO drop
+ * `User.email_unique_ci`, the case-insensitive unique index that is the
+ * duplicate-account guard, because Prisma cannot represent a collation index in
+ * the schema and therefore sees it as "not in schema" and removes it — with no
+ * warning and without needing --accept-data-loss. That hazard is written out in
+ * prisma/schema.prisma, in the "⚠️ `prisma db push` DROPS" block of the comment
+ * directly above `model User` — SEARCH FOR "email_unique_ci" rather than going
+ * by a line number. (It sits around lines 934-946 today; that is a HINT and is
+ * allowed to be stale. The previous citation here read `schema.prisma:877-887`,
+ * and by the time anyone followed it line 877 was inside `model Restaurants`.)
+ * It has been dropped and restored on this cluster before. So `db push` is
+ * forbidden, and `createIndexes` is how the indexes get made.
+ *
+ * WITHOUT THESE TWO INDEXES, MECHANISM M3 DOES NOT EXIST. M3 is the one that
+ * says a pin cannot be re-aimed: `pinnedUserID` unique means two emails cannot
+ * share a pin, so a live privileged key cannot be quietly handed to a second
+ * party while the first still holds it. M1 (the ':' makes the EXT and NUSNET
+ * namespaces provably disjoint), M2 (`asExtUserID` re-validates at every read)
+ * and M4 (adminProcedure + audited + three refusals) all still stand — but M3
+ * is the only one of the four that is enforced by the DATABASE rather than by
+ * code, and it is the only one that survives a bad write path. Skipping this
+ * script leaves a silent hole. rbac-doctor.mjs's allowlist section detects it
+ * FROM THE DATA (it asserts pin uniqueness directly) precisely because nobody
+ * should have to remember to read `listIndexes`.
+ *
+ * ---------------------------------------------------------------------------
+ * IDEMPOTENT, AND WHAT "ALREADY PRESENT" MEANS
+ * ---------------------------------------------------------------------------
+ *
+ * Re-running is safe. These replies are reported as "already present", NOT as
+ * failures:
+ *   48  NamespaceExists        the collection is already there
+ *   68  IndexAlreadyExists     that index name is already there
+ *   85  IndexOptionsConflict   same name, different options
+ *   86  IndexKeySpecsConflict  same key, different name/options
+ * An identical `createIndexes` normally just returns ok:1 with
+ * numIndexesBefore == numIndexesAfter, so 85/86 mean somebody built a DIFFERENT
+ * index under one of these names. That is reported loudly, and the VERIFY pass
+ * at the end is what decides the exit code: it re-reads `listIndexes` and
+ * requires both indexes to exist with `unique: true`. A conflicting index is
+ * therefore surfaced rather than swallowed.
+ *
+ * 11000 (E11000 duplicate key) is NOT idempotency and is NEVER swallowed. It
+ * means rows already exist that violate the uniqueness being requested — the
+ * index is not created, M3 still does not exist, and the data must be fixed
+ * first. The dry run reads the existing rows and reports such duplicates in
+ * advance so this is not a surprise.
+ *
+ * ---------------------------------------------------------------------------
+ * $runCommandRaw RETURNS ERRORS AS DATA
+ * ---------------------------------------------------------------------------
+ *
+ * This is the trap that makes an uninspected raw command worse than useless. A
+ * failed command resolves as `{ ok: 0, code, errmsg }`, and a command whose
+ * individual writes failed resolves as `{ ok: 1, writeErrors: [...] }` — a
+ * `$jsonSchema` rejection arrives as `writeErrors[0].code === 121` with
+ * `ok: 1`. Neither throws. A script built around try/catch alone reports
+ * SUCCESS on a command that did nothing (see merge-by-canonical.mjs's note at
+ * its survivor `$set`, and lib/rbac.mjs's `inspectWriteReply`). Every command
+ * below goes through `runCmd`, which inspects the reply AND catches, and
+ * `inspectWriteReply` is applied wherever writeErrors are possible.
+ *
+ * Run `node scripts/remediation/index-census.mjs` before and after this, and
+ * diff the two. The only acceptable delta is the two indexes created here.
+ */
+import { PrismaClient } from "@prisma/client";
+import { numify, inspectWriteReply, isCommit, banner, abort } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+const COLL = "AuthAllowlist";
+
+/**
+ * The two indexes, spelled out exactly as they will be created. Names are
+ * chosen and FIXED here: a name is what `IndexOptionsConflict` compares on, and
+ * what a future operator greps the census for.
+ */
+const INDEXES = [
+  { key: { email: 1 }, name: "email_unique", unique: true },
+  { key: { pinnedUserID: 1 }, name: "pin_unique", unique: true },
+];
+
+/** Replies that mean "someone got here first". See the header. */
+const IDEMPOTENT_CODES = new Map([
+  [48, "NamespaceExists — the collection already exists"],
+  [68, "IndexAlreadyExists — that index name already exists"],
+  [85, "IndexOptionsConflict — an index of that NAME exists with different options"],
+  [86, "IndexKeySpecsConflict — an index on that KEY exists under a different name/options"],
+]);
+
+const NS_NOT_FOUND = 26;
+
+/**
+ * Run one raw command and normalise BOTH failure shapes into one value.
+ * Returns { ok, code, codeName, errmsg, reply, threw }.
+ *
+ * `ok: false` here means the COMMAND failed. Per-write failures (writeErrors)
+ * are a separate axis and are inspected by the caller with inspectWriteReply —
+ * `create` and `createIndexes` report failure at the command level, but the
+ * distinction is kept explicit rather than assumed.
+ */
+async function runCmd(cmd, label) {
+  let reply;
+  try {
+    reply = await db.$runCommandRaw(cmd);
+  } catch (e) {
+    const msg = String(e?.message ?? e);
+    // Best effort at recovering a numeric code from a thrown driver error. If
+    // it cannot be recovered the command is reported as a plain failure — never
+    // guessed into an idempotent one, because guessing here would mean
+    // reporting "already present" over an index that does not exist.
+    const m = /code[^0-9]{0,4}(\d{1,5})/i.exec(msg);
+    return {
+      ok: false,
+      code: m ? Number(m[1]) : null,
+      codeName: null,
+      errmsg: msg,
+      reply: null,
+      threw: true,
+      label,
+    };
+  }
+  return {
+    ok: numify(reply?.ok) === 1,
+    code: reply?.code === undefined ? null : numify(reply.code),
+    codeName: reply?.codeName ?? null,
+    errmsg: reply?.errmsg === undefined ? null : String(reply.errmsg),
+    reply,
+    threw: false,
+    label,
+  };
+}
+
+/** listIndexes, tolerating an absent collection (which is the pre-run state). */
+async function readIndexes() {
+  const r = await runCmd({ listIndexes: COLL }, "listIndexes");
+  if (!r.ok) {
+    if (r.code === NS_NOT_FOUND || /ns does not exist|NamespaceNotFound/i.test(String(r.errmsg))) {
+      return { absent: true, indexes: [] };
+    }
+    return { absent: false, indexes: null, error: r.errmsg };
+  }
+  return { absent: false, indexes: r.reply?.cursor?.firstBatch ?? [] };
+}
+
+function printIndexes(list) {
+  if (list === null) return console.log(`  (unreadable)`);
+  if (!list.length) return console.log(`  (none)`);
+  for (const i of [...list].sort((a, b) => String(a?.name).localeCompare(String(b?.name)))) {
+    const opts = { ...i };
+    delete opts.name;
+    delete opts.key;
+    delete opts.v;
+    delete opts.ns;
+    console.log(
+      `  ${String(i?.name ?? "(unnamed)").padEnd(26)} ${JSON.stringify(i?.key ?? {})}` +
+        `${Object.keys(opts).length ? `  ${JSON.stringify(opts)}` : ""}`,
+    );
+  }
+}
+
+async function main() {
+  banner("create-auth-allowlist.mjs", COMMIT);
+
+  // -- 0. BEFORE ------------------------------------------------------------
+  console.log(`--- [0] ${COLL} indexes BEFORE ---`);
+  const before = await readIndexes();
+  if (before.absent) {
+    console.log(`  collection ABSENT — this is the expected pre-rollout state`);
+  } else if (before.indexes === null) {
+    return abort(`could not read ${COLL} indexes: ${before.error}`);
+  } else {
+    printIndexes(before.indexes);
+  }
+
+  // -- 1. Existing rows, and whether they would VIOLATE the new indexes -----
+  //
+  // Read-only, and it exists so an E11000 under --commit is never a surprise.
+  // If the collection already holds rows (someone hand-inserted in Atlas, or an
+  // earlier partial rollout), a duplicate email or a duplicate pin makes
+  // createIndexes FAIL — the index is not built, M3 still does not exist, and
+  // the fix is in the DATA, not in this script.
+  let rows = [];
+  if (!before.absent) {
+    const f = await runCmd({ find: COLL, filter: {}, limit: 1000, batchSize: 1000 }, "find");
+    if (!f.ok) {
+      return abort(`could not read existing ${COLL} rows: ${f.errmsg}`);
+    }
+    rows = f.reply?.cursor?.firstBatch ?? [];
+  }
+  console.log(`\n--- [1] existing rows ---`);
+  console.log(`  ${COLL} documents: ${rows.length}`);
+  const dup = (field) => {
+    const seen = new Map();
+    for (const r of rows) {
+      const v = r?.[field];
+      if (v === undefined) continue;
+      seen.set(String(v), (seen.get(String(v)) ?? 0) + 1);
+    }
+    return [...seen].filter(([, n]) => n > 1).map(([v, n]) => `${JSON.stringify(v)} x${n}`);
+  };
+  const dupEmail = dup("email");
+  const dupPin = dup("pinnedUserID");
+  if (dupEmail.length || dupPin.length) {
+    console.error(`  duplicate email:        ${dupEmail.join(", ") || "(none)"}`);
+    console.error(`  duplicate pinnedUserID: ${dupPin.join(", ") || "(none)"}`);
+    return abort(
+      `existing rows already violate the uniqueness being requested. createIndexes ` +
+        `would fail with E11000 and build NOTHING. Resolve the duplicate rows first — ` +
+        `a duplicate pinnedUserID in particular means two addresses currently mint the ` +
+        `SAME identity key, which is the exact state M3 exists to make impossible.`,
+    );
+  }
+  if (rows.length) console.log(`  no duplicate email / pinnedUserID among them — safe to index`);
+
+  // -- 2. Plan --------------------------------------------------------------
+  const have = new Set((before.indexes ?? []).map((i) => String(i?.name ?? "")));
+  console.log(`\n--- [2] plan ---`);
+  console.log(
+    `  ${COMMIT ? "+" : "~"} create collection ${COLL}` +
+      `${before.absent ? "" : "   (already exists — will report NamespaceExists and continue)"}`,
+  );
+  for (const ix of INDEXES) {
+    console.log(
+      `  ${COMMIT ? "+" : "~"} createIndex ${ix.name.padEnd(14)} ${JSON.stringify(ix.key)} unique:true` +
+        `${have.has(ix.name) ? "   (already present)" : ""}`,
+    );
+  }
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing was created. Re-run with --commit to apply.`);
+    console.log(
+      `Then re-run \`node scripts/remediation/index-census.mjs\` and diff it against\n` +
+        `the census you took beforehand. The ONLY acceptable delta is the two indexes\n` +
+        `above; User.email_unique_ci must still be present.`,
+    );
+    return;
+  }
+
+  // -- 3. create ------------------------------------------------------------
+  console.log(`\n--- [3] create ---`);
+  const c = await runCmd({ create: COLL }, "create");
+  if (c.ok) {
+    console.log(`  created collection ${COLL}`);
+  } else if (IDEMPOTENT_CODES.has(c.code)) {
+    console.log(`  already present: ${IDEMPOTENT_CODES.get(c.code)} (code ${c.code})`);
+  } else {
+    // Not fatal on its own — createIndexes creates the collection implicitly —
+    // but it must be reported rather than silently absorbed, because an
+    // unexpected failure here (auth, quota, a locked namespace) is very likely
+    // to make the next command fail too, and the VERIFY pass is what decides.
+    console.error(
+      `  ! create FAILED: code=${c.code} codeName=${c.codeName} errmsg=${c.errmsg}` +
+        `${c.threw ? " (thrown, not returned)" : ""}`,
+    );
+    console.error(`    continuing to createIndexes — VERIFY below is the authority.`);
+  }
+
+  // -- 4. createIndexes -----------------------------------------------------
+  //
+  // Both indexes in ONE command. Mongo builds them together and reports one
+  // result, so there is no window in which `email` is unique and `pinnedUserID`
+  // is not.
+  console.log(`\n--- [4] createIndexes ---`);
+  const ci = await runCmd({ createIndexes: COLL, indexes: INDEXES }, "createIndexes");
+  if (ci.ok) {
+    const b = numify(ci.reply?.numIndexesBefore);
+    const a = numify(ci.reply?.numIndexesAfter);
+    console.log(`  ok — numIndexesBefore=${b} numIndexesAfter=${a}`);
+    if (ci.reply?.note) console.log(`  note: ${String(ci.reply.note)}   (already present)`);
+    // Belt and braces: createIndexes reports at the command level, but if a
+    // future server version ever reports per-index failures this catches them
+    // rather than reading ok:1 as done.
+    const w = inspectWriteReply(ci.reply, "createIndexes");
+    if (w.writeErrors.length) {
+      console.error(`  ! writeErrors: ${JSON.stringify(w.writeErrors)}`);
+    }
+  } else if (IDEMPOTENT_CODES.has(ci.code)) {
+    console.log(`  already present: ${IDEMPOTENT_CODES.get(ci.code)} (code ${ci.code})`);
+    if (ci.code === 85 || ci.code === 86) {
+      console.error(
+        `    WARNING: a CONFLICTING index exists — same name or same key, different\n` +
+          `    options. That is not the same as "already correct". VERIFY below checks\n` +
+          `    unique:true explicitly and will fail if what exists is not what M3 needs.`,
+      );
+    }
+  } else if (ci.code === 11000) {
+    return abort(
+      `E11000 while building the unique indexes: ${ci.errmsg}. Existing rows violate ` +
+        `uniqueness, so NOTHING was built and M3 does not exist. Fix the data first.`,
+    );
+  } else {
+    console.error(
+      `  ! createIndexes FAILED: code=${ci.code} codeName=${ci.codeName} errmsg=${ci.errmsg}` +
+        `${ci.threw ? " (thrown, not returned)" : ""}`,
+    );
+  }
+
+  // -- 5. VERIFY ------------------------------------------------------------
+  //
+  // The reply above is a claim; this is the measurement. Every path through
+  // this script lands here, including the "already present" ones, so the exit
+  // code always reflects the state of the CLUSTER and never the shape of a
+  // reply.
+  console.log(`\n=== VERIFY: ${COLL} indexes AFTER ===`);
+  const after = await readIndexes();
+  if (after.absent) {
+    return abort(`${COLL} still does not exist. Nothing was created.`);
+  }
+  if (after.indexes === null) {
+    return abort(`could not read ${COLL} indexes back: ${after.error}`);
+  }
+  printIndexes(after.indexes);
+
+  const problems = [];
+  for (const want of INDEXES) {
+    const got = after.indexes.find((i) => String(i?.name ?? "") === want.name);
+    if (!got) {
+      problems.push(`${want.name} is MISSING`);
+      continue;
+    }
+    if (got.unique !== true) {
+      problems.push(`${want.name} exists but unique=${JSON.stringify(got.unique)} — it enforces NOTHING`);
+    }
+    if (JSON.stringify(got.key ?? {}) !== JSON.stringify(want.key)) {
+      problems.push(
+        `${want.name} is on ${JSON.stringify(got.key ?? {})}, expected ${JSON.stringify(want.key)}`,
+      );
+    }
+  }
+
+  console.log(`\n================================`);
+  if (problems.length) {
+    for (const p of problems) console.error(`  RED  ${p}`);
+    return abort(
+      `the AuthAllowlist uniqueness guarantee (M3) is NOT in place. Do not provision ` +
+        `any EXT account until this is resolved: without pin_unique, two addresses can ` +
+        `be pinned to one identity key and admin.addAuthAllowlistEntry's P2002 refusal ` +
+        `can never fire.`,
+    );
+  }
+  console.log(`Both unique indexes are present and enforcing. M3 is live.`);
+  console.log(
+    `NOW re-run \`node scripts/remediation/index-census.mjs\` and diff it against the\n` +
+      `census taken before this script. The ONLY acceptable delta is the two indexes\n` +
+      `above. User.email_unique_ci MUST still be present.`,
+  );
+}
+
+main()
+  // Conditional on the exit code: printing "Done." under an ABORT banner is how
+  // an operator skim-reads a refusal as a success.
+  .then(() => console.log(process.exitCode ? "\nAborted — see above." : "\nDone."))
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/index-census.mjs
+++ b/scripts/remediation/index-census.mjs
@@ -1,0 +1,435 @@
+/**
+ * INDEX CENSUS. READ-ONLY — it issues `listCollections` and `listIndexes` and
+ * nothing else. Both are reads that take no locks. There is no `--commit` flag
+ * because there is no write path; passing one is refused.
+ *
+ *   node scripts/remediation/index-census.mjs
+ *   node scripts/remediation/index-census.mjs > census-before.txt
+ *
+ * WHY THIS EXISTS AT ALL — read this before deciding it is a footnote.
+ *
+ * Prisma's Mongo connector cannot represent every index this cluster carries.
+ * The one that matters most is `email_unique_ci` on `User`:
+ *
+ *   { key: {email:1}, name:"email_unique_ci", unique:true,
+ *     collation:{locale:"en", strength:2} }
+ *
+ * It is the ONLY thing stopping two rows differing solely in letter case from
+ * becoming two accounts for one human — the duplicate-account class this
+ * repository has already had to remediate by hand (merge-by-canonical.mjs,
+ * fix-*-duplicate.mjs). prisma/schema.prisma states the hazard explicitly, in
+ * the "⚠️ `prisma db push` DROPS" block of the comment directly above
+ * `model User` — SEARCH FOR "email_unique_ci"; do not go by a line number. (It
+ * is around lines 934-946 today. That is a HINT and is allowed to rot: this
+ * file used to cite `schema.prisma:877-887`, and line 877 has since become part
+ * of `model Restaurants`, so an operator following a RED banner under time
+ * pressure landed on a restaurant model.) `prisma db push` cannot see a
+ * collation index in the schema, so it classifies it as "not in schema" and
+ * DROPS IT — silently, and without needing --accept-data-loss. It has been
+ * dropped and restored before.
+ *
+ * So the phase-2 rule is: NEVER run `prisma db push` or `prisma migrate` on
+ * this cluster. The AuthAllowlist collection and its two unique indexes are
+ * created explicitly with `createIndexes`, by create-auth-allowlist.mjs.
+ *
+ * THIS SCRIPT IS THE PROOF, NOT THE PROMISE. Run it BEFORE any
+ * schema-adjacent operation and AGAIN afterwards, and DIFF THE TWO OUTPUTS.
+ * The only acceptable delta for phase 2 is the two new AuthAllowlist indexes.
+ * The repo documents `email_unique_ci` in one place; a document is a claim,
+ * this is a measurement, and only the measurement counts on the day.
+ *
+ * IT CENSUSES THE WHOLE CLUSTER, NOT A LIST OF FAVOURITES. The collections are
+ * DISCOVERED with `listCollections`, and every one of them is measured. This
+ * used to be a hand-written list of 15 names, which meant `Facilities`,
+ * `Account`, `Session`, `EventSignup` and `EventLock` were not in it — so a
+ * dropped index on any of them was INVISIBLE to the before/after diff that the
+ * entire `db push`-safety procedure rests on. A census that only looks where it
+ * expects trouble is not a census. The hand-written list survives as EXPECTED
+ * (below): a name on it that is missing from the cluster is still printed as
+ * `(absent)`, and the ones that cannot legitimately be missing are flagged.
+ *
+ * OUTPUT IS DESIGNED TO BE DIFFED, which is why it is deliberately boring:
+ *   - collections in SORTED order, so a collection appearing or disappearing
+ *     inserts or removes one block and moves nothing else. (This was a fixed
+ *     hand-written order for the same reason; sorting is what preserves the
+ *     property now that the list is discovered and can grow.)
+ *   - indexes within a collection sorted by name;
+ *   - every option except `key` rendered with recursively SORTED keys, so a
+ *     reply whose field order shifts between server versions still diffs clean;
+ *   - `key` rendered in its ORIGINAL order, because for a compound index the
+ *     field order is the index's meaning and sorting it would be a lie. This is
+ *     the one deliberate exception to "sort everything".
+ *
+ * A MISSING COLLECTION PRINTS `(absent)` AND IS NOT AN ERROR. `AuthAllowlist`
+ * is expected absent on the first run — that is the whole pre-rollout state.
+ * A missing collection is distinguished from an empty index list, which cannot
+ * happen (every collection has at least `_id_`).
+ *
+ * IF `listCollections` ITSELF FAILS the census falls back to the EXPECTED list
+ * and marks the whole run PARTIAL with exit 1 — because a narrowed census that
+ * does not say it was narrowed is exactly the false baseline this script is
+ * supposed to be an antidote to.
+ *
+ * THE ONE RED LINE: `email_unique_ci` missing from `User`. That exits 1. If it
+ * is gone, STOP and restore it before anything else touches this cluster:
+ *
+ *   db.runCommand({ createIndexes: "User", indexes: [{
+ *     key: { email: 1 }, name: "email_unique_ci", unique: true,
+ *     collation: { locale: "en", strength: 2 } }] })
+ *
+ * (the same one-liner appears inside that schema.prisma comment — search
+ * "createIndexes" within the `email_unique_ci` block). Note it will FAIL with
+ * E11000 if duplicates have already formed in the window it was absent — that
+ * failure is the point, and merge-by-canonical.mjs is the remedy.
+ */
+import { PrismaClient } from "@prisma/client";
+import { numify, isCommit, abort } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+
+/**
+ * NOT the census population — the census is whatever `listCollections` reports.
+ * This is the ASSERTION list: collections the phase-2 plan (F9) names, plus the
+ * ones the auth stack depends on, each of which must show up in the output. A
+ * name here that the cluster does not have is printed as `(absent)` and counted,
+ * so its disappearance is visible rather than silent.
+ *
+ * Grouped by why each is here rather than alphabetised (the OUTPUT is sorted;
+ * this list is documentation):
+ *   identity + authz    User, UserRole, FacilityAccess, RoleAuditLog
+ *   switches + sessions SystemFlag, PasswordResetSession
+ *   next-auth adapter   Account, Session
+ *   phase 2's new one   AuthAllowlist (expected ABSENT before the rollout)
+ *   profile + grants    UserMatric, ProfileCompletion, PendingRoleGrant, CcaHead
+ *   data the app joins  Facilities, Bookings, Posts, UserCCA, Event,
+ *                       EventSignup, EventLock
+ */
+const EXPECTED = [
+  "User",
+  "UserRole",
+  "FacilityAccess",
+  "RoleAuditLog",
+  "SystemFlag",
+  "PasswordResetSession",
+  "Account",
+  "Session",
+  "AuthAllowlist",
+  "UserMatric",
+  "ProfileCompletion",
+  "PendingRoleGrant",
+  "CcaHead",
+  "Facilities",
+  "Bookings",
+  "Posts",
+  "UserCCA",
+  "Event",
+  "EventSignup",
+  "EventLock",
+];
+
+/**
+ * The subset whose ABSENCE is a stop rather than a note.
+ *
+ * Deliberately short. `AuthAllowlist` is legitimately absent before step 19 and
+ * `Account`/`Session` only exist once the next-auth adapter has written one, so
+ * neither belongs here. These four have carried rows since phase 1 and are read
+ * on the authenticated request path; if `listCollections` cannot see one of
+ * them, either the census is looking at the wrong database or something has
+ * gone very wrong, and both answers are reached faster by exiting 1 than by
+ * printing `(absent)` into a diff.
+ */
+const MUST_EXIST = new Set(["User", "UserRole", "FacilityAccess", "RoleAuditLog"]);
+
+/** The index this whole script exists to watch. */
+const GUARD_COLLECTION = "User";
+const GUARD_INDEX = "email_unique_ci";
+
+/** Mongo's "namespace does not exist". Not an error here — see the header. */
+const NS_NOT_FOUND = 26;
+
+/**
+ * Recursively key-sorted JSON. Two servers (or two driver versions) may hand
+ * back the same option document with its fields in a different order; without
+ * this, a census diff would light up on a difference that does not exist.
+ * Used for OPTIONS ONLY — never for `key`, whose order is semantic.
+ */
+function stableJson(v) {
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(stableJson).join(",")}]`;
+  const keys = Object.keys(v).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableJson(v[k])}`).join(",")}}`;
+}
+
+/**
+ * `listIndexes`, tolerant of BOTH failure shapes.
+ *
+ * $runCommandRaw does not have one error convention. A command the server
+ * rejects can come back as DATA (`{ ok: 0, code, errmsg }`) or as a thrown
+ * PrismaClientKnownRequestError depending on the failure. A reader that only
+ * catches, or only inspects, mistakes one of them for success — and for a
+ * census "success with no indexes" reads as a collection that has been
+ * stripped bare, which is precisely the alarm this script is supposed to
+ * raise honestly. So: try/catch AND inspect `ok`.
+ *
+ * Returns { state: "ok" | "absent" | "error", indexes, detail }.
+ */
+async function listIndexes(coll) {
+  let reply;
+  try {
+    reply = await db.$runCommandRaw({ listIndexes: coll });
+  } catch (e) {
+    const msg = String(e?.message ?? e);
+    // The thrown shape carries no structured code we can rely on, so match the
+    // server's wording. Conservative: anything we cannot positively identify as
+    // "namespace missing" is reported as an ERROR, never as an absence.
+    if (/ns does not exist|NamespaceNotFound|Collection.*not found/i.test(msg)) {
+      return { state: "absent", indexes: [], detail: msg };
+    }
+    return { state: "error", indexes: [], detail: `threw: ${msg}` };
+  }
+  if (numify(reply?.ok) !== 1) {
+    const code = numify(reply?.code);
+    if (code === NS_NOT_FOUND) {
+      return { state: "absent", indexes: [], detail: String(reply?.errmsg ?? "") };
+    }
+    return {
+      state: "error",
+      indexes: [],
+      detail: `ok=${JSON.stringify(reply?.ok)} code=${code} errmsg=${String(reply?.errmsg ?? "(none)")}`,
+    };
+  }
+  return { state: "ok", indexes: reply?.cursor?.firstBatch ?? [], detail: "" };
+}
+
+/**
+ * Every collection that actually exists, discovered rather than assumed.
+ *
+ * NO SERVER-SIDE `filter`, and that is not a style choice — the same Atlas quirk
+ * preflight-scrc-validators.mjs documents: Atlas rejects
+ * `filter: { name: { $in: [...] } }` with "Error code 8000 (AtlasError): can't
+ * get regex from filter doc not a regex", because its listCollections filter
+ * accepts an exact string or a regex on `name` and nothing else. Ask for
+ * everything, narrow in JS. One round trip, read-only, and immune to the next
+ * Atlas quirk.
+ *
+ * VIEWS AND SYSTEM NAMESPACES ARE EXCLUDED. A view has no indexes of its own, so
+ * `listIndexes` against one fails — which would land in the `errors` list and
+ * mark an otherwise clean census PARTIAL. `system.*` is server bookkeeping.
+ *
+ * Returns { ok, names, detail }. `ok:false` is a PARTIAL census, never an empty
+ * one: a failed discovery must not be rendered as "the cluster has no
+ * collections", which is the fabricated-zero class this file already refuses
+ * elsewhere.
+ */
+async function listCollectionNames() {
+  let reply;
+  try {
+    reply = await db.$runCommandRaw({ listCollections: 1 });
+  } catch (e) {
+    return { ok: false, names: [], detail: `threw: ${String(e?.message ?? e)}` };
+  }
+  if (numify(reply?.ok) !== 1) {
+    return {
+      ok: false,
+      names: [],
+      detail: `ok=${JSON.stringify(reply?.ok)} code=${numify(reply?.code)} errmsg=${String(reply?.errmsg ?? "(none)")}`,
+    };
+  }
+  const batch = reply?.cursor?.firstBatch ?? [];
+  const names = batch
+    .filter((c) => (c?.type ?? "collection") === "collection")
+    .map((c) => String(c?.name ?? ""))
+    .filter((n) => n && !n.startsWith("system."));
+  if (names.length === 0) {
+    return { ok: false, names: [], detail: `listCollections returned no collections at all` };
+  }
+  return { ok: true, names, detail: "" };
+}
+
+/** One stable, diffable line per index. */
+function renderIndex(coll, idx) {
+  const name = String(idx?.name ?? "(unnamed)");
+  // ORIGINAL order — a compound index's field order is its meaning.
+  const key = JSON.stringify(idx?.key ?? {});
+  const opts = { ...idx };
+  // `v` is the index-format version and `ns` is echoed back by older servers;
+  // both are server bookkeeping that would add pure noise to every diff.
+  delete opts.name;
+  delete opts.key;
+  delete opts.v;
+  delete opts.ns;
+  const optKeys = Object.keys(opts).sort();
+  const rendered = optKeys.map((k) => `${k}=${stableJson(opts[k])}`).join(" ");
+  return `  ${coll.padEnd(22)} ${name.padEnd(26)} ${key}${rendered ? `  ${rendered}` : ""}`;
+}
+
+async function main() {
+  // Defence in depth. Nothing below can write — the only command issued is
+  // `listIndexes` — but an operator who typed --commit believes they are
+  // running a migration, and printing a census under that belief invites them
+  // to record it as the "after" of a step that never ran.
+  if (isCommit()) {
+    return abort(
+      "index-census.mjs is READ-ONLY and has no write path. Drop --commit / APPLY=yes. " +
+        "If you meant to CREATE the AuthAllowlist indexes, that is create-auth-allowlist.mjs.",
+    );
+  }
+
+  console.log(`\n=== index-census.mjs (READ-ONLY) ===`);
+  console.log(`at:   ${new Date().toISOString()}`);
+  console.log(`Diff this against the run you took before/after the change.\n`);
+
+  // DISCOVER, then union with EXPECTED. The union is what makes a MISSING
+  // expected collection visible: discovery alone would simply not print it, and
+  // a diff cannot show the absence of a line that was never going to be there.
+  const disco = await listCollectionNames();
+  const errors = [];
+  if (!disco.ok) {
+    console.error(`  *** listCollections FAILED — ${disco.detail}`);
+    console.error(
+      `  Falling back to the ${EXPECTED.length} EXPECTED collections. This census is\n` +
+        `  PARTIAL: any collection outside that list is unmeasured, so it cannot be\n` +
+        `  used as the before/after baseline for a schema-adjacent change.`,
+    );
+    errors.push(`listCollections: ${disco.detail}`);
+  }
+  const discovered = new Set(disco.names);
+
+  // Sorted, so a new collection inserts one block and moves nothing else.
+  const census = [...new Set([...disco.names, ...EXPECTED])].sort();
+  const unexpected = census.filter((c) => discovered.has(c) && !EXPECTED.includes(c));
+
+  console.log(`  collections discovered: ${disco.ok ? disco.names.length : "(discovery failed)"}`);
+  console.log(`  collections censused:   ${census.length}  (discovered ∪ expected)\n`);
+  console.log(`  ${"collection".padEnd(22)} ${"index".padEnd(26)} key  options`);
+  console.log(`  ${"-".repeat(22)} ${"-".repeat(26)} ${"-".repeat(30)}`);
+
+  let guardPresent = false;
+  let guardLine = null;
+  const absent = [];
+  const missingRequired = [];
+  let total = 0;
+
+  for (const coll of census) {
+    const r = await listIndexes(coll);
+
+    if (r.state === "absent") {
+      // NOT an error by default. AuthAllowlist is expected absent before step 19
+      // of the rollout, and several of the others are droplet-owned collections
+      // that may simply not exist on a given cluster.
+      //
+      // MUST_EXIST is the exception, and it is what keeps the widened census
+      // from being purely additive: a name on the EXPECTED list that vanishes
+      // from the cluster now produces a LINE (`(absent)`) rather than nothing at
+      // all, and for these four it also stops the run.
+      const required = MUST_EXIST.has(coll);
+      console.log(`  ${coll.padEnd(22)} (absent)${required ? "   *** REQUIRED — see below" : ""}`);
+      absent.push(coll);
+      if (required) missingRequired.push(coll);
+      continue;
+    }
+    if (r.state === "error") {
+      // A command that FAILED must never be rendered as "no indexes". That is
+      // the fabricated-zero class: it would read as a collection someone has
+      // stripped, and send the operator to re-create indexes that are fine.
+      console.log(`  ${coll.padEnd(22)} *** UNREADABLE — ${r.detail}`);
+      errors.push(`${coll}: ${r.detail}`);
+      continue;
+    }
+
+    // Sorted by name so the census does not reorder when Mongo does.
+    const sorted = [...r.indexes].sort((a, b) =>
+      String(a?.name ?? "").localeCompare(String(b?.name ?? "")),
+    );
+    if (sorted.length === 0) {
+      // Not reachable in practice — every collection has `_id_` — so if it ever
+      // prints, something is wrong with the READ, not with the collection.
+      console.log(`  ${coll.padEnd(22)} *** ZERO INDEXES (impossible — every collection has _id_)`);
+      errors.push(`${coll}: listIndexes returned an empty list`);
+      continue;
+    }
+    for (const idx of sorted) {
+      const lineText = renderIndex(coll, idx);
+      console.log(lineText);
+      total++;
+      if (coll === GUARD_COLLECTION && String(idx?.name ?? "") === GUARD_INDEX) {
+        guardPresent = true;
+        guardLine = lineText.trim();
+      }
+    }
+  }
+
+  console.log(`\n--- summary ---`);
+  console.log(`  collections discovered ...... ${disco.ok ? disco.names.length : "(discovery FAILED)"}`);
+  console.log(`  collections censused ........ ${census.length}`);
+  console.log(`  collections absent .......... ${absent.length}${absent.length ? `  [${absent.join(", ")}]` : ""}`);
+  console.log(`  collections unreadable ...... ${errors.length}`);
+  console.log(`  indexes counted ............. ${total}`);
+  // Informational. A collection nobody thought to name is exactly the kind this
+  // census was widened to cover, so seeing it listed is the feature working —
+  // and a NEW name appearing here between two runs is itself worth a look.
+  console.log(
+    `  outside the expected list ... ${unexpected.length}${unexpected.length ? `  [${unexpected.join(", ")}]` : ""}`,
+  );
+
+  if (missingRequired.length) {
+    console.error(`\n  *** RED: required collection(s) MISSING: ${missingRequired.join(", ")} ***`);
+    console.error(
+      `  These carry rows on the authenticated request path and cannot legitimately\n` +
+        `  be absent. Either this census is pointed at the wrong database (check\n` +
+        `  DATABASE_URL's db name) or something has removed them. Do not use this\n` +
+        `  output as a baseline; resolve it first.`,
+    );
+    process.exitCode = 1;
+  }
+
+  console.log(`\n--- the guard index ---`);
+  if (guardPresent) {
+    console.log(`  OK   ${GUARD_COLLECTION}.${GUARD_INDEX} is PRESENT`);
+    console.log(`       ${guardLine}`);
+    console.log(
+      `       This is the case-insensitive unique index on User.email. It is the\n` +
+        `       duplicate-account guard, it is NOT representable in schema.prisma,\n` +
+        `       and \`prisma db push\` DROPS IT without warning. Re-run this census\n` +
+        `       after anything schema-adjacent and confirm this line is still here.`,
+    );
+  } else {
+    console.error(`\n  *** RED: ${GUARD_COLLECTION}.${GUARD_INDEX} IS MISSING ***`);
+    console.error(
+      `  The case-insensitive unique index on User.email is GONE. Duplicate\n` +
+        `  accounts differing only in letter case can be created RIGHT NOW, and\n` +
+        `  nothing in the application will notice. The usual cause is that someone\n` +
+        `  ran \`prisma db push\` — see prisma/schema.prisma, the "⚠️ prisma db push\n` +
+        `  DROPS" block in the comment above \`model User\` (search: email_unique_ci).\n\n` +
+        `  STOP. Restore it before any other work on this cluster:\n\n` +
+        `    db.runCommand({ createIndexes: "User", indexes: [{\n` +
+        `      key: { email: 1 }, name: "email_unique_ci", unique: true,\n` +
+        `      collation: { locale: "en", strength: 2 } }] })\n\n` +
+        `  If that fails with E11000, duplicates have ALREADY formed in the window\n` +
+        `  it was absent. Do not force it — run merge-by-canonical.mjs (dry run\n` +
+        `  first) to resolve them, then create the index.`,
+    );
+    process.exitCode = 1;
+  }
+
+  if (errors.length) {
+    console.error(`\n  COMMANDS THAT FAILED (these are NOT measured absences):`);
+    for (const e of errors) console.error(`      ${e}`);
+    console.error(
+      `  A census with a failed read is a PARTIAL census. Do not paste it into\n` +
+        `  the PR as the before/after baseline until every line above resolves.`,
+    );
+    process.exitCode = 1;
+  }
+
+  if (!process.exitCode) {
+    console.log(`\nCensus complete. Nothing was written.`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/inventory-rbac.mjs
+++ b/scripts/remediation/inventory-rbac.mjs
@@ -277,7 +277,7 @@ async function step5() {
   const template = {
     _comment: "facilityID -> requiredRoles. Facilities NOT listed here get [\"resident\"]. " +
       "facilityID -1 is the Calender_v2.tsx:306 sentinel and is excluded entirely. " +
-      "Allowed values: resident | jcrc | cca_head. NEVER \"admin\" — admin is an implicit bypass, never stored.",
+      "Allowed values: resident | jcrc | cca_head | scrc. NEVER \"admin\" — admin is an implicit bypass, never stored.",
     _reviewedBy: null,
     _reviewedAt: null,
     byFacilityID: Object.fromEntries(

--- a/scripts/remediation/lib/identity.mjs
+++ b/scripts/remediation/lib/identity.mjs
@@ -80,11 +80,72 @@ export function canonicalUserID(email) {
 }
 
 /**
+ * THE EXTERNAL IDENTITY NAMESPACE. An admin-pinned key for a principal that has
+ * no @u.nus.edu address — hall office staff, whose addresses are @nus.edu.sg
+ * (08-userid-keydrift.md §3 Branch C). One `AuthAllowlist` row pins one address
+ * to one of these.
+ *
+ * THE ':' IS THE WHOLE MECHANISM (M1). NUS_STUDENT_EMAIL's capture class is
+ * `[A-Z0-9._%-]` — it does not contain ':' — so `canonicalUserID()` can NEVER
+ * return a string matching this pattern, for ANY input, because every character
+ * it can return comes from that class. The two key spaces are PROVABLY
+ * DISJOINT, not conventionally separate.
+ *
+ * That is what makes the attack in 05-verification.md §164 —
+ * `{ email: "attacker@gmail.com", pinnedUserID: "E1633673" }`, which would
+ * hand an admin's authorization key to a stranger with NO grant path and
+ * therefore NO escalation guard firing — UNREPRESENTABLE rather than merely
+ * refused. `isExtUserID("E1633673")` is false, and the parity gate asserts it.
+ *
+ * Uppercase and `_` only, so a pin is legible in `RoleAuditLog.actorUserID` and
+ * greppable across collections. Length-bounded at both ends: the 3-char floor
+ * keeps `EXT:` alone from being a key, and the 32-char ceiling stops an id
+ * being used to smuggle a payload into an audit row.
+ *
+ * WHY THIS IS MIRRORED INTO THE .mjs AT ALL, when the TS half's value is the
+ * brand and brands are erased: same answer as asStoredCanonicalUserID below.
+ * The runtime half — "return the absent value for anything failing the shape
+ * test" — is the load-bearing half, and it is the half the scripts need.
+ * provision-ext-account.mjs must refuse a pin outside this namespace, and
+ * rbac-doctor.mjs must be able to REPORT a stored pin that is outside it (that
+ * is a row which mints no identity at all — see M2 in
+ * src/server/api/services/authAllowlist.ts). Both would otherwise hand-roll the
+ * regex, which verify-identity-parity.mjs's private-derivation ban exists to
+ * stop.
+ */
+export const EXT_ID = /^EXT:[A-Z0-9_]{3,32}$/;
+
+/** Pure shape test over the EXT namespace. See EXT_ID for why ':' matters. */
+export function isExtUserID(id) {
+  return typeof id === "string" && EXT_ID.test(id);
+}
+
+/**
+ * The ONE minting function for the EXT half of the brand — the exact mirror of
+ * asStoredCanonicalUserID for the canonical half, and A RUNTIME CHECK, NEVER A
+ * CAST. Every EXT id in this codebase passes through here.
+ *
+ * On the .ts side it is what pinnedUserIDFor calls on the value it READ BACK
+ * OUT OF MONGO (mechanism M2), so a row typed by hand in Atlas mints NO
+ * IDENTITY AT ALL rather than a bad one. On this side it is the same refusal,
+ * available to scripts that have no type system watching them.
+ */
+export function asExtUserID(id) {
+  return isExtUserID(id) ? id : null;
+}
+
+/**
  * POST-CANONICALIZATION SANITY CHECK. A pure SHAPE test carrying no
  * provenance — sound only over a string canonicalUserID() has just produced.
  * Backfills and merge scripts must call it as
  * `isCanonicalResidentID(canonicalUserID(user.email))`, never on a userID read
  * straight out of a document (I-8d).
+ *
+ * AN `EXT:` PIN PASSES THIS TEST — a documented false positive, asserted as
+ * such by the parity gate. Safe only because every baseline writer takes an
+ * EMAIL and canonicalizes internally (I-8d), so ensureBaseline returns false at
+ * its `!userID` clause long before this predicate is consulted. See the fuller
+ * note in src/lib/identity.ts.
  */
 export function isCanonicalResidentID(userID) {
   return typeof userID === "string" && userID.length > 0 && !userID.includes("@");

--- a/scripts/remediation/lib/rbac.mjs
+++ b/scripts/remediation/lib/rbac.mjs
@@ -235,12 +235,19 @@ export function inspectWriteReply(reply, label) {
 }
 
 /** Role vocabulary. roles[] lives in a collection with NO $jsonSchema validator,
- *  so nothing but code constrains what strings land there (06 D1). */
-export const ROLE_VOCAB = ["admin", "jcrc", "cca_head", "resident"];
+ *  so nothing but code constrains what strings land there (06 D1).
+ *
+ *  MUST match ROLES in src/server/api/services/roles.ts. This list is what
+ *  rbac-doctor.mjs calls "out of vocabulary": a role added to the app but not
+ *  here makes the doctor RED on every legitimate grant, which is why "scrc" is
+ *  added HERE FIRST, before anyone can hold it. */
+export const ROLE_VOCAB = ["admin", "jcrc", "cca_head", "resident", "scrc"];
 
 /** Values legal in FacilityAccess.requiredRoles. A DIFFERENT enum from
- *  GRANTABLE_ROLES. "admin" is an implicit bypass and is NEVER stored. */
-export const FACILITY_ROLES = ["resident", "jcrc", "cca_head"];
+ *  GRANTABLE_ROLES. "admin" is an implicit bypass and is NEVER stored.
+ *  "scrc" is here because the SCRC Room (facilityID 17) is gated on
+ *  ["jcrc","scrc"] — the hall office books its own room. */
+export const FACILITY_ROLES = ["resident", "jcrc", "cca_head", "scrc"];
 
 /**
  * Highest privilege first. Single source of truth for the legacy mirror.
@@ -250,6 +257,15 @@ export const FACILITY_ROLES = ["resident", "jcrc", "cca_head"];
  * FacilityAccess.requiredRole would make a Phase-2 revert DENY that room to
  * every non-admin. And roles[0] is NOT a substitute: it would mirror an
  * admin+jcrc user as "jcrc", silently demoting them on rollback.
+ *
+ * "scrc" is deliberately absent for the SAME reason, and the omission is
+ * load-bearing rather than an oversight. The only consumer of the mirror is the
+ * pre-v2 access.ts, which knows nothing of "scrc"; mirroring a jcrc+scrc holder
+ * as "scrc" would write an uninterpretable scalar and DEMOTE that person out of
+ * the SCRC Room and /admin on a rollback. Leaving it out mirrors them as "jcrc"
+ * (correct) and mirrors a plain scrc holder as "" (falsy, benign — exactly the
+ * resident treatment). Must stay identical to PRECEDENCE in
+ * src/server/api/services/roles.ts: three elements, in this order.
  */
 export const PRECEDENCE = ["admin", "jcrc", "cca_head"];
 export const legacyMirror = (roles) => PRECEDENCE.find((r) => (roles ?? []).includes(r)) ?? "";

--- a/scripts/remediation/preflight-scrc-validators.mjs
+++ b/scripts/remediation/preflight-scrc-validators.mjs
@@ -1,0 +1,671 @@
+/**
+ * The `scrc` rollout pre-flight. READ-ONLY — it issues no write of any kind.
+ *
+ *   node scripts/remediation/preflight-scrc-validators.mjs
+ *
+ * RUN THIS BEFORE GRANTING ANYONE THE `scrc` ROLE, and before writing
+ * `SystemFlag { key: "scrc.enabled" }` or re-gating facility 17. It answers the
+ * one question that, if answered wrong, makes the whole rollout fail silently.
+ *
+ * THE QUESTION. `UserRole.roles` and `FacilityAccess.requiredRoles` are Mongo
+ * `String[]`s, so Prisma needs no migration to store a new role — that is why
+ * this change requires NO `prisma db push` (which in this cluster silently
+ * drops non-schema indexes such as `roles_multikey`) and no `prisma migrate`.
+ * But a `$jsonSchema` validator on either collection COULD enumerate the legal
+ * role strings, and if one does, every write carrying "scrc" is rejected with
+ * code 121.
+ *
+ * WHY THAT REJECTION IS DANGEROUS RATHER THAN MERELY ANNOYING: a `$jsonSchema`
+ * rejection arrives from `$runCommandRaw` as DATA — `{ ok: 1, writeErrors: [{
+ * code: 121 }] }` — not as a thrown exception (see the note at
+ * merge-by-canonical.mjs, and I-8f in services/roles.ts). A caller that only
+ * reads the catch block sees success. The grant would appear to work and would
+ * not exist.
+ *
+ * FOUR INDEPENDENT IN-REPO SOURCES say neither collection is validated —
+ * lib/rbac.mjs's ROLE_VOCAB note, rbac-doctor.mjs's stray-role note,
+ * verify-legacy-drop.mjs, and docs/plans/rbac/04-profile-page.md — and
+ * prisma/schema.prisma says FacilityAccess was created precisely BECAUSE the
+ * `Facilities` collection is validated. This script confirms that against the
+ * LIVE cluster, which is the only source that counts on the day.
+ *
+ * EXPECTED RESULT: `validator: null` for both ROLE collections, and the script
+ * exits 0. If either returns a non-null validator that enumerates role strings,
+ * it exits 1 and you must run
+ *
+ *   db.runCommand({ collMod: "<name>", validator: <the existing one, with
+ *                   "scrc" added>, validationLevel: "moderate" })
+ *
+ * BEFORE any grant and before flipping the flag.
+ *
+ * It also reports the out-of-vocabulary role-string count, so you have the
+ * before-baseline that `rbac-doctor.mjs` must still show as 0 after the grant
+ * (which is what proves ROLE_VOCAB in lib/rbac.mjs was updated first).
+ *
+ * ===========================================================================
+ * PHASE 2 EXTENSION — `User` and `AuthAllowlist`
+ * ===========================================================================
+ *
+ * Phase 2 INSERTS A `User` ROW (provision-ext-account.mjs), and that is new:
+ * every previous step in this rollout only ever wrote to collections with no
+ * validator. `User` HAS a `$jsonSchema` validator — prisma/schema.prisma carries
+ * the marker directly above `model User` (SEARCH FOR: "This collection uses a
+ * JSON Schema defined in the database"), and 00-overview.md:318 enumerates the
+ * validated set as User / Facilities / CCA / UserCCA / Posts.
+ *
+ * CITED BY SEARCH STRING, NOT BY LINE NUMBER, THROUGHOUT THIS FILE. The old
+ * citation `schema.prisma:875` rotted when the schema grew: line 875 now lands
+ * inside `model Restaurants`, so an operator following a RED banner under time
+ * pressure arrived at a restaurant model. Line ranges below appear only as
+ * parenthesised HINTS and are allowed to be stale; the quoted search string is
+ * the anchor.
+ *
+ * The row phase 2 writes is deliberately SPARSE:
+ *     { email, displayName, userID: "EXT:…" }
+ * with `passwordHash` OMITTED (so the account cannot be logged into until the
+ * reset flow sets one) and `block` / `telegramHandle` / `bio` OMITTED (hall
+ * office staff have no hall block and publish no Telegram handle). If the
+ * validator lists any of those in `required`, or declares
+ * `additionalProperties: false` without declaring the three fields we do send,
+ * or puts a `pattern` (or an `enum`) on `userID` that "EXT:NGOCANH_MAI" fails,
+ * THE INSERT IS REJECTED WITH CODE 121.
+ *
+ * THE CONSTRAINTS ARE NOT ALWAYS AT THE TOP LEVEL, AND READING ONLY THE TOP
+ * LEVEL IS HOW THIS CHECK PRINTS A FALSE "OK". A `$jsonSchema` may express the
+ * same three things inside `allOf` / `anyOf` / `oneOf` — which is legal, and is
+ * what a validator naturally turns into once it has been edited a few times.
+ * Such a validator has NO top-level `required` at all, so a reader that does
+ * `schema.required ?? []` sees an empty list and cheerfully reports that
+ * nothing required is missing, for a validator that WILL reject the sparse row
+ * with code 121. The operator then proceeds to provisioning and finds out
+ * there.
+ *
+ * So the checks below WALK the schema: top level plus every branch of every
+ * combinator, recursively. The direction of every judgement is FAIL-SAFE:
+ *   - a field required in ANY branch is treated as required;
+ *   - EVERY subschema that declares `additionalProperties: false` must itself
+ *     declare all three fields we send (that is draft-4 semantics: the keyword
+ *     is evaluated against the `properties` of the SAME subschema, not against
+ *     the union);
+ *   - a `pattern`/`enum` on `userID` in ANY branch must accept the real pins.
+ * The last two are deliberately over-strict for `anyOf`/`oneOf`, where only one
+ * branch has to match. That trade is made on purpose: a false STOP costs one
+ * hand inspection, a false OK costs a failed provisioning mid-rollout.
+ *
+ * AND WHAT THE WALK CANNOT INTERPRET, IT REFUSES TO PASS. The walk works off an
+ * ALLOWLIST of keywords (INTERPRETABLE_KEYWORDS below), so anything it has not
+ * been taught — `$ref`, `not`, `dependentRequired`, `patternProperties`,
+ * `minProperties`, an `if`/`then`, a schema-valued `additionalProperties`, or
+ * whatever a future MongoDB adds — is reported as UNINTERPRETABLE and STOPS the
+ * pre-flight with an instruction to read the printed JSON by hand against the
+ * exact field list. That is the same posture this file already takes for a
+ * non-`$jsonSchema` (query-operator) validator: "cannot verify" is a stop, not
+ * a pass.
+ *
+ * THAT IS WHY THIS IS A STOP-THE-LINE CHECK RATHER THAN A NICE-TO-HAVE. Code
+ * 121 from `$runCommandRaw` arrives as DATA — `{ok:1, writeErrors:[{code:121}]}`
+ * — not as a throw. provision-ext-account.mjs uses Prisma's TYPED `create`,
+ * which does throw, so it will not lie about it; but discovering the constraint
+ * from a failed provisioning run mid-rollout is strictly worse than reading it
+ * here first, and if a validator DOES demand `passwordHash` then the whole
+ * "no password until the reset link" design has to change, not just one line.
+ *
+ * `AuthAllowlist` is EXPECTED ABSENT on the first run — it does not exist until
+ * create-auth-allowlist.mjs runs. Absent is reported, never an error. A
+ * brand-new collection carries no validator; this is where that is confirmed
+ * rather than assumed.
+ */
+import { PrismaClient } from "@prisma/client";
+import { ROLE_VOCAB } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+
+/** Every collection phase 1 or phase 2 writes to. */
+const COLLECTIONS = ["UserRole", "FacilityAccess", "User", "AuthAllowlist"];
+
+/** The two whose validator must be NULL — a validator on either could enumerate
+ *  legal role strings and reject every write carrying "scrc". */
+const ROLE_COLLECTIONS = ["UserRole", "FacilityAccess"];
+
+/** Fields provision-ext-account.mjs deliberately OMITS from the User row. If
+ *  any of these is `required`, the sparse row is rejected and the design of the
+ *  provisioning flow — no password until the reset link — has to change. */
+const MUST_NOT_BE_REQUIRED = ["passwordHash", "block", "telegramHandle", "bio"];
+
+/** Fields it DOES send. Under `additionalProperties: false` each must be a
+ *  declared property or the insert is rejected. */
+const FIELDS_SENT = ["email", "displayName", "userID"];
+
+/** The pins the rollout will actually use. Tested against any `pattern` the
+ *  validator puts on `userID` — a shape test on a made-up example would not
+ *  prove anything about the values that are really going in. */
+const PINS = ["EXT:NGOCANH_MAI", "EXT:VINCENT_KOH"];
+
+/** The combinators the walk descends into. Every branch of each is collected. */
+const COMBINATORS = ["allOf", "anyOf", "oneOf"];
+
+/**
+ * KEYWORDS THIS SCRIPT CLAIMS TO UNDERSTAND — an ALLOWLIST, not a blocklist,
+ * and that direction is the whole safety property.
+ *
+ * A blocklist of "dangerous" keywords fails open: the next keyword nobody
+ * thought of (or the next one MongoDB adds) sails through and the pre-flight
+ * prints OK over a validator it never evaluated. An allowlist fails closed —
+ * an unrecognised keyword is reported as UNINTERPRETABLE and stops the run.
+ *
+ * What is on the list is exactly what cannot change the answer to "is a
+ * three-field document with these values accepted":
+ *   - annotations (`title`, `description`) — no effect on validation;
+ *   - VALUE constraints (`bsonType`, `type`, `pattern`, `enum`, the length /
+ *     numeric / array bounds) — they constrain values of fields, and the ones
+ *     that could reject OUR values are checked explicitly below for `userID`;
+ *   - `required`, `properties`, `additionalProperties` — collected and checked;
+ *   - the three combinators — descended into.
+ *
+ * DELIBERATELY ABSENT, so that they trip the backstop: `$ref` (indirection this
+ * script cannot resolve), `not` (inverts the sense of everything under it, so
+ * fail-safe collection becomes fail-OPEN), `dependentRequired` / `dependencies`
+ * (makes a field required conditionally on another), `patternProperties` (can
+ * satisfy `additionalProperties:false` for names we would report as
+ * undeclared), `minProperties` (can reject a sparse row on COUNT alone),
+ * `if`/`then`/`else`, `propertyNames`, `unevaluatedProperties`.
+ */
+const INTERPRETABLE_KEYWORDS = new Set([
+  "title",
+  "description",
+  "bsonType",
+  "type",
+  "enum",
+  "pattern",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "items",
+  "required",
+  "properties",
+  "additionalProperties",
+  ...COMBINATORS,
+]);
+
+/** A fresh accumulator for one walk. Every entry carries the JSON PATH it came
+ *  from, because "required demands passwordHash" and "required demands
+ *  passwordHash inside allOf[2]" send an operator to two different places in
+ *  the printed JSON. */
+const newAcc = () => ({
+  /** { field, path } — required in ANY branch counts. */
+  required: [],
+  /** { path, declared[] } — one entry per subschema closing the document. */
+  closed: [],
+  /** { field, path, keyword, value } — value constraints on the fields we send. */
+  valueConstraints: [],
+  /** { path, why } — anything the allowlist did not cover. NON-EMPTY MEANS STOP. */
+  unhandled: [],
+});
+
+const isPlainObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+
+/**
+ * Walk a SUBSCHEMA that applies to the whole document (the top level, and every
+ * combinator branch of it), collecting `required`, `additionalProperties:false`
+ * and the property declarations at each level.
+ *
+ * `properties.<f>` subschemas are NOT walked by this function — they constrain a
+ * VALUE, not the document, and hoisting a nested object's `required` into the
+ * document's required set would invent a constraint that is not there. They go
+ * to walkValueSchema instead.
+ */
+function walkDocSchema(node, path, acc) {
+  if (!isPlainObject(node)) {
+    acc.unhandled.push({ path, why: `subschema is ${JSON.stringify(node)}, not an object` });
+    return;
+  }
+
+  for (const k of Object.keys(node)) {
+    if (!INTERPRETABLE_KEYWORDS.has(k)) {
+      acc.unhandled.push({ path: `${path}.${k}`, why: `keyword "${k}" is not one this script can evaluate` });
+    }
+  }
+
+  // -- required ------------------------------------------------------------
+  if (node.required !== undefined) {
+    if (Array.isArray(node.required)) {
+      for (const f of node.required) acc.required.push({ field: String(f), path });
+    } else {
+      acc.unhandled.push({ path: `${path}.required`, why: `"required" is ${JSON.stringify(node.required)}, not an array` });
+    }
+  }
+
+  // -- properties ----------------------------------------------------------
+  let declared = [];
+  if (node.properties !== undefined) {
+    if (isPlainObject(node.properties)) {
+      declared = Object.keys(node.properties);
+      for (const f of FIELDS_SENT) {
+        if (f in node.properties) {
+          walkValueSchema(f, node.properties[f], `${path}.properties.${f}`, acc);
+        }
+      }
+    } else {
+      acc.unhandled.push({ path: `${path}.properties`, why: `"properties" is not an object` });
+    }
+  }
+
+  // -- additionalProperties ------------------------------------------------
+  //
+  // Draft-4 semantics, which is what MongoDB implements: this keyword is
+  // evaluated against the `properties` of THIS subschema alone. A branch that
+  // closes the document while declaring only two of our three fields rejects
+  // the third, no matter what the top level declares — which is exactly the
+  // case the old top-level-only read could not see.
+  if (node.additionalProperties === false) {
+    acc.closed.push({ path, declared });
+  } else if (node.additionalProperties !== undefined && node.additionalProperties !== true) {
+    acc.unhandled.push({
+      path: `${path}.additionalProperties`,
+      why: `additionalProperties is a SUBSCHEMA (${JSON.stringify(node.additionalProperties).slice(0, 80)}), not true/false`,
+    });
+  }
+
+  // -- combinators ---------------------------------------------------------
+  for (const comb of COMBINATORS) {
+    if (node[comb] === undefined) continue;
+    if (!Array.isArray(node[comb])) {
+      acc.unhandled.push({ path: `${path}.${comb}`, why: `"${comb}" is not an array` });
+      continue;
+    }
+    node[comb].forEach((branch, i) => walkDocSchema(branch, `${path}.${comb}[${i}]`, acc));
+  }
+}
+
+/**
+ * Walk the subschema attached to ONE property we send, collecting the value
+ * constraints that could reject the value we are actually going to write. Same
+ * combinator descent, same allowlist backstop — a `pattern` hidden under
+ * `properties.userID.anyOf[1]` rejects the pin just as hard as one at the top.
+ */
+function walkValueSchema(field, node, path, acc) {
+  if (!isPlainObject(node)) {
+    acc.unhandled.push({ path, why: `property subschema is ${JSON.stringify(node)}, not an object` });
+    return;
+  }
+  for (const k of Object.keys(node)) {
+    if (!INTERPRETABLE_KEYWORDS.has(k)) {
+      acc.unhandled.push({ path: `${path}.${k}`, why: `keyword "${k}" is not one this script can evaluate` });
+    }
+  }
+  if (typeof node.pattern === "string") {
+    acc.valueConstraints.push({ field, path, keyword: "pattern", value: node.pattern });
+  } else if (node.pattern !== undefined) {
+    acc.unhandled.push({ path: `${path}.pattern`, why: `"pattern" is not a string` });
+  }
+  if (node.enum !== undefined) {
+    if (Array.isArray(node.enum)) {
+      acc.valueConstraints.push({ field, path, keyword: "enum", value: node.enum });
+    } else {
+      acc.unhandled.push({ path: `${path}.enum`, why: `"enum" is not an array` });
+    }
+  }
+  for (const comb of COMBINATORS) {
+    if (node[comb] === undefined) continue;
+    if (!Array.isArray(node[comb])) {
+      acc.unhandled.push({ path: `${path}.${comb}`, why: `"${comb}" is not an array` });
+      continue;
+    }
+    node[comb].forEach((branch, i) => walkValueSchema(field, branch, `${path}.${comb}[${i}]`, acc));
+  }
+  // `properties` / `required` under a property subschema describe a NESTED
+  // OBJECT. None of the three fields we send is an object, so a validator that
+  // puts them there is describing something this script's model does not cover.
+  if (node.properties !== undefined || node.required !== undefined) {
+    acc.unhandled.push({
+      path,
+      why: `this property is described as an OBJECT (it carries properties/required); the three fields written are scalars, so this validator is not the one this script was written against`,
+    });
+  }
+}
+
+let failed = 0;
+const fail = (m) => {
+  console.error(`  FAIL  ${m}`);
+  failed++;
+};
+
+async function main() {
+  console.log(`\n=== preflight-scrc-validators.mjs (READ-ONLY) ===\n`);
+  console.log(`ROLE_VOCAB in lib/rbac.mjs: ${JSON.stringify(ROLE_VOCAB)}`);
+  if (!ROLE_VOCAB.includes("scrc")) {
+    fail(
+      `"scrc" is NOT in ROLE_VOCAB. Step 1 of the rollout has not landed — ` +
+        `rbac-doctor.mjs will report every scrc grant as an out-of-vocabulary ` +
+        `stray and exit 1. Fix lib/rbac.mjs before granting the role.`,
+    );
+  }
+
+  // [1] THE check. listCollections is a read; it takes no locks and writes
+  //     nothing. `options.validator` is present only if one was ever installed.
+  //
+  //     NO SERVER-SIDE `filter`, and that is not a style choice. Atlas rejects
+  //     `filter: { name: { $in: [...] } }` on this command with
+  //     "Error code 8000 (AtlasError): can't get regex from filter doc not a
+  //     regex" — its listCollections filter accepts an exact string or a regex
+  //     on `name` and nothing else. Asking for everything and narrowing in JS
+  //     is one round trip, still read-only, and cannot be broken by the next
+  //     Atlas quirk. Verified against the live cluster.
+  console.log(`\n[1] $jsonSchema validators on every collection this rollout writes`);
+  const reply = await db.$runCommandRaw({ listCollections: 1 });
+  const batch = (reply?.cursor?.firstBatch ?? []).filter((c) =>
+    COLLECTIONS.includes(c.name),
+  );
+
+  const found = batch.map((c) => ({
+    name: c.name,
+    validator: c.options?.validator ?? null,
+    validationLevel: c.options?.validationLevel ?? null,
+    validationAction: c.options?.validationAction ?? null,
+  }));
+
+  for (const name of COLLECTIONS) {
+    const row = found.find((c) => c.name === name);
+    console.log(`\n  --- ${name} ---`);
+    if (!row) {
+      // Not fatal, ever. A collection Prisma has never written may not exist,
+      // and AuthAllowlist is EXPECTED absent before create-auth-allowlist.mjs
+      // runs. It cannot carry a validator if it does not exist.
+      console.log(`  (absent) — no validator possible`);
+      if (name === "AuthAllowlist") {
+        console.log(
+          `  This is the expected pre-rollout state. It is created by\n` +
+            `  create-auth-allowlist.mjs, NOT by \`prisma db push\` (which would drop\n` +
+            `  User.email_unique_ci — see the "⚠️ \`prisma db push\` DROPS" block in the\n` +
+            `  comment directly above \`model User\` in prisma/schema.prisma; SEARCH FOR\n` +
+            `  "email_unique_ci", do not go by a line number).`,
+        );
+      }
+      continue;
+    }
+
+    // Print EVERYTHING, in full. The whole point of a pre-flight is that a
+    // human reads the actual constraint rather than a summary of it.
+    const schema = row.validator?.$jsonSchema ?? null;
+    const required = schema?.required ?? null;
+    const addProps = schema?.additionalProperties;
+    console.log(`  validationLevel:      ${JSON.stringify(row.validationLevel)}`);
+    console.log(`  validationAction:     ${JSON.stringify(row.validationAction)}`);
+    // Labelled TOP-LEVEL, because that is all these two lines are. The checks
+    // for `User` below work off a full walk of the combinators instead, and
+    // reading these as the whole constraint is the mistake that made this
+    // pre-flight print OK for a validator that rejects the row.
+    console.log(`  required (top level):             ${JSON.stringify(required)}`);
+    console.log(`  additionalProperties (top level): ${JSON.stringify(addProps === undefined ? null : addProps)}`);
+    console.log(`  validator:`);
+    console.log(
+      row.validator === null
+        ? `    null`
+        : JSON.stringify(row.validator, null, 2).split("\n").map((l) => `    ${l}`).join("\n"),
+    );
+
+    // -- the two ROLE collections: a validator at all is a problem ----------
+    if (ROLE_COLLECTIONS.includes(name)) {
+      if (row.validator === null) {
+        console.log(`  OK — validator: null`);
+      } else {
+        fail(
+          `${name} HAS a validator (validationLevel=${row.validationLevel}, ` +
+            `validationAction=${row.validationAction}). STOP. Inspect the JSON ` +
+            `printed above: if it enumerates role strings, every write carrying ` +
+            `"scrc" will be rejected with code 121 — and $runCommandRaw returns ` +
+            `that as { ok: 1, writeErrors: [...] } rather than throwing, so the ` +
+            `grant will LOOK like it succeeded. Run collMod with "scrc" added to ` +
+            `the enum before any write.`,
+        );
+      }
+      continue;
+    }
+
+    // -- AuthAllowlist: present but unexpected-validator --------------------
+    if (name === "AuthAllowlist") {
+      if (row.validator === null) {
+        console.log(`  OK — brand-new collection, no validator, as designed`);
+      } else {
+        fail(
+          `AuthAllowlist has acquired a validator. Nothing in this repo installs ` +
+            `one, so somebody added it by hand. Read it before any pin is written — ` +
+            `a rejected AuthAllowlist insert is a provisioning that silently does ` +
+            `not happen.`,
+        );
+      }
+      continue;
+    }
+
+    // -- User: the STOP-THE-LINE checks ------------------------------------
+    if (name === "User") {
+      if (row.validator === null) {
+        console.log(
+          `  OK — no validator on this cluster. (schema.prisma's "This collection uses a ` +
+            `JSON Schema defined in the database" marker above \`model User\` says there is ` +
+            `one, so this is worth a second look, but nothing can reject the insert.)`,
+        );
+        continue;
+      }
+      if (schema === null) {
+        // A non-$jsonSchema validator (query-operator form) cannot be checked
+        // by the tests below. "Cannot verify" is a stop, not a pass: the whole
+        // reason this section exists is that a 121 rejection is silent on the
+        // raw path and mid-rollout on the typed one.
+        fail(
+          `User has a validator that is NOT a $jsonSchema (it is in query-operator ` +
+            `form). The checks below cannot evaluate it. Read the JSON printed above ` +
+            `BY HAND and confirm it accepts { email, displayName, userID } with no ` +
+            `passwordHash, before provisioning anything.`,
+        );
+        continue;
+      }
+
+      // THE WALK. Top level PLUS every branch of every allOf/anyOf/oneOf, so a
+      // constraint moved into a combinator by a past collMod is still seen.
+      // Everything below reads the accumulator, never `schema.required`
+      // directly — that read is exactly the blind spot this replaced.
+      const acc = newAcc();
+      walkDocSchema(schema, "$jsonSchema", acc);
+
+      console.log(
+        `  walked: ${acc.required.length} required entr(ies), ` +
+          `${acc.closed.length} subschema(s) with additionalProperties:false, ` +
+          `${acc.valueConstraints.length} value constraint(s) on the fields sent, ` +
+          `${acc.unhandled.length} uninterpretable construct(s)`,
+      );
+      console.log(`  required (WALKED, all branches): ${JSON.stringify([...new Set(acc.required.map((r) => r.field))])}`);
+
+      // (a) required — IN ANY BRANCH — must not demand a field the sparse row
+      //     omits. A field required in one `anyOf` branch and not another is
+      //     still treated as required: fail-safe, and the path is printed so a
+      //     human can decide whether the branch actually applies.
+      const badRequired = acc.required.filter((r) => MUST_NOT_BE_REQUIRED.includes(r.field));
+      if (badRequired.length) {
+        fail(
+          `User requires ${JSON.stringify([...new Set(badRequired.map((r) => r.field))])} ` +
+            `(at ${badRequired.map((r) => `${r.path}.required`).join(", ")}). The row ` +
+            `provision-ext-account.mjs writes OMITS ${JSON.stringify(MUST_NOT_BE_REQUIRED)} ` +
+            `on purpose — omitting passwordHash is what forces the password-reset flow ` +
+            `(auth.ts's authorize refuses login while it is absent), and omitting ` +
+            `block/telegramHandle/bio is requirement 2. With this validator the insert ` +
+            `is REJECTED WITH CODE 121 and the account is never created. STOP and ` +
+            `decide: relax the validator with collMod, or change the provisioning design.`,
+        );
+      } else {
+        console.log(
+          `  OK — no \`required\` anywhere in this validator (top level or any ` +
+            `allOf/anyOf/oneOf branch) demands an omitted field`,
+        );
+      }
+
+      // (b) additionalProperties:false, EVALUATED PER SUBSCHEMA. Draft 4 scopes
+      //     the keyword to the `properties` of the same subschema, so a branch
+      //     that closes the document while declaring only some of the fields we
+      //     send rejects the rest — regardless of what the top level declares.
+      if (acc.closed.length === 0) {
+        console.log(`  OK — no subschema declares additionalProperties:false`);
+      } else {
+        let anyBad = false;
+        for (const c of acc.closed) {
+          const undeclared = FIELDS_SENT.filter((f) => !c.declared.includes(f));
+          if (undeclared.length) {
+            anyBad = true;
+            fail(
+              `${c.path} declares additionalProperties:false and does NOT declare ` +
+                `${JSON.stringify(undeclared)} (it declares ${JSON.stringify(c.declared)}). ` +
+                `Those are fields the provisioned row sends, so the insert is rejected ` +
+                `with code 121.`,
+            );
+          }
+        }
+        if (!anyBad) {
+          console.log(
+            `  OK — ${acc.closed.length} subschema(s) close the document, and each one ` +
+              `declares all of ${JSON.stringify(FIELDS_SENT)}`,
+          );
+        }
+      }
+
+      // (c) `pattern` / `enum` on a field we send, anywhere in the walk, tested
+      //     against the REAL pins rather than a made-up example. `enum` is
+      //     checked as well as `pattern` because it rejects in exactly the same
+      //     way and used to be invisible here.
+      const userIDConstraints = acc.valueConstraints.filter((c) => c.field === "userID");
+      if (userIDConstraints.length === 0) {
+        console.log(`  OK — no pattern/enum constraint on userID anywhere in the validator`);
+      }
+      for (const c of userIDConstraints) {
+        if (c.keyword === "pattern") {
+          let rx = null;
+          try {
+            rx = new RegExp(c.value);
+          } catch (e) {
+            fail(`${c.path} = ${JSON.stringify(c.value)} is not a regex this script can compile (${e.message}). Check it by hand against ${JSON.stringify(PINS)}.`);
+            continue;
+          }
+          const rejected = PINS.filter((p) => !rx.test(p));
+          if (rejected.length) {
+            fail(
+              `${c.path} = ${JSON.stringify(c.value)} REJECTS ${JSON.stringify(rejected)}. ` +
+                `userID must hold the EXT pin: it is what facilitiesBooking.ts joins ` +
+                `booking -> owner on, so without it every hall office booking renders with ` +
+                `a blank owner name — and with this pattern the row cannot be inserted at ` +
+                `all (code 121).`,
+            );
+          } else {
+            console.log(`  OK — ${c.path} = ${JSON.stringify(c.value)} accepts ${JSON.stringify(PINS)}`);
+          }
+        } else {
+          const rejected = PINS.filter((p) => !c.value.includes(p));
+          if (rejected.length) {
+            fail(
+              `${c.path} is an enum that does NOT contain ${JSON.stringify(rejected)} ` +
+                `(it allows ${JSON.stringify(c.value)}). The insert is rejected with code 121.`,
+            );
+          } else {
+            console.log(`  OK — ${c.path} enumerates the pins`);
+          }
+        }
+      }
+
+      // (d) THE BACKSTOP. Anything the walk could not interpret makes the whole
+      //     verdict unsafe, so it is a STOP — the same posture this file already
+      //     takes for a query-operator validator. The OK lines above are true
+      //     statements about the parts that WERE interpreted; they are not a
+      //     verdict on the validator, and this is what stops them being read as
+      //     one.
+      if (acc.unhandled.length) {
+        fail(
+          `User's validator contains ${acc.unhandled.length} construct(s) this script ` +
+            `CANNOT INTERPRET, so it cannot tell you whether the insert will be accepted:\n` +
+            acc.unhandled.map((u) => `        ${u.path}: ${u.why}`).join("\n") +
+            `\n      Read the JSON printed above BY HAND and confirm it accepts exactly\n` +
+            `      { ${FIELDS_SENT.join(", ")} } with ${MUST_NOT_BE_REQUIRED.join(" / ")} ABSENT and\n` +
+            `      userID one of ${JSON.stringify(PINS)}. Do not provision until you have.`,
+        );
+      }
+
+      // (e) bsonType on userID / passwordHash, reported for the reader. A
+      //     bsonType that excludes "null" on an OPTIONAL field is only a
+      //     problem if the field is also present-and-null, which this row never
+      //     does (it omits, it does not null). TOP-LEVEL ONLY, and labelled as
+      //     such — it is informational, and the checks that decide the exit
+      //     code are the walked ones above.
+      const bt = (f) => JSON.stringify(schema?.properties?.[f]?.bsonType ?? null);
+      console.log(
+        `  (fyi, top-level properties only) bsonType: email=${bt("email")} ` +
+          `displayName=${bt("displayName")} userID=${bt("userID")} passwordHash=${bt("passwordHash")}`,
+      );
+    }
+  }
+
+  // [2] The baseline rbac-doctor.mjs must still report after the grant.
+  console.log(`\n[2] out-of-vocabulary role strings (baseline for rbac-doctor)`);
+  const rows = await db.userRole.findMany({ select: { roles: true } });
+  const stray = new Map();
+  for (const r of rows) {
+    for (const s of r.roles ?? []) {
+      if (!ROLE_VOCAB.includes(s)) stray.set(s, (stray.get(s) ?? 0) + 1);
+    }
+  }
+  console.log(`  UserRole rows scanned:        ${rows.length}`);
+  console.log(`  out-of-vocabulary strings:    ${stray.size}`);
+  for (const [s, n] of stray) console.log(`    ${JSON.stringify(s)} x${n}`);
+  if (stray.size > 0) {
+    fail(
+      `out-of-vocabulary role strings exist BEFORE the rollout. Resolve them ` +
+        `first — otherwise rbac-doctor.mjs's post-grant check cannot ` +
+        `distinguish them from a bad scrc write.`,
+    );
+  }
+
+  // [3] Facility 17 (SCRC Room), for the record. Reported, never changed —
+  //     the re-gate to ["jcrc","scrc"] must go through /admin/facilities so it
+  //     writes a `facilityAccess.set` audit row.
+  console.log(`\n[3] facility 17 (SCRC Room) current gate — REPORTED, NOT CHANGED`);
+  const f17 = await db.facilityAccess.findFirst({ where: { facilityID: 17 } });
+  console.log(
+    f17
+      ? `  requiredRoles=${JSON.stringify(f17.requiredRoles)}  legacy requiredRole=${JSON.stringify(f17.requiredRole)}`
+      : `  no FacilityAccess row for facility 17`,
+  );
+
+  // [4] The kill switch. Expected ABSENT at pre-flight time: the surface ships
+  //     inert and is switched on deliberately, after the role is granted.
+  console.log(`\n[4] scrc.enabled kill switch`);
+  const flag = await db.systemFlag.findUnique({ where: { key: "scrc.enabled" } });
+  console.log(
+    flag
+      ? `  present, value=${JSON.stringify(flag.value)} (surface is ${flag.value === "on" ? "ON" : "OFF"})`
+      : `  absent — the surface is OFF, which is the expected pre-rollout state`,
+  );
+
+  console.log(`\n================================`);
+  if (failed) {
+    console.error(`${failed} pre-flight failure(s). DO NOT proceed with the rollout.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Pre-flight clean.`);
+  console.log(`  phase 1: safe to grant the role and flip scrc.enabled.`);
+  console.log(`  phase 2: the User validator was walked in full — top level and every`);
+  console.log(`           allOf/anyOf/oneOf branch — with no uninterpretable construct left`);
+  console.log(`           over, and it accepts the sparse EXT row, so provision-ext-account.mjs`);
+  console.log(`           will not be rejected with code 121.`);
+  console.log(`  Take the index census next: node scripts/remediation/index-census.mjs`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/provision-ext-account.mjs
+++ b/scripts/remediation/provision-ext-account.mjs
@@ -1,0 +1,871 @@
+/**
+ * Provisions ONE admin-pinned external account: an `AuthAllowlist` row, the
+ * `User` row that goes with it, and one `authAllowlist.add` audit row.
+ *
+ *   node scripts/remediation/provision-ext-account.mjs \
+ *     --email ngocanh.mai@nus.edu.sg --name "Mai Ngoc Anh" \
+ *     --pin EXT:NGOCANH_MAI --actor E1633673
+ *   ... add --commit to actually write.
+ *   ... add --print-reset-link to also mint a password-reset URL.
+ *
+ * Dry run by default. It prints the exact three documents it would write and
+ * every refusal it evaluated, then stops.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT AN "EXT" ACCOUNT IS, AND WHY IT IS DANGEROUS
+ * ---------------------------------------------------------------------------
+ *
+ * Whatever string lands in `session.user.userID` IS the authorization key.
+ * `auth.ts` does a bare `db.userRole.findUnique({ where: { userID } })` and
+ * `access.ts`'s `getUserRoles` does the same; neither checks provenance. So a
+ * row `{ email: "attacker@gmail.com", pinnedUserID: "E1633673" }` would hand an
+ * attacker an admin's roles with NO grant path — meaning no escalation guard
+ * anywhere would fire, because none was crossed.
+ *
+ * Four mechanisms make that unrepresentable rather than merely refused:
+ *   M1  `canonicalUserID`'s capture class is [A-Z0-9._%-]. It does not contain
+ *       ':'. `EXT_ID` requires one. The two key spaces are PROVABLY DISJOINT,
+ *       so a pin can never equal a NUSNET id for any input. "E1633673" fails
+ *       EXT_ID; that is refusal PIN_NOT_EXT below.
+ *   M2  `asExtUserID` re-validates the pin AT EVERY READ in
+ *       services/authAllowlist.ts, so a row hand-written in Atlas mints NO
+ *       identity at all.
+ *   M3  `pinnedUserID` unique, enforced by a real Mongo index built by
+ *       create-auth-allowlist.mjs. A Prisma @unique alone enforces nothing.
+ *   M4  the write path is adminProcedure + audited + refuses three shapes.
+ *
+ * THIS SCRIPT IS A FIFTH WRITE PATH INTO THAT COLLECTION, so it reproduces M4's
+ * refusals itself rather than inheriting them. Read the refusal list below as
+ * the security surface it is.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS — every one exits 1 and writes NOTHING
+ * ---------------------------------------------------------------------------
+ *
+ *  EMAIL_IS_CANONICAL       `canonicalUserID(email)` is non-null, i.e. the
+ *                           address is an @u.nus.edu one that ALREADY has an
+ *                           identity. Pinning it would give one human two
+ *                           identity keys — two role rows, two booking owners,
+ *                           two audit trails, and a permanent split-brain that
+ *                           no merge script can cleanly undo.
+ *  PIN_NOT_EXT              the pin fails EXT_ID. This is M1 at the write side.
+ *                           Without it the script IS the attack.
+ *  USER_ALREADY_EXISTS      a `User` row already exists for that address
+ *                           (case-insensitively — `email_unique_ci` folds case
+ *                           but NOT whitespace). Creating a second row makes a
+ *                           duplicate account, which is the class this repo has
+ *                           already had to remediate by hand.
+ *  PIN_ALREADY_HAS_ROLES    a `UserRole` row already exists under this pin.
+ *                           Defence in depth behind M3: refuses aiming a key
+ *                           that ALREADY CARRIES PRIVILEGE at a new address,
+ *                           even if the unique index were somehow absent.
+ *  PIN_ALREADY_ON_USER_ROW  a `User` row ALREADY CARRIES this pin in `userID`,
+ *                           under a DIFFERENT email. THERE IS NO DATABASE
+ *                           GUARD FOR THIS: `User.userID` has no `@unique` in
+ *                           schema.prisma and no index behind it, so
+ *                           `db.user.create` would cheerfully make a second row
+ *                           on the same identity key. Two `User` rows sharing
+ *                           one key makes facilitiesBooking.ts's booking->owner
+ *                           join (`where: { userID: booking.userID }`)
+ *                           AMBIGUOUS — whichever row Mongo returns first names
+ *                           the owner — and makes `admin.listUsers`'
+ *                           `keyMismatch` meaningless for the pair. Every one of
+ *                           the other refusals passes in this state, so without
+ *                           this one the script writes the duplicate.
+ *  EMAIL_ALREADY_PINNED     the address is already in `AuthAllowlist`.
+ *  PIN_ALREADY_USED         the pin is already in `AuthAllowlist`.
+ *  ALLOWLIST_UNREADABLE     the collection could not be read. FAIL CLOSED — an
+ *                           unreadable allowlist must never be treated as an
+ *                           empty one, or the two refusals above evaporate.
+ *  ALLOWLIST_INDEXES_MISSING (--commit only) `pin_unique` / `email_unique` are
+ *                           not built, so M3 does not exist and the two
+ *                           refusals above are the ONLY thing preventing a
+ *                           duplicate pin — a check-then-write with a race in
+ *                           it. Run create-auth-allowlist.mjs first. Reported
+ *                           as a WARNING in a dry run so a preview still works
+ *                           before that step of the rollout.
+ *  BAD_ACTOR                --actor is missing or is not a well-shaped
+ *                           identity key. It is written to
+ *                           `RoleAuditLog.actorUserID`; an audit row naming
+ *                           nobody is not an audit row.
+ *
+ * ---------------------------------------------------------------------------
+ * THE `User` ROW — every field is a decision
+ * ---------------------------------------------------------------------------
+ *
+ *  email        normalizeEmail'd (trimmed, lowercased). Must match
+ *               AuthAllowlist.email BYTE FOR BYTE — `email_unique_ci` is
+ *               collation strength 2, which folds CASE but not WHITESPACE.
+ *  displayName  SET AT CREATION, and load-bearing: it is the only profile field
+ *               the strict always-on profile gate will still demand of an
+ *               `scrc` holder, so setting it here means the forced dialog never
+ *               opens for them.
+ *  userID       the pin. Three consequences, and the third is the real reason:
+ *               it matches register/route.ts's pattern; it makes `keyMismatch`
+ *               false so a future delete is not blocked by LEGACY_KEY_MISMATCH;
+ *               and facilitiesBooking.ts joins booking -> owner on
+ *               `where: { userID: booking.userID }`, so WITHOUT IT every hall
+ *               office booking renders with a blank owner name.
+ *  passwordHash OMITTED (null) ON PURPOSE. `auth.ts`'s credentials `authorize`
+ *               does `if (!user?.passwordHash) return null`, so this account
+ *               CANNOT BE LOGGED INTO until a password is set. The password
+ *               reset flow is the only way in, which is exactly the intended
+ *               provisioning path — an admin never types someone's password.
+ *  block, telegramHandle, bio   OMITTED. A hall office staff member has no hall
+ *               block to live in and no reason to publish a Telegram handle to
+ *               residents. (There is no `matric` field on `User` at all; matric
+ *               lives in its own collection and none is written.)
+ *  createdAt    left to @default(now()).
+ *
+ * PRISMA'S TYPED `create` IS USED FOR THE `User` INSERT, NOT $runCommandRaw,
+ * AND THAT IS NOT A STYLE CHOICE. The `User` collection carries a DB-level
+ * `$jsonSchema` validator. A validator rejection is error code 121, and
+ * `$runCommandRaw` returns it as DATA — `{ ok: 1, writeErrors: [{ code: 121 }] }`
+ * — rather than throwing. A raw insert would therefore report SUCCESS on a row
+ * that does not exist, and the operator would move on to granting roles to an
+ * account that was never created. Prisma's typed `create` THROWS. Run
+ * preflight-scrc-validators.mjs first to see the validator before you find out
+ * this way.
+ *
+ * ---------------------------------------------------------------------------
+ * THE INVARIANT: A FAILED RUN LEAVES THE CLUSTER RE-RUNNABLE
+ * ---------------------------------------------------------------------------
+ *
+ * After any failure of this script, RE-RUNNING THE SAME COMMAND SUCCEEDS. That
+ * is a property of the write path, not an aspiration, and it is stated here
+ * because the previous shape did not have it and the cost was hidden.
+ *
+ * WHAT THE PREVIOUS SHAPE COST. The three documents were three separate
+ * un-transacted creates. An `AuthAllowlist` row that landed followed by a `User`
+ * create that threw left an ORPHAN PIN — and a re-run then trips BOTH
+ * `EMAIL_ALREADY_PINNED` and `PIN_ALREADY_USED` and refuses. There is no script
+ * in this repository that deletes an `AuthAllowlist` row; the only remover is
+ * `admin.removeAuthAllowlistEntry` on the tRPC surface. So the operator
+ * discovered, mid-provisioning, that the documented next step was hand surgery.
+ *
+ * WHAT IT IS NOW: ONE `db.$transaction([...])` carrying all three creates.
+ * Mongo aborts the whole transaction on any failure, so the three documents
+ * appear together or not at all, and "not at all" is precisely the state a
+ * re-run wants.
+ *
+ *   - THE ARRAY FORM, not the interactive callback. It issues the three writes
+ *     sequentially in one transaction and, critically, still THROWS on failure
+ *     — so the P2002 and code-121 handling below stays meaningful rather than
+ *     becoming a branch that can no longer be reached.
+ *   - ORDER INSIDE THE ARRAY IS STILL AuthAllowlist, User, audit. The allowlist
+ *     row is the one protected by a UNIQUE INDEX, and writing it first means a
+ *     concurrent run conflicts on the index at the earliest possible moment
+ *     rather than after a `User` row exists.
+ *   - MONGO WILL NOT IMPLICITLY CREATE A COLLECTION INSIDE A TRANSACTION. All
+ *     three collections must therefore already exist. `User` and `RoleAuditLog`
+ *     have existed since phase 1; `AuthAllowlist` is created by
+ *     create-auth-allowlist.mjs, which the rollout order guarantees has run
+ *     (step 19 precedes step 20) — and which the `ALLOWLIST_INDEXES_MISSING`
+ *     refusal below independently PROVES under --commit, since `listIndexes`
+ *     cannot report both unique indexes on a collection that does not exist.
+ *   - THE AUDIT ROW IS INSIDE THE TRANSACTION, which DIVERGES DELIBERATELY from
+ *     `writeAudit`'s posture in routers/admin.ts ("the audit write must not undo
+ *     the act"). That posture is right for a user-facing mutation, where undoing
+ *     is worse than an unaudited act. It is wrong here: this script is re-runnable
+ *     by construction, so rolling back and letting the operator run the same
+ *     command again costs nothing — and it is the only way "provisioned" and
+ *     "audited" cannot come apart. An unaudited provisioning is exactly the
+ *     untraceable state the audit row exists to prevent.
+ *
+ * BELT AND BRACES, because the transaction has a PREREQUISITE (a replica set —
+ * Atlas is one — and the three collections existing). If the transaction throws,
+ * the catch RE-READS the cluster and, if it finds the allowlist row present with
+ * no `User` row, DELETES the orphan it just created. If that compensating delete
+ * also fails, it prints the exact recovery command rather than the word
+ * "cleaned up". See section 7.
+ *
+ * ---------------------------------------------------------------------------
+ * --print-reset-link
+ * ---------------------------------------------------------------------------
+ *
+ * Mints a `PasswordResetSession` directly and prints the URL, mirroring
+ * src/app/api/reset-password/request-verification-code/route.ts exactly: a
+ * 32-byte hex token, a 15-MINUTE TTL, and prior outstanding tokens for that
+ * address deleted first. It exists because `sendPasswordResetEmail` goes out
+ * through Resend from noreply@rhapp.lol, and NUS staff mail may spam-file or
+ * reject that sender — in which case the account is a dead end (no
+ * passwordHash, no way to set one) until someone hands over a link out of band.
+ *
+ * If the account is ALREADY provisioned — an AuthAllowlist row exists pinning
+ * EXACTLY this email to EXACTLY this pin, and the User row exists — then
+ * --print-reset-link puts the script into LINK-ONLY mode: it provisions
+ * nothing and only mints the token. That is the documented recovery path.
+ * The exact-pair requirement is what stops this being a general-purpose "mint
+ * a password reset for any address" tool.
+ */
+import { PrismaClient } from "@prisma/client";
+import { randomBytes } from "node:crypto";
+import {
+  canonicalUserID,
+  normalizeEmail,
+  isCanonicalResidentID,
+  isExtUserID,
+  EXT_ID,
+} from "./lib/identity.mjs";
+import { isCommit, banner, abort } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+const PRINT_LINK = process.argv.includes("--print-reset-link");
+
+/** `--flag value`. Same shape as inventory-rbac.mjs / restore-legacy-scalars.mjs. */
+function argOf(flag) {
+  const i = process.argv.indexOf(flag);
+  if (i === -1) return null;
+  const v = process.argv[i + 1];
+  return v === undefined || v.startsWith("--") ? null : v;
+}
+
+const RAW_EMAIL = argOf("--email");
+const RAW_NAME = argOf("--name");
+const RAW_PIN = argOf("--pin");
+const RAW_ACTOR = argOf("--actor");
+
+/** Same transform the server's zod schema applies (.trim().toUpperCase()), so a
+ *  pin typed here and a pin typed in the admin UI cannot diverge. */
+const PIN = RAW_PIN === null ? null : RAW_PIN.trim().toUpperCase();
+const EMAIL = RAW_EMAIL === null ? null : normalizeEmail(RAW_EMAIL);
+const NAME = RAW_NAME === null ? null : RAW_NAME.trim();
+const ACTOR = RAW_ACTOR === null ? null : RAW_ACTOR.trim();
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+
+const refusals = [];
+const refuse = (code, why) => refusals.push({ code, why });
+
+const USAGE =
+  `usage: node scripts/remediation/provision-ext-account.mjs \\\n` +
+  `         --email <address> --name "<display name>" --pin EXT:<SLUG> --actor <userID> \\\n` +
+  `         [--commit] [--print-reset-link]`;
+
+async function main() {
+  banner("provision-ext-account.mjs", COMMIT);
+
+  // -- 0. arguments ---------------------------------------------------------
+  if (!RAW_EMAIL || !RAW_NAME || !RAW_PIN || !RAW_ACTOR) {
+    console.log(USAGE);
+    return abort(`--email, --name, --pin and --actor are all required.`);
+  }
+  console.log(`  email  : ${JSON.stringify(EMAIL)}   (normalizeEmail'd from ${JSON.stringify(RAW_EMAIL)})`);
+  console.log(`  name   : ${JSON.stringify(NAME)}`);
+  console.log(`  pin    : ${JSON.stringify(PIN)}`);
+  console.log(`  actor  : ${JSON.stringify(ACTOR)}`);
+  console.log(`  link   : ${PRINT_LINK ? "yes (--print-reset-link)" : "no"}`);
+
+  if (!NAME) {
+    refuse("EMPTY_NAME", `--name is blank after trimming. displayName is the ONE profile field an scrc holder must have; without it the forced profile dialog opens on their first request.`);
+  }
+
+  // -- 1. refusals that need no database ------------------------------------
+  //
+  // EMAIL_IS_CANONICAL. Written as a null test, never against a string literal:
+  // the absent canonical id is null, and a `=== ""` form here would be VACUOUS
+  // rather than wrong — it would match nothing, this refusal would never fire,
+  // and the script would happily mint a second identity for a real student.
+  const cid = canonicalUserID(EMAIL);
+  if (cid !== null) {
+    refuse(
+      "EMAIL_IS_CANONICAL",
+      `${JSON.stringify(EMAIL)} already canonicalises to ${JSON.stringify(cid)} — it is an ` +
+        `@u.nus.edu address and therefore ALREADY has an identity. Pinning it would give ` +
+        `one human two identity keys. This account does not need provisioning; it needs ` +
+        `a role grant through /admin/users.`,
+    );
+  }
+
+  // PIN_NOT_EXT. M1 at the write side. "E1633673" fails here, which is the
+  // whole attack from 05-verification.md refused in one line.
+  if (!isExtUserID(PIN)) {
+    refuse(
+      "PIN_NOT_EXT",
+      `${JSON.stringify(PIN)} does not match ${String(EXT_ID)}. The ':' is the mechanism: ` +
+        `canonicalUserID's capture class excludes it, so an EXT id can never collide with a ` +
+        `NUSNET id. A pin outside this namespace mints NO identity at read time (M2) and, ` +
+        `if it happened to BE a NUSNET id, would hand this address that person's roles.`,
+    );
+  }
+
+  // BAD_ACTOR. isCanonicalResidentID is a SHAPE test (non-empty, no '@') — the
+  // right predicate here precisely because it is not an E-format test: L-27,
+  // "G.S_SAMUEL" is a real admin-capable id and refusing it would be the same
+  // mistake as gating eligibility on /^E\d{7}$/. It also accepts an EXT pin.
+  if (!isCanonicalResidentID(ACTOR)) {
+    refuse(
+      "BAD_ACTOR",
+      `--actor ${JSON.stringify(ACTOR)} is not a well-shaped identity key. It is written ` +
+        `verbatim to RoleAuditLog.actorUserID and to AuthAllowlist.addedBy; an audit row ` +
+        `that names nobody is not an audit row. Pass the id of the human running this.`,
+    );
+  }
+
+  // -- 2. state of the world (all reads) ------------------------------------
+  console.log(`\n--- [1] current state ---`);
+
+  // Case-insensitive, because `email_unique_ci` is collation strength 2: two
+  // rows differing only in case are the SAME account to the index, and creating
+  // the second one fails with E11000 (or, if the index has been dropped,
+  // succeeds and makes a duplicate — which is worse).
+  const existingUser = await db.user.findFirst({
+    where: { email: { equals: EMAIL, mode: "insensitive" } },
+    select: { id: true, email: true, userID: true, displayName: true, passwordHash: true },
+  });
+  console.log(
+    `  User row for this email:      ` +
+      (existingUser
+        ? `PRESENT  userID=${JSON.stringify(existingUser.userID)} displayName=${JSON.stringify(existingUser.displayName)} passwordHash=${existingUser.passwordHash ? "set" : "(none)"}`
+        : `absent`),
+  );
+
+  // THE PIN, AGAINST `User.userID` — the check with NO DATABASE GUARD BEHIND IT.
+  //
+  // `User.userID` carries no `@unique` in schema.prisma and no index in the
+  // cluster, so unlike the pin checks against UserRole (@unique on userID) and
+  // AuthAllowlist (pin_unique, M3), nothing stops `db.user.create` writing a
+  // SECOND row on a key some other row already holds. A pre-existing `User` row
+  // carrying this pin under a different address passes every other refusal in
+  // this file.
+  //
+  // findFirst, not findUnique: findUnique needs a unique constraint the Prisma
+  // schema does not declare, so it will not compile against this field — which
+  // is itself the tell that the database is not enforcing anything here.
+  const existingUserByPin = PIN
+    ? await db.user.findFirst({
+        where: { userID: PIN },
+        select: { id: true, email: true, userID: true, displayName: true },
+      })
+    : null;
+  console.log(
+    `  User row carrying this pin:   ` +
+      (existingUserByPin
+        ? `PRESENT  email=${JSON.stringify(existingUserByPin.email)} displayName=${JSON.stringify(existingUserByPin.displayName)}`
+        : `absent`) +
+      `   (User.userID has NO unique index — this check is the only guard)`,
+  );
+
+  const existingRole = PIN
+    ? await db.userRole.findUnique({ where: { userID: PIN }, select: { userID: true, roles: true } })
+    : null;
+  console.log(
+    `  UserRole row for this pin:    ` +
+      (existingRole ? `PRESENT  roles=${JSON.stringify(existingRole.roles)}` : `absent`),
+  );
+
+  // FAIL CLOSED on an unreadable allowlist. An error here must never read as
+  // "no row" — that would silently disable EMAIL_ALREADY_PINNED and
+  // PIN_ALREADY_USED, which are the two refusals standing between this script
+  // and a duplicate pin.
+  let byEmail = null;
+  let byPin = null;
+  let allowlistReadable = true;
+  try {
+    byEmail = await db.authAllowlist.findUnique({ where: { email: EMAIL } });
+    byPin = PIN ? await db.authAllowlist.findUnique({ where: { pinnedUserID: PIN } }) : null;
+  } catch (e) {
+    allowlistReadable = false;
+    refuse(
+      "ALLOWLIST_UNREADABLE",
+      `could not read AuthAllowlist: ${String(e?.message ?? e)}. Refusing to treat an ` +
+        `unreadable allowlist as an empty one. If db.authAllowlist does not exist on the ` +
+        `client, run \`npx prisma generate\` (NOT \`prisma db push\` — it drops ` +
+        `User.email_unique_ci).`,
+    );
+  }
+  if (allowlistReadable) {
+    console.log(
+      `  AuthAllowlist row for email:  ` +
+        (byEmail ? `PRESENT  pinnedUserID=${JSON.stringify(byEmail.pinnedUserID)}` : `absent`),
+    );
+    console.log(
+      `  AuthAllowlist row for pin:    ` +
+        (byPin ? `PRESENT  email=${JSON.stringify(byPin.email)}` : `absent`),
+    );
+  }
+
+  // M3's index, checked rather than assumed (risk R3: someone ships the model
+  // and skips create-auth-allowlist.mjs; the @unique then enforces nothing and
+  // the duplicate refusals below become a check-then-write with a race in it).
+  let indexesOk = false;
+  let indexNames = [];
+  try {
+    const li = await db.$runCommandRaw({ listIndexes: "AuthAllowlist" });
+    indexNames = (li?.cursor?.firstBatch ?? [])
+      .filter((i) => i?.unique === true)
+      .map((i) => String(i?.name ?? ""));
+    indexesOk = indexNames.includes("email_unique") && indexNames.includes("pin_unique");
+  } catch {
+    indexesOk = false; // collection absent, or unreadable — either way, not built
+  }
+  console.log(`  AuthAllowlist unique idx:     ${indexesOk ? "email_unique + pin_unique OK" : `MISSING  (found: ${indexNames.join(", ") || "none"})`}`);
+
+  // -- 3. LINK-ONLY mode ----------------------------------------------------
+  //
+  // The documented recovery path when the reset email cannot be delivered. It
+  // requires the EXACT pair to exist already — this address pinned to this pin,
+  // plus the User row — so it cannot be used to mint a reset link for an
+  // arbitrary account. Anything short of an exact match falls through to the
+  // normal refusals.
+  const exactPair =
+    allowlistReadable &&
+    !!byEmail &&
+    !!byPin &&
+    byEmail.pinnedUserID === PIN &&
+    byPin.email === EMAIL;
+  const LINK_ONLY = PRINT_LINK && exactPair && !!existingUser;
+
+  if (LINK_ONLY) {
+    console.log(`\n--- [2] LINK-ONLY mode ---`);
+    console.log(
+      `  This account is ALREADY provisioned: the AuthAllowlist row pins exactly this\n` +
+        `  address to exactly this pin, and the User row exists. Nothing will be\n` +
+        `  provisioned. Only a password-reset token is minted.`,
+    );
+    if (existingUser.passwordHash) {
+      console.log(
+        `  NOTE: this account already HAS a password. The link below will let whoever\n` +
+          `  holds it replace that password. Only hand it to the account owner.`,
+      );
+    }
+    // Every argument-level refusal still applies here. Only the four
+    // already-exists refusals are expected in this mode, and those are
+    // evaluated further down, after this branch returns. A malformed pin that
+    // somehow reached the collection by hand must not be handed a login path —
+    // M2 would refuse to mint an identity from it at read time anyway, so the
+    // link would be a dead end that looks like a working one.
+    if (refusals.length) {
+      for (const r of refusals) console.error(`  REFUSED  ${r.code}: ${r.why}`);
+      return abort(`the existing pair is malformed. Fix the AuthAllowlist row first.`);
+    }
+    return mintResetLink();
+  }
+
+  // -- 4. refusals that needed the database ---------------------------------
+  if (existingUser) {
+    refuse(
+      "USER_ALREADY_EXISTS",
+      `a User row already exists for ${JSON.stringify(existingUser.email)} ` +
+        `(matched case-insensitively). Creating a second one makes a DUPLICATE ACCOUNT — ` +
+        `the exact class this repo has already had to remediate by hand. If this is the ` +
+        `account you meant to provision, it needs an AuthAllowlist row and a role grant, ` +
+        `not a new User row.`,
+    );
+  }
+  // PIN_ALREADY_ON_USER_ROW. Only when it is a DIFFERENT document from the one
+  // USER_ALREADY_EXISTS is already reporting: if the same row matches both the
+  // email and the pin, that refusal has already said everything true about it,
+  // and a second entry saying it again would read as two problems.
+  if (existingUserByPin && existingUserByPin.id !== existingUser?.id) {
+    refuse(
+      "PIN_ALREADY_ON_USER_ROW",
+      `a User row already carries userID=${JSON.stringify(PIN)} under ` +
+        `${JSON.stringify(existingUserByPin.email)}, which is not the address being ` +
+        `provisioned. NOTHING IN THE DATABASE WOULD STOP THIS: User.userID has no ` +
+        `@unique in schema.prisma and no index, so db.user.create would succeed and ` +
+        `leave TWO User rows on one identity key. facilitiesBooking.ts joins ` +
+        `booking -> owner with \`where: { userID: booking.userID }\`, so every hall ` +
+        `office booking would then render whichever of the two rows came back first, ` +
+        `and admin.listUsers' keyMismatch becomes meaningless for the pair. Choose a ` +
+        `different pin, or resolve that row first.`,
+    );
+  }
+  if (existingRole) {
+    refuse(
+      "PIN_ALREADY_HAS_ROLES",
+      `a UserRole row already exists under ${JSON.stringify(PIN)} carrying ` +
+        `${JSON.stringify(existingRole.roles)}. Pinning a NEW address to a key that ` +
+        `already carries privilege is the re-aiming attack. Revoke those roles through ` +
+        `the audited role path first, or choose a different pin.`,
+    );
+  }
+  if (byEmail) {
+    refuse(
+      "EMAIL_ALREADY_PINNED",
+      `${JSON.stringify(EMAIL)} is already pinned to ${JSON.stringify(byEmail.pinnedUserID)}. ` +
+        `A pin is immutable by design: changing which key an address owns is remove-then-add, ` +
+        `two audit rows, through the admin surface.`,
+    );
+  }
+  if (byPin) {
+    refuse(
+      "PIN_ALREADY_USED",
+      `${JSON.stringify(PIN)} is already pinned to ${JSON.stringify(byPin.email)}. Two ` +
+        `addresses sharing one pin means two humans sharing one identity key, one role row ` +
+        `and one audit trail.`,
+    );
+  }
+  if (!indexesOk) {
+    if (COMMIT) {
+      refuse(
+        "ALLOWLIST_INDEXES_MISSING",
+        `AuthAllowlist's unique indexes are not built, so M3 does not exist: the Prisma ` +
+          `@unique enforces NOTHING at runtime and the two refusals above are a ` +
+          `check-then-write with a race in it. Run ` +
+          `\`node scripts/remediation/create-auth-allowlist.mjs --commit\` first.`,
+      );
+    } else {
+      console.log(
+        `\n  WARNING: AuthAllowlist's unique indexes are not built. This is fine for a dry\n` +
+          `  run, but --commit will REFUSE until create-auth-allowlist.mjs has run.`,
+      );
+    }
+  }
+
+  // -- 5. verdict -----------------------------------------------------------
+  if (refusals.length) {
+    console.error(`\n--- REFUSED (${refusals.length}) ---`);
+    for (const r of refusals) console.error(`  ${r.code}\n      ${r.why}\n`);
+    return abort(`nothing was written. Resolve every refusal above and re-run.`);
+  }
+
+  // -- 6. the plan ----------------------------------------------------------
+  const allowlistDoc = {
+    email: EMAIL,
+    pinnedUserID: PIN,
+    note: `provisioned by scripts/remediation/provision-ext-account.mjs`,
+    addedBy: ACTOR,
+  };
+  // OMISSIONS ARE THE POINT — see the header. passwordHash absent forces the
+  // reset flow; block / telegramHandle / bio absent is requirement 2.
+  const userDoc = { email: EMAIL, displayName: NAME, userID: PIN };
+
+  console.log(`\n--- [2] documents to write — ALL THREE IN ONE TRANSACTION ---`);
+  console.log(`  1. AuthAllowlist  ${JSON.stringify(allowlistDoc)}`);
+  console.log(`  2. User           ${JSON.stringify(userDoc)}`);
+  console.log(`     (passwordHash, block, telegramHandle and bio are DELIBERATELY OMITTED)`);
+  console.log(`  3. RoleAuditLog   action="authAllowlist.add" targetUserID=${JSON.stringify(PIN)} reason=${JSON.stringify(EMAIL)}`);
+  console.log(
+    `  They land together or not at all (db.$transaction), so a failure cannot leave\n` +
+      `  an orphan pin that makes a re-run refuse. See the header.`,
+  );
+
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing was written. Re-run with --commit to apply.`);
+    console.log(
+      `AFTERWARDS the account still CANNOT sign in: it has no passwordHash, and\n` +
+        `auth.ts's authorize refuses on that. The reset flow is the only way in — either\n` +
+        `the Forgot-password form, or --print-reset-link if mail cannot be delivered.\n` +
+        `It also holds NO ROLES until an admin grants them through /admin/users.`,
+    );
+    return;
+  }
+
+  // -- 7. write -------------------------------------------------------------
+  console.log(`\n--- [3] writing ---`);
+
+  // actorRoles is read BEFORE the transaction opens, and from the database
+  // rather than invented: the column means "the actor's roles AT THE TIME", and
+  // a script that stamps ["admin"] on faith records a claim instead of a fact.
+  // Outside the transaction because it is a READ that must not consume the
+  // transaction's time budget, and because its failure mode is "no row", which
+  // is a legitimate value here rather than an abort.
+  const actorRow = await db.userRole
+    .findUnique({ where: { userID: ACTOR }, select: { roles: true } })
+    .catch(() => null);
+
+  // ALL THREE DOCUMENTS, ONE TRANSACTION. See the header's invariant section:
+  // the array form issues them in order and THROWS on failure, so the P2002 and
+  // code-121 handling below is still live, while Mongo's abort is what makes a
+  // failed run re-runnable instead of leaving an orphan pin no script can
+  // delete.
+  //
+  // Ordered AuthAllowlist -> User -> audit. The allowlist row carries the unique
+  // index (M3), so writing it first surfaces a concurrent claim on the pin at
+  // the earliest possible moment.
+  //
+  // TYPED creates throughout, never $runCommandRaw — `User` carries a
+  // $jsonSchema validator and a 121 rejection comes back from a raw command as
+  // DATA (`{ok:1, writeErrors:[{code:121}]}`), so a raw insert would print
+  // success over a row that does not exist. These throw.
+  //
+  // The audit row is field-for-field identical to writeAudit() in
+  // src/server/api/routers/admin.ts, INCLUDING the fields it sets to null, so a
+  // row written by this script and a row written by the admin surface are
+  // indistinguishable to every reader of RoleAuditLog.
+  let created;
+  let userRow;
+  try {
+    [created, userRow] = await db.$transaction([
+      db.authAllowlist.create({ data: allowlistDoc }),
+      db.user.create({ data: userDoc }),
+      db.roleAuditLog.create({
+        data: {
+          actorUserID: ACTOR,
+          actorRoles: actorRow?.roles ?? [],
+          targetUserID: PIN,
+          targetFacilityID: null,
+          targetCcaID: null,
+          targetEventID: null,
+          action: "authAllowlist.add",
+          rolesBefore: [],
+          rolesAfter: [],
+          reason: EMAIL,
+          ok: true,
+          denyReason: null,
+          batchId: null,
+        },
+      }),
+    ]);
+  } catch (e) {
+    console.error(e);
+    if (e?.code === "P2002") {
+      console.error(
+        `\n  AuthAllowlist unique violation (P2002 on ${JSON.stringify(e?.meta?.target ?? "?")}) — ` +
+          `something\n  claimed this email or pin between the check and the write. That is M3 ` +
+          `doing\n  its job.`,
+      );
+    }
+    console.error(
+      `\n  If this was error code 121, the User $jsonSchema rejected the document — run\n` +
+        `  \`node scripts/remediation/preflight-scrc-validators.mjs\` to see which field.`,
+    );
+    return await recoverFromFailedWrite();
+  }
+  console.log(`  1. AuthAllowlist row created (_id=${created.id})`);
+  console.log(`  2. User row created (_id=${userRow.id})`);
+  console.log(`  3. RoleAuditLog authAllowlist.add written (actorRoles=${JSON.stringify(actorRow?.roles ?? [])})`);
+
+  // -- 8. verify ------------------------------------------------------------
+  console.log(`\n=== VERIFY ===`);
+  const vAllow = await db.authAllowlist.findUnique({ where: { pinnedUserID: PIN } });
+  const vUser = await db.user.findFirst({
+    where: { email: { equals: EMAIL, mode: "insensitive" } },
+    select: { email: true, userID: true, displayName: true, passwordHash: true },
+  });
+  console.log(`  AuthAllowlist: ${vAllow ? JSON.stringify({ email: vAllow.email, pinnedUserID: vAllow.pinnedUserID, addedBy: vAllow.addedBy }) : "MISSING"}`);
+  console.log(`  User:          ${vUser ? JSON.stringify(vUser) : "MISSING"}`);
+  if (!vAllow || !vUser) {
+    // The transaction committed (we are past it) but a read-back does not see
+    // both rows. That is a read problem, not a write one — but it must not be
+    // reported as success, and the operator needs to know that the RECOVERY here
+    // is not "re-run --commit" (which would refuse on the rows that ARE there).
+    return abort(
+      `read-back failed — the state above is not what was intended. The transaction ` +
+        `COMMITTED, so this is a read that disagrees with a write that succeeded. Re-run ` +
+        `WITHOUT --commit (the dry run prints the full current state) before doing ` +
+        `anything else; do not re-run with --commit, which will refuse on whichever rows ` +
+        `do exist.`,
+    );
+  }
+  if (vUser.passwordHash) {
+    console.error(
+      `  ! the User row has a passwordHash. It was supposed to be absent so that the ` +
+        `reset flow is the only way in.`,
+    );
+    process.exitCode = 1;
+  }
+
+  console.log(
+    `\nNEXT: this account holds NO ROLES and CANNOT sign in yet (no passwordHash —\n` +
+      `auth.ts's authorize refuses). Grant "Hall Office" through /admin/users -> Manage\n` +
+      `roles (which audits), and have them use Forgot password. Do NOT let them sign in\n` +
+      `before the grant: without it the strict profile gate has nothing exempting them.`,
+  );
+
+  if (PRINT_LINK) await mintResetLink();
+}
+
+/**
+ * BELT AND BRACES BEHIND THE TRANSACTION. Called from the one catch around the
+ * three creates, and its whole job is to make the header's invariant — a failed
+ * run leaves the cluster re-runnable — true even if the transaction did not do
+ * what transactions are supposed to do.
+ *
+ * WHY IT EXISTS AT ALL, given that Mongo aborts the transaction on failure. The
+ * atomicity has PREREQUISITES: a replica set (Atlas is one), and all three
+ * collections existing, because MongoDB will not implicitly create a collection
+ * inside a transaction. If either is untrue, the driver's error can arrive after
+ * some of the writes have gone through as ordinary un-transacted inserts, and
+ * separately a commit can succeed on the server while the acknowledgement is
+ * lost on the way back. In both cases the client sees a throw and the cluster
+ * holds rows. The one state that breaks re-running is the ORPHAN PIN — an
+ * AuthAllowlist row with no User row — because it trips both EMAIL_ALREADY_PINNED
+ * and PIN_ALREADY_USED, and NO SCRIPT IN THIS REPOSITORY DELETES SUCH A ROW.
+ *
+ * So this reads the cluster back and acts on what is actually there:
+ *   - nothing written        -> the transaction rolled back. Re-run and it works.
+ *   - orphan pin, no user    -> DELETE the pin this run created, restoring the
+ *                               "nothing written" state above.
+ *   - the delete also fails  -> print the EXACT recovery command. Naming the
+ *                               remedy is the entire point; "it must be cleaned
+ *                               up" is what the operator used to be told.
+ *   - both rows present      -> the provisioning actually LANDED. Say so, and
+ *                               say that the audit row is the thing to check.
+ *
+ * The compensating delete is keyed on the EXACT pair (this pin AND this email),
+ * never on the pin alone. A pin that turns out to hold somebody else's address
+ * is not ours to delete — that is the row PIN_ALREADY_USED exists to protect,
+ * and deleting it would be this script un-provisioning an unrelated account.
+ *
+ * Always returns false (via abort) so the caller can `return await` it.
+ */
+async function recoverFromFailedWrite() {
+  console.error(`\n--- [4] RECOVERY: what is actually in the cluster now ---`);
+
+  let allowRow = null;
+  let userRowNow = null;
+  try {
+    allowRow = await db.authAllowlist.findUnique({ where: { pinnedUserID: PIN } });
+    userRowNow = await db.user.findFirst({
+      where: { email: { equals: EMAIL, mode: "insensitive" } },
+      select: { id: true, email: true, userID: true },
+    });
+  } catch (readErr) {
+    // A failed probe must never read as "nothing is there" — that is the
+    // fabricated-zero class, and here it would tell the operator to re-run a
+    // command that is about to refuse.
+    console.error(`  ! could not read the cluster back: ${String(readErr?.message ?? readErr)}`);
+    printOrphanRecoveryCommand();
+    return abort(
+      `the write failed AND the state could not be read back. Assume an orphan pin may ` +
+        `exist and resolve it with the command above before re-running.`,
+    );
+  }
+
+  console.log(`  AuthAllowlist row for ${JSON.stringify(PIN)}: ${allowRow ? "PRESENT" : "absent"}`);
+  console.log(`  User row for ${JSON.stringify(EMAIL)}:        ${userRowNow ? "PRESENT" : "absent"}`);
+
+  if (!allowRow && !userRowNow) {
+    return abort(
+      `nothing was written — the transaction rolled back in full. RE-RUNNING THE SAME ` +
+        `COMMAND IS THE FIX once the cause above is resolved.`,
+    );
+  }
+
+  if (allowRow && userRowNow) {
+    return abort(
+      `both rows are PRESENT, so the provisioning committed and the error above was ` +
+        `raised after the fact (a lost acknowledgement, or a failure on the way back). ` +
+        `Do NOT re-run with --commit; it will refuse. Re-run WITHOUT --commit to see the ` +
+        `state, and CHECK RoleAuditLog for an action="authAllowlist.add" row targeting ` +
+        `${JSON.stringify(PIN)} — it was in the same transaction, so it should be there.`,
+    );
+  }
+
+  if (!allowRow && userRowNow) {
+    // A User row with no pin. Harmless in the way the reverse is not: it mints
+    // no identity, because identity comes from the allowlist. But a re-run now
+    // trips USER_ALREADY_EXISTS, so the operator must be told what to do.
+    return abort(
+      `a User row exists with NO AuthAllowlist row. It mints no identity — the pin is ` +
+        `what does that — so nobody can sign in as it, but a re-run will refuse with ` +
+        `USER_ALREADY_EXISTS. Delete that User row (it is _id=${userRowNow.id}), or add ` +
+        `the pin through /admin -> Auth allowlist, which audits.`,
+    );
+  }
+
+  // THE ONE THAT BREAKS RE-RUNNING: an orphan pin. Compensate.
+  if (allowRow.email !== EMAIL) {
+    return abort(
+      `an AuthAllowlist row holds ${JSON.stringify(PIN)} but pins ` +
+        `${JSON.stringify(allowRow.email)}, not ${JSON.stringify(EMAIL)}. THIS RUN DID NOT ` +
+        `WRITE IT and this script will not delete somebody else's pin. Choose a different ` +
+        `pin, or remove that one deliberately through /admin -> Auth allowlist.`,
+    );
+  }
+
+  console.error(
+    `  orphan pin detected: the AuthAllowlist row landed and the User row did not.\n` +
+      `  Deleting it, so that re-running this command works.`,
+  );
+  try {
+    await db.authAllowlist.delete({ where: { pinnedUserID: PIN } });
+  } catch (delErr) {
+    console.error(`  ! the compensating delete FAILED: ${String(delErr?.message ?? delErr)}`);
+    printOrphanRecoveryCommand();
+    return abort(
+      `an ORPHAN AuthAllowlist row survives and this script could not remove it. Re-running ` +
+        `will refuse with EMAIL_ALREADY_PINNED and PIN_ALREADY_USED until it is gone. Use ` +
+        `the command above.`,
+    );
+  }
+  console.log(`  orphan removed. The cluster is back to the pre-run state.`);
+  return abort(
+    `the write failed and was rolled back (the orphan pin it left was deleted). Resolve ` +
+      `the cause printed above, then RE-RUN THE SAME COMMAND.`,
+  );
+}
+
+/**
+ * The exact recovery, spelled out. An operator reading this is mid-rollout with
+ * an orphan pin, and "it must be cleaned up" is not an instruction.
+ *
+ * The tRPC surface is listed FIRST because it audits. Its one refusal,
+ * PIN_STILL_HOLDS_ROLES, cannot apply to a row this script wrote: the
+ * PIN_ALREADY_HAS_ROLES refusal above proved there was no UserRole row under
+ * this pin minutes ago, and this script never grants roles. If it somehow does
+ * refuse, that is itself the finding — something granted roles to this pin —
+ * and the raw delete below must NOT be used to paper over it.
+ */
+function printOrphanRecoveryCommand() {
+  console.error(
+    `\n  *** RECOVERY — remove the orphan AuthAllowlist row ***\n\n` +
+      `  Preferred (audited): sign in as an admin, /admin -> Auth allowlist, remove the\n` +
+      `  entry for ${JSON.stringify(PIN)}. That is admin.removeAuthAllowlistEntry, which\n` +
+      `  writes an authAllowlist.remove audit row.\n\n` +
+      `  If the surface is unreachable, in mongosh against this cluster:\n\n` +
+      `    db.AuthAllowlist.deleteOne({ pinnedUserID: ${JSON.stringify(PIN)}, email: ${JSON.stringify(EMAIL)} })\n\n` +
+      `  BOTH fields in the filter, deliberately: on the pin alone this would delete\n` +
+      `  whatever row currently holds that pin, including one belonging to somebody\n` +
+      `  else. Expect { deletedCount: 1 }. A raw delete writes NO audit row, so record\n` +
+      `  it by hand. Then re-run this script.`,
+  );
+}
+
+/**
+ * Mints a PasswordResetSession and prints the URL. An EXACT mirror of
+ * src/app/api/reset-password/request-verification-code/route.ts: 32 random
+ * bytes as hex, a 15-minute TTL, and every prior outstanding token for this
+ * address deleted first so only one link is ever live.
+ *
+ * The token is the ONLY trusted input on the consume side — reset-password's
+ * route derives the account from the stored session row, never from a
+ * client-supplied email — so printing this URL is exactly as powerful as being
+ * able to read the person's mailbox for the next 15 minutes. Hand it over
+ * directly and to nobody else.
+ */
+async function mintResetLink() {
+  const base = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? null;
+  if (!base) {
+    return abort(
+      `--print-reset-link needs APP_URL (or NEXTAUTH_URL) in the environment — it is the ` +
+        `same value the route uses to build the link, and a link against the wrong origin ` +
+        `is a link to nowhere. Note the production APP_URL has been wrong before; a link ` +
+        `pointing at localhost is the symptom.`,
+    );
+  }
+
+  if (!COMMIT) {
+    console.log(`\n--- reset link (DRY RUN) ---`);
+    console.log(`  would delete outstanding PasswordResetSession rows for ${JSON.stringify(EMAIL)}`);
+    console.log(`  would create one with a 32-byte hex token, expiring in 15 minutes`);
+    console.log(`  would print ${base}/reset-password?token=<token>`);
+    console.log(`  DRY RUN — no token was minted.`);
+    return;
+  }
+
+  const token = randomBytes(32).toString("hex");
+  const deleted = await db.passwordResetSession.deleteMany({ where: { email: EMAIL } });
+  await db.passwordResetSession.create({
+    data: { email: EMAIL, token, expiresAt: new Date(Date.now() + TOKEN_TTL_MS) },
+  });
+
+  console.log(`\n--- reset link ---`);
+  console.log(`  invalidated ${deleted.count} earlier outstanding token(s) for this address`);
+  console.log(`  expires: ${new Date(Date.now() + TOKEN_TTL_MS).toISOString()}  (15 minutes)`);
+  console.log(`\n  ${base}/reset-password?token=${token}\n`);
+  console.log(
+    `  HAND THIS OVER OUT OF BAND, to the account owner and nobody else. Anyone\n` +
+      `  holding it can set this account's password for the next 15 minutes.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/rbac-doctor.mjs
+++ b/scripts/remediation/rbac-doctor.mjs
@@ -19,6 +19,12 @@
  * By default every RED line prints up to 20 offending identifiers; --names
  * prints all of them. A bare count is not actionable (I-16).
  *
+ * THE AuthAllowlist SECTION is the D-7 break-glass detector (08 §3 Branch C).
+ * It asserts pin uniqueness FROM THE DATA rather than from `listIndexes`, so a
+ * skipped create-auth-allowlist.mjs — which leaves the Prisma @unique enforcing
+ * nothing — is still visible here. The collection being ABSENT is the normal
+ * pre-rollout state and is reported, never RED. See allowlistSection() below.
+ *
  * "eligible users MISSING it" is computed over User rows whose email matches
  * the anchored NUS regex ONLY. Counting non-NUS rows there would make it a line
  * that can NEVER reach zero, and a gate that can never reach zero gets
@@ -30,7 +36,9 @@
  * a failure. See nonNusReport() below.
  */
 import { PrismaClient } from "@prisma/client";
-import { canonicalUserID, isCanonicalResidentID } from "./lib/identity.mjs";
+import {
+  canonicalUserID, isCanonicalResidentID, normalizeEmail, isExtUserID,
+} from "./lib/identity.mjs";
 import {
   findAll, countWhere, numify, E_FORMAT, ROLE_VOCAB, SENTINEL_FACILITY_ID, legacyCanonicalUserID,
   aggregateAll, isCommit, abort,
@@ -66,6 +74,164 @@ function line(label, value, { bad = null, note = "", info = false } = {}) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// AuthAllowlist — the D-7 break-glass, COLLECTION variant (08 §3 Branch C)
+//
+// READ-ONLY, like everything else in the default mode.
+//
+// THE THING THIS SECTION IS ACTUALLY FOR. One row here is `{ email,
+// pinnedUserID }`, and `pinnedUserID` becomes `session.user.userID` verbatim —
+// which IS the authorization key: auth.ts and access.ts both do a bare
+// `findUnique({ where: { userID } })` with no provenance check. So a row
+// pinning an address to `E1633673` would hand that address an admin's roles
+// through NO GRANT PATH AT ALL, meaning not one escalation guard is crossed and
+// not one audit row is written.
+//
+// Four mechanisms stop that, and this section is the DETECTOR for two of them
+// failing:
+//
+//   M2 (namespace enforced at READ time). `asExtUserID` re-validates every pin
+//      as it is read, so a hand-written Atlas row mints nothing. A pin failing
+//      EXT_ID here is therefore not itself an escalation — it is EVIDENCE that
+//      somebody wrote to this collection outside the audited mutation, which is
+//      worth waking up for regardless of what the pin says.
+//
+//   M3 (uniqueness, enforced by a real Mongo index). A Prisma `@unique` on
+//      Mongo enforces NOTHING until `createIndexes` has run
+//      (create-auth-allowlist.mjs). If that step is skipped, two rows can share
+//      a pin and `addAuthAllowlistEntry`'s P2002 refusal can never fire —
+//      silently. So uniqueness is asserted HERE FROM THE DATA, not by reading
+//      `listIndexes`: a missing index becomes visible the moment it lets a
+//      duplicate through, without anyone having to remember to check for it.
+//
+// It also prints what each pin CARRIES, because the operational rule that an
+// EXT identity should never hold `admin` is a policy, not a code guard — and a
+// policy nobody can see is not a policy.
+//
+// ABSENT IS NORMAL. Before create-auth-allowlist.mjs runs, this collection does
+// not exist. That is reported and is NOT a RED line and NOT an exit-1.
+// ---------------------------------------------------------------------------
+
+/** { present, rows, error }. `present:false` means the collection is absent —
+ *  distinguished from "exists and is empty", because those mean different
+ *  things about where the rollout has got to. */
+async function readAuthAllowlist() {
+  try {
+    // No server-side filter on listCollections: Atlas rejects
+    // `filter: { name: { $in: [...] } }` with "can't get regex from filter doc
+    // not a regex" (see preflight-scrc-validators.mjs). Ask for everything,
+    // narrow in JS — one round trip, still read-only.
+    const lc = await raw({ listCollections: 1 });
+    const present = (lc?.cursor?.firstBatch ?? []).some((c) => c?.name === "AuthAllowlist");
+    if (!present) return { present: false, rows: [], error: null };
+    const rows = await findAll(db, "AuthAllowlist", {
+      email: 1, pinnedUserID: 1, note: 1, addedBy: 1, addedAt: 1,
+    });
+    return { present: true, rows, error: null };
+  } catch (e) {
+    // FAIL LOUD, never fail quiet. An unreadable allowlist reported as an empty
+    // one would print a clean bill of health over exactly the rows this section
+    // exists to inspect.
+    return { present: null, rows: [], error: String(e?.message ?? e) };
+  }
+}
+
+function allowlistSection(allowlist, users, userRole) {
+  console.log(``);
+  if (allowlist.error) {
+    line("AuthAllowlist: UNREADABLE", 1, {
+      bad: [allowlist.error],
+      note: "not a measured zero — resolve before trusting this report",
+    });
+    return;
+  }
+  if (allowlist.present === false) {
+    line("AuthAllowlist rows", "n/a", {
+      info: true,
+      note: "collection ABSENT — expected before create-auth-allowlist.mjs",
+    });
+    return;
+  }
+
+  const rows = allowlist.rows ?? [];
+  line("AuthAllowlist rows (admin-pinned identities)", rows.length, { info: true });
+  if (!rows.length) {
+    console.log(`      (collection exists but holds no pins — the break-glass is unused)`);
+    return;
+  }
+
+  const rolesByID = new Map(userRole.map((r) => [String(r.userID ?? ""), r.roles ?? []]));
+  const emailsPresent = new Set(users.map((u) => normalizeEmail(String(u.email ?? ""))));
+
+  // --- M2: every pin must be in the EXT namespace -------------------------
+  const notExt = rows
+    .filter((r) => !isExtUserID(String(r.pinnedUserID ?? "")))
+    .map((r) => `${String(r.email)}->${JSON.stringify(r.pinnedUserID ?? null)}`);
+  line("  pins OUTSIDE the EXT: namespace", notExt.length, {
+    bad: notExt,
+    note: "mints NO identity (M2) — someone wrote this row by hand",
+  });
+
+  // --- M3: uniqueness, asserted from the DATA -----------------------------
+  const byPin = new Map();
+  const byEmail = new Map();
+  for (const r of rows) {
+    const p = String(r.pinnedUserID ?? "");
+    const e = normalizeEmail(String(r.email ?? ""));
+    if (!byPin.has(p)) byPin.set(p, []);
+    byPin.get(p).push(e);
+    byEmail.set(e, (byEmail.get(e) ?? 0) + 1);
+  }
+  const sharedPins = [...byPin]
+    .filter(([, emails]) => emails.length > 1)
+    .map(([p, emails]) => `${p} <- ${emails.join(" + ")}`);
+  const dupEmails = [...byEmail].filter(([, n]) => n > 1).map(([e, n]) => `${e}(x${n})`);
+  line("  pins claimed by MORE THAN ONE email", sharedPins.length, {
+    bad: sharedPins,
+    note: "M3 BROKEN — the pin_unique index is missing (create-auth-allowlist.mjs)",
+  });
+  line("  emails appearing more than once", dupEmails.length, {
+    bad: dupEmails,
+    note: "the email_unique index is missing",
+  });
+
+  // --- the operational rule, made visible ---------------------------------
+  const extAdmins = rows
+    .filter((r) => (rolesByID.get(String(r.pinnedUserID ?? "")) ?? []).includes("admin"))
+    .map((r) => `${String(r.pinnedUserID)}(${String(r.email)})`);
+  line("  EXT pins holding \"admin\"", extAdmins.length, {
+    bad: extAdmins,
+    note: "an identity minted from a row, not from an NUS address, with full admin",
+  });
+
+  // --- a pinned address that ALSO has a canonical identity ----------------
+  //
+  // One human, two identity keys: two UserRole rows, two booking owners, two
+  // audit trails, and nothing that reconciles them. addAuthAllowlistEntry
+  // refuses this (EMAIL_IS_CANONICAL) and so does provision-ext-account.mjs, so
+  // a hit here means the row predates those guards or bypassed them.
+  const canonicalPinned = rows
+    .filter((r) => canonicalUserID(String(r.email ?? "")) !== null)
+    .map((r) => `${String(r.email)}->${String(r.pinnedUserID)}`);
+  line("  pinned addresses that ALSO canonicalise", canonicalPinned.length, {
+    bad: canonicalPinned,
+    note: "one human with two identity keys",
+  });
+
+  // --- the roster, one line per pin ---------------------------------------
+  console.log(`\n      pin                       email                                    roles              User row`);
+  for (const r of rows) {
+    const pin = String(r.pinnedUserID ?? "(null)");
+    const email = normalizeEmail(String(r.email ?? ""));
+    const roles = rolesByID.get(pin) ?? [];
+    const hasUser = emailsPresent.has(email);
+    console.log(
+      `      ${pin.padEnd(25)} ${email.padEnd(40)} ${JSON.stringify(roles).padEnd(18)} ` +
+        `${hasUser ? "yes" : "NO — session would sign out (accountMissing)"}`,
+    );
+  }
+}
+
 async function main() {
   if (NONNUS) return nonNusReport();
   console.log(`\n=== rbac-doctor.mjs ===  ${new Date().toISOString()}\n`);
@@ -77,13 +243,33 @@ async function main() {
   const access = (await findAll(db, "FacilityAccess", { facilityID: 1, requiredRoles: 1, requiredRole: 1 }))
     .map((a) => ({ ...a, facilityID: numify(a.facilityID) }));
 
+  // D-7 break-glass, the COLLECTION variant. Read BEFORE the population loop
+  // because the "INELIGIBLE" line below subtracts these addresses. Absent is
+  // the normal pre-rollout state and is not an error — see allowlistSection().
+  const allowlist = await readAuthAllowlist();
+  const pinnedEmails = new Map(
+    (allowlist.rows ?? []).map((r) => [normalizeEmail(String(r.email ?? "")), String(r.pinnedUserID ?? "")]),
+  );
+
   // --- population -------------------------------------------------------
   const eligible = new Map();
-  const nonNus = [], blank = [], nonE = [], collisions = [];
+  const nonNus = [], blank = [], nonE = [], collisions = [], pinned = [];
   for (const u of users) {
     const e = String(u.email ?? "");
     const id = canonicalUserID(e);
-    if (!isCanonicalResidentID(id)) { (e.trim() ? nonNus : blank).push(e || String(u._id?.$oid ?? u._id)); continue; }
+    if (!isCanonicalResidentID(id)) {
+      // AN ADDRESS WITH AN ALLOWLIST PIN IS NOT INELIGIBLE. It has no canonical
+      // id — that is the whole reason it needs a pin — but resolvePrincipalID
+      // gives it an EXT: identity, so it signs in, holds roles and books rooms.
+      // Leaving it in the INELIGIBLE bucket labels the hall office as locked
+      // out, and a future operator reading this report will go and "fix" a
+      // thing that is working exactly as designed — most likely by widening the
+      // domain rule, which is the one change this whole mechanism exists to
+      // avoid. Counted separately instead.
+      if (e.trim() && pinnedEmails.has(normalizeEmail(e))) pinned.push(e);
+      else (e.trim() ? nonNus : blank).push(e || String(u._id?.$oid ?? u._id));
+      continue;
+    }
     if (!E_FORMAT.test(id)) nonE.push(id);
     if (eligible.has(id)) collisions.push(id);
     else eligible.set(id, e);
@@ -91,11 +277,18 @@ async function main() {
 
   line("users(total)", users.length);
   line("users(eligible, canonical has no @)", eligible.size);
-  line("users(INELIGIBLE — cannot sign in under D-7)", nonNus.length, { info: true, note: "migration list" });
+  line("users(pinned via AuthAllowlist — sign in as EXT)", pinned.length, {
+    info: true, note: "NOT locked out; see the allowlist section" });
+  if (pinned.length) console.log(`      ${(ALL_NAMES ? pinned : pinned.slice(0, 20)).join(", ")}`);
+  line("users(INELIGIBLE — cannot sign in under D-7)", nonNus.length, {
+    info: true, note: "migration list; pinned addresses SUBTRACTED" });
   if (nonNus.length) console.log(`      ${(ALL_NAMES ? nonNus : nonNus.slice(0, 20)).join(", ")}`);
   line("canonical id collisions", collisions.length, { bad: collisions, note: "merged accounts" });
   line("canonical id empty (blank email)", blank.length, { bad: blank });
   line("canonical id not E-format", nonE.length, { info: true, note: "LEGITIMATE — never exclude (L-27)" });
+
+  // --- the D-7 break-glass allowlist ------------------------------------
+  allowlistSection(allowlist, users, userRole);
 
   // --- stored baseline (the flip gate) ----------------------------------
   const withResident = new Set(userRole.filter((r) => (r.roles ?? []).includes("resident")).map((r) => r.userID));
@@ -164,10 +357,14 @@ async function main() {
   let pending = [];
   try { pending = await findAll(db, "PendingRoleGrant"); } catch { /* collection may not exist yet */ }
   const nowMs = Date.now();
-  const privPending = pending.filter((p) => (p.roles ?? []).some((r) => r === "admin" || r === "jcrc"));
+  // admin | jcrc | scrc — every PRIVILEGED grantable role. Must stay in step
+  // with the identical filter in verify-legacy-drop.mjs, which BLOCKS the drop;
+  // this one only reports, so a divergence shows up here as a quiet undercount.
+  // cca_head cannot travel the deferred path (no ASSIGNABLE_BY entry).
+  const privPending = pending.filter((p) => (p.roles ?? []).some((r) => r === "admin" || r === "jcrc" || r === "scrc"));
   const expired = pending.filter((p) => p.expiresAt && new Date(p.expiresAt?.$date ?? p.expiresAt).getTime() <= nowMs);
   line("PendingRoleGrant: outstanding", pending.length);
-  line("  of which admin/jcrc", privPending.length, {
+  line("  of which admin/jcrc/scrc", privPending.length, {
     bad: privPending.map((p) => `${p.userID}:${JSON.stringify(p.roles)}`),
     note: "requires named sign-off before the legacy drop" });
   line("  expired, unclaimed", expired.length, { info: true });

--- a/scripts/remediation/rekey-to-ext-identity.mjs
+++ b/scripts/remediation/rekey-to-ext-identity.mjs
@@ -1,0 +1,801 @@
+/**
+ * Moves an EXISTING account from a legacy identity key to an `EXT:` allowlist
+ * pin, carrying its whole history with it.
+ *
+ *   node scripts/remediation/rekey-to-ext-identity.mjs \
+ *     --email vincent.koh@nus.edu.sg --from VKTJ66 --to EXT:VINCENT_KOH \
+ *     --actor E1633673
+ *   ... --commit      to apply
+ *
+ * Dry run by DEFAULT. It prints a per-collection before/after table and exits 1
+ * without writing anything if ANY refusal fires.
+ *
+ * ===========================================================================
+ * WHAT THIS IS FOR, AND HOW IT DIFFERS FROM provision-ext-account.mjs
+ * ===========================================================================
+ *
+ * provision-ext-account.mjs CREATES an identity: an AuthAllowlist row plus a
+ * brand-new `User` row with no passwordHash. It REFUSES when a `User` row
+ * already exists (`USER_ALREADY_EXISTS`), and that refusal is correct — it must
+ * never overwrite a live account.
+ *
+ * This script is the other case: THE PERSON ALREADY HAS AN ACCOUNT, with a
+ * password, a display name, and years of rows filed under a legacy key that
+ * `canonicalUserID` cannot derive from their address. Under the deployed code
+ * their session resolves to `userID: null`, so they can neither book nor SEE
+ * the bookings they already hold. Pinning the address alone does not fix that:
+ * it mints a NEW key, and every existing row of theirs is still filed under the
+ * OLD one. The rows have to move, or the pin quietly orphans their history.
+ *
+ * ===========================================================================
+ * THE THREE BUCKETS. Every collection in this database is in exactly one.
+ * ===========================================================================
+ *
+ * The taxonomy is NOT invented here. It is the one `deleteUserAccountCascade`
+ * (src/server/api/services/userAdmin.ts) already had to settle, including its
+ * long "DELIBERATELY NOT DELETED, and why" block — read that before changing
+ * any list below. What changes for a RE-KEY is only the verb.
+ *
+ * (A) OWNERSHIP — RE-KEYED. Rows the account owns, and which the app finds by
+ *     looking up this key. Leaving one behind is data silently orphaned: the
+ *     row still exists, nothing reports an error, and the user simply cannot
+ *     see it. All twelve are in the cascade's delete set for the same reason
+ *     they are here — they are the account's own records.
+ *
+ * (B) HISTORY / PROVENANCE — COUNTED AND REPORTED, NEVER RE-KEYED. Rows that
+ *     RECORD SOMETHING THAT HAPPENED, in which this key appears as a statement
+ *     of fact about the past ("the actor was VKTJ66 at 14:02"). Rewriting them
+ *     makes the record assert something that never happened. The cascade
+ *     declines to DELETE these for the mirror-image reason. They are counted
+ *     and printed so the operator sees the split rather than discovering it.
+ *
+ * (C) UNRESOLVED KEY FORMAT — COUNTED, AND A NON-ZERO COUNT IS A REFUSAL.
+ *     The supper domain. userAdmin.ts is explicit that nobody knows whether
+ *     `Order.userID` holds this key format at all, and that the last person to
+ *     guess got it wrong in both directions. An `updateMany` is safe when the
+ *     count is zero and is a decision nobody has authority to make when it is
+ *     not — so a non-zero count stops the run and hands it to a human. This is
+ *     the same "cannot verify ⇒ stop" posture preflight-scrc-validators.mjs
+ *     takes on an uninterpretable validator.
+ *
+ * (D) NOT AN IDENTITY KEY AT ALL — NEVER TOUCHED. Enumerated below, because
+ *     "we did not think about it" and "we thought about it and it must not
+ *     move" look identical in a diff. `Session.userId`, `Account.userId` and
+ *     `Authenticator.userId` are the dangerous ones: they are MONGO OBJECTIDS
+ *     referencing `User._id`, not app identity keys, and they LOOK like the
+ *     others. Writing an EXT pin into one breaks NextAuth's adapter relations
+ *     and Prisma's `onDelete: Cascade` for that account.
+ *
+ * ===========================================================================
+ * WHY RoleAuditLog IS NOT RE-KEYED — the decision, stated so it is not silent
+ * ===========================================================================
+ *
+ * schema.prisma calls RoleAuditLog append-only BY CODE CONTRACT: "There is no
+ * update or delete path in any router, and none may be added." An updateMany
+ * here would be the first violation of that contract, performed by a script,
+ * on the one collection whose entire value is that it cannot be edited.
+ *
+ * And the rows would become FALSE. `actorUserID: "VKTJ66"` does not mean "this
+ * person"; it means "the actor was keyed VKTJ66 when this happened", which is
+ * true and will stay true forever. Rewriting it to the pin produces a log
+ * claiming an identity acted before that identity existed.
+ *
+ * THE COST IS REAL AND IS NOT HIDDEN: `admin.listAuditLog` filtered by the pin
+ * will NOT return the pre-migration half of this account's trail. That is why
+ * this script writes an `identity.rekey` row carrying the old key in
+ * `rolesBefore` and the pin in `rolesAfter` — that row is the JOIN, and it is
+ * the reason the split is navigable rather than lost. The dry run prints the
+ * affected counts under (B) so the operator sees exactly how much history stays
+ * behind before they decide to proceed.
+ *
+ * The same argument covers `BookingLogs` and every `createdBy` / `updatedBy` /
+ * `decidedBy` provenance string.
+ *
+ * BookingLogs is the one worth checking rather than asserting, because the
+ * counts are not small (104 rows for the first account migrated). Three
+ * independent things say it stays:
+ *   - userAdmin.ts's not-deleted block: "BookingLogs — A log. Same class as
+ *     the above [RoleAuditLog]."
+ *   - merge-by-canonical.mjs — THE CLOSEST PRECEDENT, since it moves a losing
+ *     account's rows onto a winning key exactly as this does — lists it in
+ *     `DEPENDENTS_OPTIONAL`: "Counted, reported, NOT reassigned."
+ *   - nothing in `src/` reads or writes the collection at all. `grep -rn
+ *     BookingLogs src/` returns one hit and it is a comment. So no user-facing
+ *     surface can orphan anything by leaving it: there is no surface.
+ * If a future feature starts reading BookingLogs by userID, it moves to
+ * bucket (A) and this note is the thing that should be re-read.
+ *
+ * WHERE THIS DIVERGES FROM merge-by-canonical.mjs, deliberately: that script
+ * has `Order` in its DEPENDENTS (it moves supper orders). This one refuses on
+ * them instead. userAdmin.ts's later and much longer analysis concluded the key
+ * format there was never established and that the last person to guess got it
+ * wrong in both directions — so the newer reasoning wins. It is moot whenever
+ * the count is zero, which is the only state this script will proceed from.
+ *
+ * Note also that merge-by-canonical's dependent list is a STRICT SUBSET of
+ * bucket (A) below: it predates ProfileCompletion, CcaHead, EventSignup,
+ * CcaApplication and PendingRoleGrant. Any list of "the keyed collections"
+ * copied from a document or an older script is stale by construction; the
+ * schema is the source, and bucket (D) exists so that re-deriving it from the
+ * schema is checkable rather than a fresh judgement call every time.
+ *
+ * ===========================================================================
+ * REFUSALS — every one aborts the whole run, before any write
+ * ===========================================================================
+ *   MISSING_ARGS            --email / --from / --to / --actor not all supplied.
+ *   PIN_NOT_EXT             --to fails EXT_ID. The namespace is the mechanism
+ *                           (see src/lib/identity.ts): a pin that is not in it
+ *                           mints no identity at all, so this would move 68
+ *                           rows onto a key no session can ever produce.
+ *   FROM_IS_EXT             --from is already an EXT pin. This script moves a
+ *                           LEGACY key to a pin; pin-to-pin is a different
+ *                           operation with different hazards and does not have
+ *                           one here.
+ *   FROM_IS_BLANK           --from is empty or whitespace. `where: {userID:""}`
+ *                           is the sentinel bug class — it matches every
+ *                           ""-keyed row in the database, i.e. a stranger's.
+ *   FROM_EQUALS_TO          nothing to do, and an updateMany from a key to
+ *                           itself would produce a misleading "moved N rows".
+ *   EMAIL_IS_CANONICAL      the address already derives an identity of its own.
+ *                           Pinning it gives one human two identities — the
+ *                           same refusal addAuthAllowlistEntry makes.
+ *   NO_USER_ROW             no `User` row for --email. Use
+ *                           provision-ext-account.mjs; this script only MOVES.
+ *   USER_KEY_MISMATCH       the `User` row's stored userID is not --from. The
+ *                           operator has the wrong old key, and every count
+ *                           below would be measuring somebody else's rows.
+ *   FROM_KEY_NOT_EXCLUSIVE  more than one `User` row carries --from. `User.userID`
+ *                           has NO unique index, and the split-identity rows in
+ *                           this database are real (fix-claresta-duplicate.mjs
+ *                           documents an account whose stored userID is another
+ *                           live human's key). Re-keying by `where: {userID}`
+ *                           would carry that stranger's rows across too.
+ *   TARGET_KEY_OCCUPIED     ANY row already exists under --to, in ANY collection.
+ *                           THE WORST OUTCOME AVAILABLE HERE: the move would
+ *                           MERGE TWO IDENTITIES, and no unique index catches it
+ *                           on the non-unique collections (Bookings, Posts,
+ *                           UserCCA, Gym, CcaApplication).
+ *   EMAIL_PINNED_ELSEWHERE  an AuthAllowlist row pins --email to a different pin.
+ *   PIN_PINNED_ELSEWHERE    an AuthAllowlist row pins --to to a different email.
+ *   ALLOWLIST_INDEXES_MISSING
+ *                           `email_unique` / `pin_unique` are not on the
+ *                           collection, so M3 does not exist and the create
+ *                           below is not protected against a concurrent one.
+ *                           Run create-auth-allowlist.mjs first.
+ *   UNRESOLVED_DOMAIN_ROWS  bucket (C) is non-empty. See above.
+ *
+ * ===========================================================================
+ * ATOMICITY, IDEMPOTENCE, AND WHAT A FAILURE LEAVES BEHIND
+ * ===========================================================================
+ *
+ * ONE INTERACTIVE `db.$transaction`. The document count is irrelevant to the
+ * budget — 68 bookings move in ONE `updateMany`, which is one command — so the
+ * whole migration is ~15 operations regardless of how much history the account
+ * has. That is far inside both Prisma's transaction timeout (raised explicitly
+ * below rather than left to the 5s default) and MongoDB's 16MB oplog ceiling.
+ * Splitting it was considered and rejected: a half-applied identity move is a
+ * state in which the person's bookings are under one key and their roles under
+ * another, and no ordering makes that safe to leave sitting.
+ *
+ * A failed run therefore writes NOTHING and is re-runnable as-is.
+ *
+ * A SUCCESSFUL RUN RE-RUN IS A CLEAN NO-OP, NOT A REFUSAL. `ALREADY_MIGRATED`
+ * is detected up front — allowlist row present with exactly this (email, pin),
+ * the `User` row already carrying the pin, and zero rows under the old key —
+ * and exits 0. A refusal here would look like an error to an operator who is
+ * merely re-checking their work, and an operator who is told "error" when the
+ * answer is "done" starts investigating a healthy system.
+ *
+ * MongoDB will not implicitly CREATE a collection inside a transaction, so
+ * `AuthAllowlist` must already exist. ALLOWLIST_INDEXES_MISSING proves it does:
+ * `listIndexes` cannot report two unique indexes on a collection that is absent.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  canonicalUserID,
+  normalizeEmail,
+  isExtUserID,
+} from "./lib/identity.mjs";
+import { isCommit, banner, abort } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+const COMMIT = isCommit();
+
+/** `--flag value`. Same shape as provision-ext-account.mjs. */
+function argOf(flag) {
+  const i = process.argv.indexOf(flag);
+  if (i === -1) return null;
+  const v = process.argv[i + 1];
+  return v === undefined || v.startsWith("--") ? null : v;
+}
+
+const RAW_EMAIL = argOf("--email");
+const RAW_FROM = argOf("--from");
+const RAW_TO = argOf("--to");
+const RAW_ACTOR = argOf("--actor");
+
+const EMAIL = RAW_EMAIL === null ? null : normalizeEmail(RAW_EMAIL);
+// `--to` gets the SAME transform the server's extUserIDSchema applies
+// (.trim().toUpperCase()), so a pin typed here and a pin typed into the admin
+// UI cannot diverge into two spellings of one key.
+const TO = RAW_TO === null ? null : RAW_TO.trim().toUpperCase();
+// `--from` is a LEGACY key and is NOT uppercased. It is whatever is actually in
+// the column; "VKTJ66" and "A0221446M" happen to be upper case, but inventing a
+// transform here would silently fail to match a mixed-case legacy value and
+// report "0 rows to move" for an account with 68 of them.
+const FROM = RAW_FROM === null ? null : RAW_FROM.trim();
+const ACTOR = RAW_ACTOR === null ? null : RAW_ACTOR.trim();
+
+const refusals = [];
+const refuse = (code, why) => refusals.push({ code, why });
+
+/* ==========================================================================
+ * BUCKET (A) — OWNERSHIP. These move.
+ *
+ * `model`  the Prisma accessor.
+ * `field`  the column holding the identity key.
+ * `unique` whether a unique index covers it. Documented because it decides
+ *          what happens on a collision: a unique collection FAILS the
+ *          updateMany (loud, transaction aborts), a non-unique one silently
+ *          MERGES. TARGET_KEY_OCCUPIED is what protects the second kind, and
+ *          that is the whole reason the pre-check covers every collection
+ *          rather than just the interesting ones.
+ * ========================================================================== */
+const OWNERSHIP = [
+  { model: "bookings", field: "userID", unique: false, note: "the account's room bookings" },
+  { model: "userRole", field: "userID", unique: true, note: "THE authorization row" },
+  { model: "userMatric", field: "userID", unique: true, note: "matriculation number" },
+  { model: "profileCompletion", field: "userID", unique: true, note: "post-merge prompt" },
+  { model: "userCCA", field: "userID", unique: false, note: "CCA membership" },
+  { model: "ccaHead", field: "userID", unique: true, note: "CCA headship scopes ([userID,ccaID])" },
+  { model: "eventSignup", field: "userID", unique: true, note: "event signups ([eventID,userID])" },
+  { model: "ccaApplication", field: "userID", unique: false, note: "CCA applications they filed" },
+  { model: "posts", field: "userID", unique: false, note: "their posts" },
+  { model: "gym", field: "userID", unique: false, note: "gym key-holder records" },
+  { model: "pendingRoleGrant", field: "userID", unique: true, note: "unclaimed grant for this key" },
+];
+
+/* ==========================================================================
+ * BUCKET (B) — HISTORY / PROVENANCE. Counted, reported, NEVER moved.
+ * ========================================================================== */
+const HISTORY = [
+  { model: "roleAuditLog", field: "actorUserID", note: "who acted, AT THE TIME (append-only)" },
+  { model: "roleAuditLog", field: "targetUserID", note: "who was acted on, AT THE TIME" },
+  { model: "bookingLogs", field: "userID", note: "a log — same class as the audit log" },
+  { model: "bulkRoleImport", field: "actorUserID", note: "who ran a bulk import" },
+  { model: "ccaApplication", field: "decidedBy", note: "who decided somebody else's application" },
+  { model: "ccaInterviewNote", field: "authorUserID", note: "notes they wrote about OTHER applicants" },
+  { model: "ccaInterviewSlot", field: "createdBy", note: "slot provenance; other applicants hold seats" },
+  { model: "event", field: "createdBy", note: "the event belongs to the CCA, not the filer" },
+  { model: "event", field: "updatedBy", note: "provenance string" },
+  { model: "ccaProfile", field: "updatedBy", note: "provenance string, not a reference" },
+  { model: "facilityAccess", field: "updatedBy", note: "provenance string" },
+  { model: "systemFlag", field: "updatedBy", note: "provenance string" },
+  { model: "userRole", field: "updatedBy", note: "provenance string" },
+  { model: "pendingRoleGrant", field: "createdBy", note: "who created somebody else's grant" },
+  { model: "authAllowlist", field: "addedBy", note: "who issued somebody else's pin" },
+];
+
+/* ==========================================================================
+ * BUCKET (C) — UNRESOLVED KEY FORMAT. Non-zero here STOPS THE RUN.
+ *
+ * userAdmin.ts, verbatim: "the key format is still unresolved ... Raise it with
+ * the owner rather than guessing at the key." That was written about deleting.
+ * An updateMany is gentler — a wrong guess moves nothing rather than destroying
+ * something — but SupperGroup carries DENORMALIZED aggregates (numOrders,
+ * userIdList, totalPrice, currentFoodCost) that a partial move would leave
+ * disagreeing with the Orders they summarise. So: count, and if anything is
+ * there, stop and let a human decide.
+ * ========================================================================== */
+const UNRESOLVED = [
+  { model: "order", field: "userID", note: "supper orders — key format unresolved" },
+  { model: "supperGroup", field: "ownerId", note: "supper group owner" },
+  { model: "supperGroup", field: "userIdList", note: "supper group members (ARRAY)", isArray: true },
+];
+
+/* ==========================================================================
+ * BUCKET (D) — NOT AN IDENTITY KEY. Never touched. Listed so that "we thought
+ * about it" is distinguishable from "we forgot".
+ *
+ *   Session.userId          MONGO OBJECTID -> User._id. NextAuth adapter
+ *   Account.userId          relations and Prisma's `onDelete: Cascade` ride on
+ *   Authenticator.userId    these. They LOOK like the columns above and are a
+ *                           completely different namespace; writing a pin into
+ *                           one detaches the account from its own sessions.
+ *   PasswordResetSession    keyed by EMAIL, and the email does not change here.
+ *   BookingLock.key         ephemeral lock keys, seconds of lifetime.
+ *   EventLock.key           likewise.
+ *   RateLimit.key           likewise (and buckets expire).
+ *   FoodOrder / FoodMenu    no identity column at all.
+ *   Crowd / Counter /       no identity column at all.
+ *   Restaurants
+ *   User.userID             moved, but by _id and separately — see step 2. It
+ *                           is the ONE row this script updates rather than
+ *                           updateMany's, because `User.userID` has no unique
+ *                           index and a `where: {userID}` there can match two
+ *                           people (FROM_KEY_NOT_EXCLUSIVE).
+ * ========================================================================== */
+
+const pad = (s, n) => String(s).padEnd(n);
+const padL = (s, n) => String(s).padStart(n);
+
+/** Count rows where `field` holds `key`. `isArray` switches to a `has` filter. */
+async function countKey(model, field, key, isArray = false) {
+  const where = { [field]: isArray ? { has: key } : key };
+  return db[model].count({ where });
+}
+
+async function main() {
+  banner("rekey-to-ext-identity.mjs", COMMIT);
+
+  /* ---- 0. arguments ---------------------------------------------------- */
+  if (!EMAIL || !FROM || !TO || !ACTOR) {
+    return abort(
+      "MISSING_ARGS — all four are required:\n" +
+        "  --email <address>   the account's address (will be pinned)\n" +
+        "  --from  <old key>   the legacy identity key its rows are filed under\n" +
+        "  --to    <EXT:PIN>   the new pin\n" +
+        "  --actor <userID>    who is running this, for the audit row\n\n" +
+        "  e.g. --email vincent.koh@nus.edu.sg --from VKTJ66 \\\n" +
+        "       --to EXT:VINCENT_KOH --actor E1633673",
+    );
+  }
+
+  console.log(`  email:  ${JSON.stringify(EMAIL)}`);
+  console.log(`  from:   ${JSON.stringify(FROM)}`);
+  console.log(`  to:     ${JSON.stringify(TO)}`);
+  console.log(`  actor:  ${JSON.stringify(ACTOR)}`);
+
+  if (!isExtUserID(TO)) {
+    refuse(
+      "PIN_NOT_EXT",
+      `--to ${JSON.stringify(TO)} does not match /^EXT:[A-Z0-9_]{3,32}$/. ` +
+        `The namespace IS the mechanism: pinnedUserIDFor re-validates it at every ` +
+        `read and returns the ABSENT identity for anything outside it, so this ` +
+        `would move every row onto a key no session can ever resolve to.`,
+    );
+  }
+  if (isExtUserID(FROM)) {
+    refuse(
+      "FROM_IS_EXT",
+      `--from ${JSON.stringify(FROM)} is already an EXT pin. This script moves a ` +
+        `LEGACY key onto a pin. Pin-to-pin is a different operation (the old pin's ` +
+        `AuthAllowlist row would also have to move or be removed) and it is not ` +
+        `implemented here.`,
+    );
+  }
+  if (!FROM || FROM.trim() === "") {
+    refuse(
+      "FROM_IS_BLANK",
+      `--from is empty. \`where: { userID: "" }\` is the sentinel bug class: it ` +
+        `matches every ""-keyed row in the database, which are by definition not ` +
+        `this account's.`,
+    );
+  }
+  if (FROM === TO) {
+    refuse("FROM_EQUALS_TO", `--from and --to are the same key. Nothing to move.`);
+  }
+  if (canonicalUserID(EMAIL) !== null) {
+    refuse(
+      "EMAIL_IS_CANONICAL",
+      `${JSON.stringify(EMAIL)} derives a canonical identity of its own ` +
+        `(${JSON.stringify(canonicalUserID(EMAIL))}), so it does not need a pin. ` +
+        `Pinning it would give one human two identities — the same refusal ` +
+        `admin.addAuthAllowlistEntry makes.`,
+    );
+  }
+
+  if (refusals.length) return report();
+
+  /* ---- 1. the AuthAllowlist collection and its indexes ------------------ */
+  // M3 must exist before we create a row: without the unique indexes two
+  // concurrent runs can both claim this pin. It also PROVES the collection
+  // exists, which the transaction below depends on (Mongo will not implicitly
+  // create a collection inside one).
+  let indexNames = [];
+  try {
+    const r = await db.$runCommandRaw({ listIndexes: "AuthAllowlist" });
+    indexNames = (r?.cursor?.firstBatch ?? []).map((i) => String(i.name));
+  } catch {
+    indexNames = [];
+  }
+  const haveIdx =
+    indexNames.includes("email_unique") && indexNames.includes("pin_unique");
+  console.log(
+    `\n  AuthAllowlist indexes: ${indexNames.length ? indexNames.join(", ") : "(collection absent)"}`,
+  );
+  if (!haveIdx) {
+    refuse(
+      "ALLOWLIST_INDEXES_MISSING",
+      `email_unique and/or pin_unique are not present. Mechanism M3 does not ` +
+        `exist without them, and MongoDB will not create the collection ` +
+        `implicitly inside the transaction below. Run ` +
+        `\`node scripts/remediation/create-auth-allowlist.mjs --commit\` first.`,
+    );
+  }
+
+  /* ---- 2. the User row -------------------------------------------------- */
+  // EXPLICIT SELECT, never a bare findMany: #9 (passwordHash must not be read
+  // into this process) and I-2 (Prisma 6 throws deserializing a row missing a
+  // required non-list scalar). `passwordHash` is taken as a BOOLEAN-ish
+  // presence check only, so its value never lands in a variable or a log.
+  const usersByEmail = await db.user.findMany({
+    where: { email: { equals: EMAIL, mode: "insensitive" } },
+    select: { id: true, email: true, userID: true, displayName: true, block: true, telegramHandle: true },
+  });
+  console.log(`\n  User rows for this email: ${usersByEmail.length}`);
+  for (const u of usersByEmail) {
+    console.log(
+      `    _id=${u.id}  userID=${JSON.stringify(u.userID)}  ` +
+        `displayName=${JSON.stringify(u.displayName)}  block=${JSON.stringify(u.block)}  ` +
+        `telegramHandle=${JSON.stringify(u.telegramHandle)}`,
+    );
+  }
+  if (usersByEmail.length === 0) {
+    refuse(
+      "NO_USER_ROW",
+      `no User row for ${JSON.stringify(EMAIL)}. This script only MOVES an existing ` +
+        `account. To create one, use provision-ext-account.mjs.`,
+    );
+  }
+  if (usersByEmail.length > 1) {
+    refuse(
+      "FROM_KEY_NOT_EXCLUSIVE",
+      `${usersByEmail.length} User rows share this address. Merge them first ` +
+        `(scripts/remediation/merge-by-canonical.mjs) — re-keying one of a pair ` +
+        `leaves the other holding the old key.`,
+    );
+  }
+  const userRow = usersByEmail[0] ?? null;
+
+  // EXCLUSIVITY OF THE OLD KEY. `User.userID` has NO unique index (see M5 in
+  // provision-ext-account.mjs), and this database really does contain rows whose
+  // stored userID is a DIFFERENT LIVE HUMAN'S key — fix-claresta-duplicate.mjs
+  // documents one. Every updateMany below is `where: { userID: FROM }`, so if a
+  // second person carries FROM their rows come across too, filed under this
+  // person's new pin, and nothing would ever report it.
+  const usersByFromKey = await db.user.findMany({
+    where: { userID: FROM },
+    select: { id: true, email: true },
+  });
+  console.log(`  User rows carrying --from (${JSON.stringify(FROM)}): ${usersByFromKey.length}`);
+  for (const u of usersByFromKey) console.log(`    _id=${u.id}  email=${JSON.stringify(u.email)}`);
+  if (usersByFromKey.length > 1) {
+    refuse(
+      "FROM_KEY_NOT_EXCLUSIVE",
+      `${usersByFromKey.length} User rows carry userID=${JSON.stringify(FROM)}. ` +
+        `Re-keying by \`where: { userID }\` would carry the other account's rows ` +
+        `across as well. Resolve the split identity first.`,
+    );
+  }
+
+  /* ---- 3. the allowlist row (may already exist — resumability) ---------- */
+  const pinByEmail = await db.authAllowlist.findUnique({ where: { email: EMAIL } });
+  const pinByPin = await db.authAllowlist.findUnique({ where: { pinnedUserID: TO } });
+  console.log(
+    `\n  AuthAllowlist by email: ${pinByEmail ? JSON.stringify(pinByEmail.pinnedUserID) : "absent"}` +
+      `   by pin: ${pinByPin ? JSON.stringify(pinByPin.email) : "absent"}`,
+  );
+  if (pinByEmail && pinByEmail.pinnedUserID !== TO) {
+    refuse(
+      "EMAIL_PINNED_ELSEWHERE",
+      `${JSON.stringify(EMAIL)} is already pinned to ` +
+        `${JSON.stringify(pinByEmail.pinnedUserID)}, not ${JSON.stringify(TO)}.`,
+    );
+  }
+  if (pinByPin && normalizeEmail(pinByPin.email) !== EMAIL) {
+    refuse(
+      "PIN_PINNED_ELSEWHERE",
+      `${JSON.stringify(TO)} is already pinned to ${JSON.stringify(pinByPin.email)}. ` +
+        `Pins are not reusable.`,
+    );
+  }
+  // OUR OWN row already being there is NOT a refusal — it is what a resumed or
+  // re-checked run looks like. See ALREADY_MIGRATED below.
+  const allowlistRowIsOurs = Boolean(pinByEmail && pinByEmail.pinnedUserID === TO);
+
+  /* ---- 4. the census ---------------------------------------------------- */
+  const ownership = [];
+  for (const c of OWNERSHIP) {
+    ownership.push({
+      ...c,
+      from: await countKey(c.model, c.field, FROM),
+      to: await countKey(c.model, c.field, TO),
+    });
+  }
+  const history = [];
+  for (const c of HISTORY) {
+    history.push({
+      ...c,
+      from: await countKey(c.model, c.field, FROM),
+      to: await countKey(c.model, c.field, TO),
+    });
+  }
+  const unresolved = [];
+  for (const c of UNRESOLVED) {
+    unresolved.push({
+      ...c,
+      from: await countKey(c.model, c.field, FROM, c.isArray),
+      to: await countKey(c.model, c.field, TO, c.isArray),
+    });
+  }
+
+  const W = 22;
+  console.log(`\n--- [A] OWNERSHIP — these MOVE -------------------------------------`);
+  console.log(`  ${pad("collection.field", W + 14)} ${padL("under FROM", 11)} ${padL("under TO", 9)}   note`);
+  let totalMove = 0;
+  for (const c of ownership) {
+    totalMove += c.from;
+    console.log(
+      `  ${pad(`${c.model}.${c.field}`, W + 14)} ${padL(c.from, 11)} ${padL(c.to, 9)}   ` +
+        `${c.unique ? "[unique] " : ""}${c.note}`,
+    );
+  }
+  console.log(`  ${pad("User.userID (by _id)", W + 14)} ${padL(userRow?.userID === FROM ? 1 : 0, 11)} ${padL(userRow?.userID === TO ? 1 : 0, 9)}   the account row itself`);
+
+  console.log(`\n--- [B] HISTORY — these DELIBERATELY STAY -------------------------`);
+  console.log(`  RoleAuditLog is append-only by code contract and its rows state what`);
+  console.log(`  was TRUE AT THE TIME. Re-keying them would make the log assert history`);
+  console.log(`  that did not happen. The identity.rekey row written below is the JOIN`);
+  console.log(`  between the two keys — query BOTH when auditing this account.`);
+  console.log(`  ${pad("collection.field", W + 14)} ${padL("under FROM", 11)} ${padL("under TO", 9)}   note`);
+  let totalStay = 0;
+  for (const c of history) {
+    totalStay += c.from;
+    console.log(
+      `  ${pad(`${c.model}.${c.field}`, W + 14)} ${padL(c.from, 11)} ${padL(c.to, 9)}   ${c.note}`,
+    );
+  }
+
+  console.log(`\n--- [C] UNRESOLVED KEY FORMAT — non-zero STOPS the run -------------`);
+  console.log(`  ${pad("collection.field", W + 14)} ${padL("under FROM", 11)} ${padL("under TO", 9)}   note`);
+  for (const c of unresolved) {
+    console.log(
+      `  ${pad(`${c.model}.${c.field}`, W + 14)} ${padL(c.from, 11)} ${padL(c.to, 9)}   ${c.note}`,
+    );
+    if (c.from > 0) {
+      refuse(
+        "UNRESOLVED_DOMAIN_ROWS",
+        `${c.model}.${c.field} has ${c.from} row(s) under ${JSON.stringify(FROM)}. ` +
+          `userAdmin.ts records that nobody has established whether the supper ` +
+          `domain uses this key format, and SupperGroup carries denormalized ` +
+          `aggregates (numOrders, userIdList, totalPrice, currentFoodCost) that a ` +
+          `partial move would leave disagreeing with the Orders they summarise. ` +
+          `This script will not guess. Decide with the owner, then either move ` +
+          `them by hand in the same transaction or accept leaving them.`,
+      );
+    }
+  }
+
+  /* ---- 5. TARGET_KEY_OCCUPIED ------------------------------------------ */
+  // THE MOST IMPORTANT REFUSAL IN THIS FILE. Rows already under --to mean the
+  // move would MERGE TWO IDENTITIES. The unique collections would abort the
+  // transaction on their own, loudly; the non-unique ones (Bookings, Posts,
+  // UserCCA, Gym, CcaApplication) would silently interleave two people's rows
+  // under one key, with no error and no way to tell them apart afterwards.
+  // Checked across ALL THREE buckets, because a stray history row under the
+  // target key is equally a sign that this pin is not new.
+  const occupied = [...ownership, ...history, ...unresolved].filter((c) => c.to > 0);
+  const otherUserOnTo = await db.user.findMany({
+    where: { userID: TO },
+    select: { id: true, email: true },
+  });
+  const foreignUserOnTo = otherUserOnTo.filter((u) => u.id !== userRow?.id);
+  if (foreignUserOnTo.length) {
+    refuse(
+      "TARGET_KEY_OCCUPIED",
+      `${foreignUserOnTo.length} OTHER User row(s) already carry userID=${JSON.stringify(TO)}: ` +
+        foreignUserOnTo.map((u) => JSON.stringify(u.email)).join(", ") +
+        `. User.userID has no unique index, so nothing else would catch this.`,
+    );
+  }
+
+  /* ---- 6. ALREADY MIGRATED? -------------------------------------------- */
+  // A clean no-op, exit 0. Everything under --to and nothing under --from, with
+  // our allowlist row in place, IS the finished state. Reporting it as a
+  // refusal would send an operator who is merely re-checking their work off to
+  // investigate a healthy system.
+  const nothingLeftBehind = ownership.every((c) => c.from === 0);
+  const alreadyMigrated =
+    allowlistRowIsOurs && userRow?.userID === TO && nothingLeftBehind;
+  if (alreadyMigrated && !refusals.length) {
+    console.log(`\n=== ALREADY MIGRATED — nothing to do ===`);
+    console.log(`  AuthAllowlist pins ${JSON.stringify(EMAIL)} -> ${JSON.stringify(TO)}`);
+    console.log(`  User.userID is ${JSON.stringify(TO)}`);
+    console.log(`  0 rows remain under ${JSON.stringify(FROM)} in every ownership collection.`);
+    console.log(`  Exit 0. This is a no-op, not an error.\n`);
+    return;
+  }
+  if (occupied.length && !alreadyMigrated) {
+    for (const c of occupied) {
+      refuse(
+        "TARGET_KEY_OCCUPIED",
+        `${c.model}.${c.field} already has ${c.to} row(s) under ${JSON.stringify(TO)} ` +
+          `while ${c.from} remain under ${JSON.stringify(FROM)}. Moving now would MERGE ` +
+          `two identities' rows under one key. Nothing has been written; resolve by hand.`,
+      );
+    }
+  }
+
+  if (userRow && userRow.userID !== FROM && userRow.userID !== TO) {
+    refuse(
+      "USER_KEY_MISMATCH",
+      `the User row's stored userID is ${JSON.stringify(userRow.userID)}, not ` +
+        `${JSON.stringify(FROM)}. Every count above was measured against --from, so ` +
+        `they describe rows that may not belong to this account at all.`,
+    );
+  }
+
+  if (refusals.length) return report();
+
+  /* ---- 7. the plan ------------------------------------------------------ */
+  console.log(`\n--- [D] PLAN -------------------------------------------------------`);
+  console.log(`  1. AuthAllowlist  ${allowlistRowIsOurs ? "already present (kept)" : `create { email: ${JSON.stringify(EMAIL)}, pinnedUserID: ${JSON.stringify(TO)}, addedBy: ${JSON.stringify(ACTOR)} }`}`);
+  console.log(`  2. User._id=${userRow?.id}  userID: ${JSON.stringify(userRow?.userID)} -> ${JSON.stringify(TO)}`);
+  console.log(`     (email, passwordHash, displayName, bio, telegramHandle, block untouched —`);
+  console.log(`      Prisma's update emits $set on the named field only, so fields this`);
+  console.log(`      schema does not model, including whatever the User $jsonSchema`);
+  console.log(`      validator requires, survive the write.)`);
+  for (const c of ownership) {
+    if (c.from > 0) console.log(`  3. ${pad(`${c.model}.${c.field}`, 32)} updateMany ${padL(c.from, 4)} row(s)`);
+  }
+  console.log(`  4. RoleAuditLog   create 1 row  action="identity.rekey"  targetUserID=${JSON.stringify(TO)}`);
+  console.log(`                    rolesBefore=[${JSON.stringify(FROM)}]  rolesAfter=[${JSON.stringify(TO)}]`);
+  console.log(`\n  TOTAL DOCUMENTS MOVED: ${totalMove + 1} (${totalMove} owned rows + the User row)`);
+  console.log(`  TOTAL LEFT AS HISTORY: ${totalStay}  — see [B]; this is deliberate.`);
+
+  if (!COMMIT) {
+    console.log(`\n=== DRY RUN — nothing was written. Re-run with --commit to apply. ===`);
+    console.log(
+      `\n  After committing, the account signs in at its own address and its\n` +
+        `  session resolves to ${JSON.stringify(TO)}. It holds NO ROLES until an admin\n` +
+        `  grants them at /admin/users, and its bookings become visible again\n` +
+        `  immediately because facilitiesBooking joins owner on User.userID.\n`,
+    );
+    return;
+  }
+
+  /* ---- 8. the write — ONE transaction ----------------------------------- */
+  console.log(`\n--- [E] writing (one transaction) ----------------------------------`);
+  const actorRow = await db.userRole
+    .findUnique({ where: { userID: ACTOR }, select: { roles: true } })
+    .catch(() => null);
+
+  const moved = {};
+  await db.$transaction(
+    async (tx) => {
+      if (!allowlistRowIsOurs) {
+        await tx.authAllowlist.create({
+          data: {
+            email: EMAIL,
+            pinnedUserID: TO,
+            note: `re-keyed from legacy id ${FROM}`,
+            addedBy: ACTOR,
+          },
+        });
+      }
+
+      // The User row BY _id, never `where: { userID: FROM }` — that column is
+      // not unique and FROM_KEY_NOT_EXCLUSIVE above is a pre-check, not an
+      // index. The explicit `select` keeps this off passwordHash (#9, I-2).
+      await tx.user.update({
+        where: { id: userRow.id },
+        data: { userID: TO },
+        select: { id: true, userID: true },
+      });
+
+      for (const c of ownership) {
+        if (c.from === 0) {
+          moved[`${c.model}.${c.field}`] = 0;
+          continue;
+        }
+        const r = await tx[c.model].updateMany({
+          where: { [c.field]: FROM },
+          data: { [c.field]: TO },
+        });
+        moved[`${c.model}.${c.field}`] = r.count;
+      }
+
+      // INSIDE the transaction, deliberately diverging from writeAudit's
+      // "audit outside, so an audit failure cannot undo the act" posture — the
+      // same trade provision-ext-account.mjs makes and for the same reason.
+      // This run is atomic and re-runnable, so a rollback costs nothing, and it
+      // is the only way "the identity moved" and "there is a record of it"
+      // cannot come apart. That matters more here than anywhere else in this
+      // codebase: this row is the ONLY link between the two halves of a
+      // split audit trail (see [B]).
+      await tx.roleAuditLog.create({
+        data: {
+          actorUserID: ACTOR,
+          actorRoles: actorRow?.roles ?? [],
+          targetUserID: TO,
+          targetFacilityID: null,
+          targetCcaID: null,
+          targetEventID: null,
+          action: "identity.rekey",
+          rolesBefore: [FROM],
+          rolesAfter: [TO],
+          reason: EMAIL,
+          ok: true,
+          denyReason: null,
+          batchId: null,
+        },
+      });
+    },
+    // Raised from Prisma's 5s default. The operation count is small (~15
+    // commands regardless of document count — 68 bookings move in ONE
+    // updateMany), but a cold Atlas connection plus a transaction commit on a
+    // replica set is worth the headroom, and a timeout here rolls the whole
+    // thing back rather than half-applying it.
+    { timeout: 120_000, maxWait: 15_000 },
+  );
+
+  for (const [k, v] of Object.entries(moved)) {
+    if (v > 0) console.log(`  moved ${padL(v, 4)}  ${k}`);
+  }
+  console.log(`  User row re-keyed.`);
+
+  /* ---- 9. verify by RE-READ -------------------------------------------- */
+  // The transaction returning is not proof. Re-read from the cluster: zero left
+  // behind, and the counts we expected now under the new key.
+  console.log(`\n--- [F] verification (re-read) -------------------------------------`);
+  let bad = 0;
+  for (const c of ownership) {
+    const left = await countKey(c.model, c.field, FROM);
+    const now = await countKey(c.model, c.field, TO);
+    const ok = left === 0 && now === c.from + c.to;
+    if (!ok) bad++;
+    console.log(
+      `  ${ok ? "OK  " : "BAD "} ${pad(`${c.model}.${c.field}`, W + 14)} ` +
+        `left under FROM=${padL(left, 4)}  under TO=${padL(now, 4)} (expected ${c.from + c.to})`,
+    );
+  }
+  const finalUser = await db.user.findUnique({
+    where: { id: userRow.id },
+    select: { id: true, email: true, userID: true, displayName: true, block: true, telegramHandle: true },
+  });
+  const userOk = finalUser?.userID === TO;
+  if (!userOk) bad++;
+  console.log(`  ${userOk ? "OK  " : "BAD "} User._id=${userRow.id} userID=${JSON.stringify(finalUser?.userID)}`);
+  console.log(
+    `       preserved: email=${JSON.stringify(finalUser?.email)} ` +
+      `displayName=${JSON.stringify(finalUser?.displayName)} ` +
+      `block=${JSON.stringify(finalUser?.block)} ` +
+      `telegramHandle=${JSON.stringify(finalUser?.telegramHandle)}`,
+  );
+  const finalPin = await db.authAllowlist.findUnique({ where: { pinnedUserID: TO } });
+  const pinOk = finalPin && normalizeEmail(finalPin.email) === EMAIL;
+  if (!pinOk) bad++;
+  console.log(`  ${pinOk ? "OK  " : "BAD "} AuthAllowlist ${JSON.stringify(TO)} -> ${JSON.stringify(finalPin?.email)}`);
+
+  if (bad) {
+    return abort(
+      `${bad} verification failure(s). The transaction reported success, so the ` +
+        `cluster and this read disagree — do NOT re-run blindly. Inspect by hand.`,
+    );
+  }
+  console.log(`\n=== DONE. Re-running this command is now a clean no-op. ===`);
+  console.log(
+    `  NEXT: the account still holds NO ROLES. Grant them at /admin/users ->\n` +
+      `  Manage roles (the row is now keyed ${JSON.stringify(TO)} and the Manage button\n` +
+      `  is enabled). Their ${totalMove} moved row(s) are visible to them immediately.\n`,
+  );
+}
+
+function report() {
+  console.error(`\n*** ${refusals.length} REFUSAL(S) — NOTHING WAS WRITTEN ***\n`);
+  for (const r of refusals) console.error(`  [${r.code}] ${r.why}\n`);
+  process.exitCode = 1;
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    abort(
+      `unhandled failure. If it happened during [E], the transaction rolled back ` +
+        `and NOTHING was written — re-run the dry run to confirm, then re-run with ` +
+        `--commit.`,
+    );
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/set-scrc-flag.mjs
+++ b/scripts/remediation/set-scrc-flag.mjs
@@ -1,0 +1,140 @@
+/**
+ * Turns the Hall Office (SCRC) kill switch on or off (services/scrcFlag.ts).
+ *
+ *   key:  scrc.enabled   value: "on" | "off"   default (no row): OFF
+ *
+ * The whole /scrc surface is INERT until this row is "on": listJcrcRoster,
+ * resolveJcrcCandidate, setJcrcRole, cca.listAllForOversight,
+ * event.listForOversight / getForOversight, and the read-only branch of
+ * assertMayViewCcaRoster all refuse with SCRC_DISABLED. It fails CLOSED exactly
+ * like isCcaManagementEnabled and isEventsEnabled: a new surface behaves as it
+ * did yesterday (i.e. absent) unless someone deliberately enables it.
+ *
+ *   node scripts/remediation/set-scrc-flag.mjs             # show current
+ *   node scripts/remediation/set-scrc-flag.mjs on          # dry run
+ *   node scripts/remediation/set-scrc-flag.mjs on --commit # apply
+ *   node scripts/remediation/set-scrc-flag.mjs off --commit
+ *
+ * THIS SCRIPT EXISTS SO THE ROLLOUT IS NOT A HAND EDIT. There is no admin UI for
+ * arbitrary SystemFlag rows, so without it step 12 of the rollout is somebody
+ * typing into Atlas — unaudited, unverified, and easy to typo into a value that
+ * is not exactly "on" (which fails closed and looks like a code bug).
+ *
+ * WHAT IT DOES *NOT* GATE, so nobody flips it expecting more than it does:
+ *   - it does not grant anyone the role (that is /admin/users -> Manage roles),
+ *   - it does not open the SCRC Room (that is /admin/facilities on facility 17),
+ *   - it does not gate BOOKING at all. Room access is governed purely by the
+ *     FacilityAccess row, so turning this off does NOT lock the hall office out
+ *     of a room they were already allowed to book. That separation is deliberate.
+ *
+ * Run `node scripts/remediation/preflight-scrc-validators.mjs` FIRST.
+ *
+ * NO `prisma db push` IS REQUIRED for the scrc feature — it adds no model and no
+ * field, only a SystemFlag ROW, and `db push` silently drops non-schema indexes
+ * in this cluster. Do not run it "to be safe".
+ */
+import { PrismaClient } from "@prisma/client";
+import { inspectWriteReply, isCommit, abort, nowExt } from "./lib/rbac.mjs";
+
+const db = new PrismaClient();
+
+const KEY = "scrc.enabled";
+const MODES = ["on", "off"];
+
+const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const MODE = positional[0];
+const COMMIT = isCommit();
+
+async function current() {
+  const r = await db.$runCommandRaw({
+    find: "SystemFlag",
+    filter: { key: KEY },
+    limit: 1,
+  });
+  return r?.cursor?.firstBatch?.[0] ?? null;
+}
+
+async function main() {
+  console.log(`\n=== set-scrc-flag.mjs ===`);
+  const before = await current();
+  console.log(
+    `current: ${before ? JSON.stringify(before.value) : '(no row — surface is OFF)'}`,
+  );
+
+  if (!MODE) {
+    console.log(
+      `\nusage: node scripts/remediation/set-scrc-flag.mjs <${MODES.join("|")}> [--commit]`,
+    );
+    return;
+  }
+  if (!MODES.includes(MODE)) {
+    return abort(`mode must be one of ${MODES.join(" | ")} — got ${JSON.stringify(MODE)}`);
+  }
+
+  // Reported, never enforced: switching the surface on before anybody holds the
+  // role is harmless (nothing changes for anyone), but it is almost always a
+  // sign the rollout steps were done out of order, and the operator should see
+  // that before they walk away thinking the feature is live.
+  if (MODE === "on") {
+    const holders = await db.userRole.count({
+      where: { OR: [{ roles: { has: "scrc" } }, { role: "scrc" }] },
+    });
+    console.log(`accounts currently holding "scrc": ${holders}`);
+    if (holders === 0) {
+      console.log(
+        `  note: nobody holds the role yet, so turning this on changes nothing ` +
+          `visible. Grant it via /admin/users -> Manage roles (which audits).`,
+      );
+    }
+  }
+
+  console.log(
+    `\n  ${COMMIT ? "+" : "~"} ${KEY}: ${JSON.stringify(before?.value ?? null)} -> ${JSON.stringify(MODE)}`,
+  );
+  if (!COMMIT) {
+    console.log(`\nDRY RUN — nothing changed. Re-run with --commit to apply.`);
+    return;
+  }
+
+  const reply = await db.$runCommandRaw({
+    update: "SystemFlag",
+    updates: [
+      {
+        q: { key: KEY },
+        u: {
+          $set: {
+            key: KEY,
+            value: MODE,
+            updatedAt: nowExt(),
+            updatedBy: "script:set-scrc-flag",
+          },
+        },
+        upsert: true,
+      },
+    ],
+  });
+  const r = inspectWriteReply(reply, KEY);
+  if (r.writeErrors.length) {
+    console.error(`  ! WRITE FAILED: ${JSON.stringify(r.writeErrors)}`);
+    return abort(`the flag was NOT changed.`);
+  }
+
+  const after = await current();
+  console.log(`\n=== VERIFY ===`);
+  console.log(`${KEY} = ${JSON.stringify(after?.value ?? null)}`);
+  if (after?.value !== MODE) {
+    return abort(`read-back mismatch: expected ${MODE}, got ${JSON.stringify(after?.value ?? null)}`);
+  }
+  // The per-lambda cache in scrcFlag.ts is 15s, so a deploy already running will
+  // pick this up within that window without a redeploy. That is the whole point
+  // of the switch being a row rather than an env var.
+  console.log(`effective on all running instances within ~15s (scrcFlag.ts cache TTL).`);
+}
+
+main()
+  .then(() => console.log("\nDone."))
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/scripts/remediation/verify-identity-parity.mjs
+++ b/scripts/remediation/verify-identity-parity.mjs
@@ -81,6 +81,50 @@ const FIXTURES = [
   [undefined, null, false],
 ];
 
+/**
+ * THE `EXT:` NAMESPACE (08-userid-keydrift.md §3 Branch C).
+ *
+ * These fixtures turn mechanism M1 from an argument into a test. The claim is
+ * that `EXT_ID` and the value set of `canonicalUserID` are PROVABLY DISJOINT,
+ * because NUS_STUDENT_EMAIL's capture class `[A-Z0-9._%-]` does not contain
+ * ':'. The whole security case for the allowlist rests on it: an
+ * `AuthAllowlist` row can never pin an address to a key some real NUS session
+ * also resolves to.
+ *
+ * Longhand for the same reason the email fixtures are: so a regression present
+ * in BOTH implementations still fails the gate.
+ */
+const EXT_FIXTURES = [
+  ["EXT:NGOCANH_MAI", true],
+  ["EXT:VINCENT_KOH", true],
+  ["EXT:ABC", true], // exactly the 3-char floor
+  ["EXT:AB", false], // below it
+  ["EXT:" + "A".repeat(32), true], // exactly the 32-char ceiling
+  ["EXT:" + "A".repeat(33), false], // above it
+  // THE ATTACK (05-verification.md:164). A NUSNET id is NOT an EXT id, so a row
+  // {email:"attacker@gmail.com", pinnedUserID:"E1633673"} mints nothing. If this
+  // line ever goes true, an admin's authorization key is pinnable to a stranger
+  // with no grant path and therefore no escalation guard firing.
+  ["E1633673", false],
+  ["G.S_SAMUEL", false], // L-27's real account: a canonical id, not an EXT id
+  ["ext:alice", false], // lowercased namespace prefix
+  ["EXT:alice", false], // lowercased slug
+  ["EXT:A B", false], // space is not in the slug class
+  ["EXT:A-B", false], // nor is '-'
+  ["EXT:A.B", false], // nor is '.'
+  ["XEXT:ABC", false], // unanchored would accept this
+  // A trailing newline. JS `$` without /m asserts END OF INPUT and does NOT
+  // match before a trailing \n (unlike Perl/Python), so this is false — pinned
+  // here because that is a language detail an author could easily assume the
+  // other way, and the assumption would admit a smuggled trailing byte.
+  ["EXT:ABC\n", false],
+  ["EXT:", false],
+  ["EXT", false],
+  ["", false],
+  [null, false],
+  [undefined, false],
+];
+
 /** isCanonicalResidentID is a shape test on an ID, not on an email. */
 const ID_FIXTURES = [
   ["E1234567", true],
@@ -153,8 +197,47 @@ for (const [input, expectedID, expectedNus] of FIXTURES) {
     if ((mod.canonicalUserID(input) !== null) !== mod.isNusStudentEmail(input)) {
       failures.push(`GATE/KEY DISAGREE (${name}) on ${i}`);
     }
+
+    // ---- M1, AS A TEST RATHER THAN AS AN ARGUMENT ------------------------
+    // NOTHING canonicalUserID CAN PRODUCE IS AN EXT ID. Asserted over the whole
+    // email fixture list, in both implementations, rather than reasoned about
+    // in a comment: the disjointness of the two key spaces is the entire
+    // security case for AuthAllowlist. If it ever fails, one address could
+    // resolve to a key an admin-issued pin also resolves to, and
+    // {email:"attacker@…", pinnedUserID:"<an admin's id>"} stops being
+    // unrepresentable. The argument is that NUS_STUDENT_EMAIL's capture class
+    // [A-Z0-9._%-] excludes ':' while EXT_ID requires one; this is the check
+    // that the argument still describes the code.
+    if (mod.isExtUserID(mod.canonicalUserID(input))) {
+      failures.push(`NAMESPACE COLLISION (${name}): canonicalUserID(${i}) is an EXT id`);
+    }
   }
 }
+
+// ---------------------------------------------------------------------------
+// The EXT namespace itself. See EXT_FIXTURES.
+// ---------------------------------------------------------------------------
+for (const [input, expected] of EXT_FIXTURES) {
+  const i = show(input);
+  check(`isExtUserID(${i})`, ts.isExtUserID(input), mjs.isExtUserID(input), expected);
+  // asExtUserID is the MINTING function (M2). The brand it applies is erased at
+  // runtime, so the only thing left to compare is exactly the thing that
+  // matters: it passes a well-formed pin through and turns everything else into
+  // the ABSENT value. Derived from the longhand `expected` column one line up,
+  // so each fixture's truth is still stated by hand exactly once.
+  check(
+    `asExtUserID(${i})`,
+    ts.asExtUserID(input),
+    mjs.asExtUserID(input),
+    expected ? input : null,
+  );
+}
+
+// EXT_ID is a RegExp, and two RegExp objects are never `===` even when
+// identical — comparing them through check() would report DRIFT on every run.
+// Compare the source and flags instead, which is what actually has to match.
+check("EXT_ID.source", ts.EXT_ID.source, mjs.EXT_ID.source, "^EXT:[A-Z0-9_]{3,32}$");
+check("EXT_ID.flags", ts.EXT_ID.flags, mjs.EXT_ID.flags, "");
 
 for (const [input, expected] of ID_FIXTURES) {
   const i = show(input);
@@ -309,7 +392,11 @@ for (const { root, exts } of SCAN) {
 // report
 // ---------------------------------------------------------------------------
 
-const cases = FIXTURES.length * 3 + ID_FIXTURES.length * 3;
+// FIXTURES: canonicalUserID + isNusStudentEmail + normalizeEmail per row.
+// ID_FIXTURES: isCanonicalResidentID + isResidentEligible + asStoredCanonicalUserID.
+// EXT_FIXTURES: isExtUserID + asExtUserID. Plus the two EXT_ID regex compares.
+const cases =
+  FIXTURES.length * 3 + ID_FIXTURES.length * 3 + EXT_FIXTURES.length * 2 + 2;
 
 if (failures.length) {
   console.error(failures.join("\n"));

--- a/scripts/remediation/verify-legacy-drop.mjs
+++ b/scripts/remediation/verify-legacy-drop.mjs
@@ -122,13 +122,22 @@ async function main() {
 
   // --- B6: unexercised deferred privilege -------------------------------
   // PendingRoleGrant is a THIRD repository of privilege that survives the
-  // cutover. An outstanding deferred admin/jcrc grant redeemed AFTER the drop
-  // is a privilege change nobody at the go/no-go gate ever saw.
+  // cutover. An outstanding deferred admin/jcrc/scrc grant redeemed AFTER the
+  // drop is a privilege change nobody at the go/no-go gate ever saw.
+  //
+  // "scrc" (hall office) is in this list because it is a PRIVILEGED grantable
+  // role like the other two, not a baseline: it carries the power to appoint
+  // the JCRC. Leaving it out would let an outstanding hall-office grant sail
+  // through the gate unseen, which is the exact failure this check exists to
+  // prevent — and this list is the one that BLOCKS, so an omission here is
+  // silent. Any future addition to GRANTABLE_ROLES must be added here too.
+  // `cca_head` is deliberately absent: it is in no ASSIGNABLE_BY entry, so it
+  // cannot travel the deferred path at all.
   let pending = [];
   try { pending = await findAll(db, "PendingRoleGrant"); } catch { /* may not exist yet */ }
   const nowMs = Date.now();
   const livePriv = pending.filter((p) =>
-    (p.roles ?? []).some((r) => r === "admin" || r === "jcrc") &&
+    (p.roles ?? []).some((r) => r === "admin" || r === "jcrc" || r === "scrc") &&
     (!p.expiresAt || new Date(p.expiresAt?.$date ?? p.expiresAt).getTime() > nowMs));
   for (const p of livePriv) {
     blocking.push(`PendingRoleGrant ${p.userID}: outstanding ${JSON.stringify(p.roles)} created by ` +

--- a/src/app/_components/EditProfileModal.tsx
+++ b/src/app/_components/EditProfileModal.tsx
@@ -50,6 +50,24 @@ interface EditProfileModalProps {
   forced?: boolean;
   /** In forced mode, the fields that must be filled/valid before Save. */
   requiredFields?: ProfileField[];
+  /**
+   * MINIMAL-PROFILE mode: this account is exempt from the strict profile gate's
+   * block/telegram/matric requirements (see MINIMAL_PROFILE_ROLES in
+   * src/lib/profileCompleteness.ts — hall-office staff, who have no hall block).
+   *
+   * IT EXISTS BECAUSE THE BLOCK CHECK IN handleSubmit WAS UNCONDITIONAL. That
+   * check returns before any mutation fires, so without this prop an exempt
+   * account could not save the form AT ALL — not even a display-name change —
+   * and the only symptom would be an inline "Please select your block." on a
+   * field they were told was not required. A hard blocker with a soft-looking
+   * error message.
+   *
+   * Deliberately SEPARATE from `forced`: it describes WHO the account is, not
+   * whether the dialog is dismissable, and the two combine in all four ways (an
+   * exempt account still gets the non-dismissable dialog if its display name is
+   * missing).
+   */
+  minimalProfile?: boolean;
   /** Called after a successful save INSTEAD of onClose when forced — the parent
    *  refreshes the session so the gate re-evaluates and unmounts this itself. */
   onSaved?: () => void | Promise<void>;
@@ -66,6 +84,12 @@ const normalizeMatric = (v: string) => v.trim().toUpperCase();
  * impossible for a profile save to strip `resident` (lockout mode 16). Roles are
  * read-only badges on the profile page. Keep it that way; role mutation belongs
  * to the admin surface behind its escalation guards.
+ *
+ * It DOES take a `minimalProfile` flag, which is a different thing entirely: it
+ * carries no privilege and grants nothing. It only relaxes the client-side
+ * BLOCK requirement for accounts the profile gate already exempts server-side
+ * (src/lib/profileCompleteness.ts). The server re-derives that exemption from
+ * the live role set on every request; this flag is never trusted for anything.
  */
 const EditProfileModal: React.FC<EditProfileModalProps> = ({
   isOpen,
@@ -74,6 +98,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
   onSuccess,
   forced = false,
   requiredFields = [],
+  minimalProfile = false,
   onSaved,
 }) => {
   const requires = (f: ProfileField) => forced && requiredFields.includes(f);
@@ -106,10 +131,25 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
   const handleSubmit = async () => {
     setFormError(null);
 
-    if (block === "") {
+    // A RESIDENT MUST STILL PICK A BLOCK, and this returns before any mutation
+    // fires, so it is a hard stop rather than a warning. It was UNCONDITIONAL,
+    // which made the form unsaveable for a profile-gate-exempt account (hall
+    // office: no block to pick, and none required of them) — see the
+    // `minimalProfile` prop. Gating it here rather than deleting it keeps every
+    // resident's path byte-identical: their payload always carries a block, so
+    // the server's `block` becoming optional never widens what they can send.
+    if (!minimalProfile && block === "") {
       setFieldErrors({ block: "Please select your block." });
       return;
     }
+
+    // OMITTED, NOT SENT AS "" OR null. `block` is optional on the shared schema
+    // and `undefined` means "leave the stored value alone" — there is
+    // deliberately no value meaning "clear it". Computed ONCE and spread into
+    // BOTH the client-side mirror parse below and the mutation payload, so the
+    // two cannot disagree about what is being submitted. Only reachable with
+    // `block === ""` in minimal mode, because of the guard above.
+    const blockPayload = block === "" ? {} : { block };
 
     // Mirror the server's validation client-side using the SAME schema, so the
     // two can never disagree about what is accepted.
@@ -117,7 +157,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
       displayName,
       telegramHandle,
       bio,
-      block,
+      ...blockPayload,
     });
 
     const errs: Record<string, string> = {};
@@ -149,6 +189,14 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
 
     // Forced-mode presence requirements: these fields are optional on a normal
     // edit but mandatory when completing a profile.
+    //
+    // ALREADY ROLE-AWARE, with no change needed here: `requires(f)` is driven by
+    // `requiredFields`, which the page passes straight from the session's
+    // `profileMissingFields` — computed server-side by the role-aware
+    // computeProfileGaps. An exempt account is never asked for these, so these
+    // two checks simply do not fire for them. Do NOT add `minimalProfile` here;
+    // that would be a second derivation of the same exemption, and the two would
+    // drift.
     if (requires("telegramHandle") && telegramHandle.trim() === "") {
       errs.telegramHandle ??= "Enter your Telegram handle to continue.";
     }
@@ -184,7 +232,8 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
         displayName,
         telegramHandle,
         bio,
-        block,
+        // The SAME object the mirror parse above validated. See blockPayload.
+        ...blockPayload,
       });
 
       // The MERGE matters: the mutation deliberately returns neither roles nor

--- a/src/app/_components/RoleBadges.tsx
+++ b/src/app/_components/RoleBadges.tsx
@@ -22,6 +22,11 @@ const ROLE_META: Record<
     className: "bg-emerald-100 text-emerald-800 border-emerald-300",
     title: "Can manage roles and book the SCRC Room.",
   },
+  scrc: {
+    label: "Hall Office",
+    className: "bg-amber-100 text-amber-800 border-amber-300",
+    title: "Hall Office / SCRC. Can appoint JCRC and book the SCRC Room.",
+  },
   cca_head: {
     label: "CCA Head",
     className: "bg-indigo-100 text-indigo-800 border-indigo-300",
@@ -36,7 +41,7 @@ const ROLE_META: Record<
 
 /** Baseline first, then escalating. A stable order so the row does not reshuffle
  *  between renders when the underlying array order changes. */
-const ORDER = ["resident", "cca_head", "jcrc", "admin"];
+const ORDER = ["resident", "cca_head", "jcrc", "scrc", "admin"];
 
 export function RoleBadges({ roles }: { roles: string[] }) {
   // "user" was the v1 implicit default and is never stored by the new writers.

--- a/src/app/_components/RosterTable.tsx
+++ b/src/app/_components/RosterTable.tsx
@@ -201,6 +201,7 @@ function EntryRow({
   expanded,
   onToggleExpand,
   colSpan,
+  showEmail,
 }: {
   entry: RosterEntry;
   selection?: RosterSelection;
@@ -209,6 +210,8 @@ function EntryRow({
   expanded: boolean;
   onToggleExpand: () => void;
   colSpan: number;
+  /** Mirrors RosterTable's prop — see it for why this is not a guard. */
+  showEmail: boolean;
 }) {
   const duplicate = entry.userCcaRowCount > 1;
   const selected =
@@ -230,7 +233,9 @@ function EntryRow({
             </span>
           )}
         </TableCell>
-        <TableCell className="text-amber-700">—</TableCell>
+        {showEmail && (
+          <TableCell className="text-amber-700">—</TableCell>
+        )}
         <TableCell className="text-right">
           <RoleLabel isHead={entry.isHead} />
         </TableCell>
@@ -272,7 +277,9 @@ function EntryRow({
             </span>
           )}
         </TableCell>
-        <TableCell className="text-gray-600">{entry.email}</TableCell>
+        {showEmail && (
+          <TableCell className="text-gray-600">{entry.email}</TableCell>
+        )}
         <TableCell className="text-right">
           <RoleLabel isHead={entry.isHead} />
         </TableCell>
@@ -303,12 +310,27 @@ export default function RosterTable({
    * there is clickable.
    */
   details,
+  /**
+   * DEFAULT TRUE, so every existing caller is unchanged.
+   *
+   * Set false by the hall-office viewer, whose roster arrives from the server
+   * with `email` already NULLED (cca.getRoster redacts on the `readOnly` tier —
+   * see redactRosterForReadOnly). This flag does not hide anything the client
+   * holds; it stops the table drawing a column header over data the server
+   * declined to send, which reads as broken rather than as deliberate.
+   *
+   * It is presentation only and must never be mistaken for a guard: passing
+   * `showEmail` has no effect on what the server returns, and passing it TRUE
+   * on a redacted roster shows an empty column, not an address.
+   */
+  showEmail = true,
 }: {
   title: string;
   entries: RosterEntry[];
   emptyCopy: string;
   selection?: RosterSelection;
   details?: Map<string, MemberDetail>;
+  showEmail?: boolean;
 }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggleExpand = (key: string) =>
@@ -319,9 +341,10 @@ export default function RosterTable({
       return next;
     });
 
-  // Name + Email + Role, plus the select column when present. The expanded
-  // detail row spans all of them.
-  const colSpan = (selection ? 1 : 0) + 3;
+  // Name + Role, plus Email when shown and the select column when present. The
+  // expanded detail row spans all of them, so this must track both flags or the
+  // detail panel stops lining up with the table above it.
+  const colSpan = (selection ? 1 : 0) + (showEmail ? 1 : 0) + 2;
 
   return (
     <section>
@@ -352,7 +375,7 @@ export default function RosterTable({
                   </TableHead>
                 )}
                 <TableHead>Name</TableHead>
-                <TableHead>Email</TableHead>
+                {showEmail && <TableHead>Email</TableHead>}
                 <TableHead className="text-right">Role</TableHead>
               </TableRow>
             </TableHeader>
@@ -370,6 +393,7 @@ export default function RosterTable({
                     expanded={expanded.has(key)}
                     onToggleExpand={() => toggleExpand(key)}
                     colSpan={colSpan}
+                    showEmail={showEmail}
                   />
                 );
               })}

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -14,6 +14,7 @@ import {
   LogOut,
   UserCircle,
   ShieldCheck,
+  Landmark,
 } from "lucide-react";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
@@ -44,6 +45,8 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
    * every user, so it must not pull in the capability module or issue a
    * whoAmI query on every page load just to decide whether to draw one link.
    * `session.user.roles` is render-only (I-5); nothing is authorised from it.
+   *
+   * Roles tested here under the exception: admin, jcrc, cca_head, scrc.
    */
   const roles = session?.user?.roles ?? [];
   const canReachAdmin = roles.includes("admin") || roles.includes("jcrc");
@@ -63,6 +66,18 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
    */
   const isCcaHead = roles.includes("cca_head");
 
+  /**
+   * Same sanctioned exception as canReachAdmin above, for the same reason.
+   *
+   * Gated on `scrc` ALONE, not on `reachScrcDashboard` (admin || scrc): a plain
+   * hall-office holder cannot reach /admin at all, so this link is their only
+   * way in, whereas an admin who does not hold `scrc` has no business being
+   * pointed at someone else's surface and can still type the URL. The link is
+   * cosmetic either way — /scrc/layout.tsx does the real check with a LIVE role
+   * read, and every procedure behind it re-checks its own capability.
+   */
+  const isScrc = roles.includes("scrc");
+
   const navLinks = [
     { name: "Home", href: "/", icon: Home },
     // My Bookings lives in the profile dropdown (below), not the top nav, to
@@ -74,6 +89,9 @@ const Header: React.FC<HeaderProps> = ({ currentPage }) => {
     { name: "CCAs", href: "/ccas", icon: LayoutGrid },
     { name: "Events", href: "/events", icon: CalendarDays },
     ...(isCcaHead ? [{ name: "Manage CCAs", href: "/cca", icon: Users }] : []),
+    ...(isScrc
+      ? [{ name: "Hall Office", href: "/scrc", icon: Landmark }]
+      : []),
     ...(canReachAdmin
       ? [{ name: "Admin", href: "/admin", icon: ShieldCheck }]
       : []),

--- a/src/app/admin/_components/AdminShell.tsx
+++ b/src/app/admin/_components/AdminShell.tsx
@@ -11,6 +11,7 @@ import {
   ScrollText,
   Settings2,
   CalendarCheck,
+  KeyRound,
 } from "lucide-react";
 
 import Header from "~/app/_components/header";
@@ -66,6 +67,12 @@ const ADMIN_TABS = [
     label: "Facilities",
     icon: DoorOpen,
     requires: "manageFacilityAccess",
+  },
+  {
+    href: "/admin/allowlist",
+    label: "Allowlist",
+    icon: KeyRound,
+    requires: "modifyAdmins",
   },
   {
     href: "/admin/audit",

--- a/src/app/admin/_components/RoleBadge.tsx
+++ b/src/app/admin/_components/RoleBadge.tsx
@@ -24,6 +24,11 @@ const ROLE_STYLES: Record<
     label: "JCRC",
     cls: "bg-emerald-100 text-emerald-800 border-emerald-300 hover:bg-emerald-100",
   },
+  scrc: {
+    label: "Hall Office",
+    cls: "bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-100",
+    title: "Hall Office / SCRC. Can appoint JCRC and book the SCRC Room.",
+  },
   cca_head: {
     label: "CCA Head",
     cls: "bg-blue-100 text-blue-800 border-blue-300 hover:bg-blue-100",

--- a/src/app/admin/_components/allowlist/AuthAllowlistPanel.tsx
+++ b/src/app/admin/_components/allowlist/AuthAllowlistPanel.tsx
@@ -1,0 +1,641 @@
+"use client";
+
+import { useState } from "react";
+import { format, formatDistanceToNow } from "date-fns";
+import { AlertTriangle, ShieldAlert, Trash2 } from "lucide-react";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import { EXT_ID } from "~/lib/identity";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Textarea } from "~/components/ui/textarea";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+
+import EmptyState from "../EmptyState";
+import RoleBadge from "../RoleBadge";
+import { friendlyError, type ClientErrorLike } from "../../_lib/userDetail";
+
+/**
+ * THE ADMIN SIDE OF D-7 BREAK-GLASS (AuthAllowlist). Read
+ * src/server/api/routers/admin.ts's "THE D-7 BREAK-GLASS ALLOWLIST" block
+ * before changing anything here — this panel is the ONLY UI over the ONLY
+ * surface that MINTS an identity rather than moving a privilege around on top
+ * of one. Every other admin screen edits or grants against an id that already
+ * exists; a click on "Add" here is what makes one exist in the first place,
+ * for an address the app would otherwise never let sign in.
+ *
+ * `adminProcedure` on all three underlying calls, same tier as
+ * `manageFacilityAccess` / `readAuditLog` — an scrc holder (whose own
+ * identity was very possibly issued from this exact table) must not see or
+ * edit the collection that issued it. The route's own layout.tsx re-asserts
+ * this with a live role read; this component trusts nothing about "the tab
+ * was hidden" as a security boundary, only as a courtesy.
+ */
+type Row = RouterOutputs["admin"]["listAuthAllowlist"]["items"][number];
+
+/** Same "under 7 days is relative, else absolute" rule AuditLogTable uses —
+ *  consistent reading across the two accountability surfaces this role touches. */
+function when(at: Date) {
+  const d = new Date(at);
+  return Date.now() - d.getTime() < 7 * 24 * 3600 * 1000
+    ? formatDistanceToNow(d, { addSuffix: true })
+    : format(d, "d MMM yyyy, HH:mm");
+}
+
+/**
+ * The convention this UI SUGGESTS, never enforces: uppercase the email
+ * localpart, replace every character outside [A-Z0-9_] with '_'. The server's
+ * `extUserIDSchema` is the only thing that actually decides whether a typed
+ * value is admitted — this only saves the operator from typing the transform
+ * by hand for the common case.
+ */
+function suggestPin(email: string): string {
+  const local = email.trim().split("@")[0] ?? "";
+  const slug = local.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+  return slug ? `EXT:${slug}` : "EXT:";
+}
+
+/**
+ * Pulls a field-level message out of a tRPC BAD_REQUEST's attached
+ * `zodError` (see trpc.ts's `errorFormatter`), which `friendlyError` in
+ * userDetail.ts does not look at — that map is keyed on whole messages and
+ * codes shared with the user-profile surfaces, and a schema shaped like
+ * `{ email, pinnedUserID, note }` is unique to this form. Falls back to
+ * `null` so the caller always has `friendlyError`'s generic banner to show
+ * instead of nothing.
+ */
+function zodFieldError(err: unknown, field: string): string | null {
+  const data = (
+    err as {
+      data?: { zodError?: { fieldErrors?: Record<string, string[]> } | null };
+    } | null
+  )?.data;
+  return data?.zodError?.fieldErrors?.[field]?.[0] ?? null;
+}
+
+export default function AuthAllowlistPanel() {
+  const utils = api.useUtils();
+  const {
+    data,
+    isLoading,
+    isError,
+    error: loadError,
+    refetch,
+  } = api.admin.listAuthAllowlist.useQuery();
+  // Initial-load failure only (09 §2.8) — a later refetch blip must not wipe
+  // a panel that is already showing live pins.
+  const loadFailed = isError && !data;
+  const rows = data?.items ?? [];
+
+  /* ---------------------------------------------------------------------- */
+  /* ADD                                                                    */
+  /* ---------------------------------------------------------------------- */
+  const [email, setEmail] = useState("");
+  const [pinnedUserID, setPinnedUserID] = useState("");
+  const [note, setNote] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [pinFieldError, setPinFieldError] = useState<string | null>(null);
+  const [emailFieldError, setEmailFieldError] = useState<string | null>(null);
+
+  const add = api.admin.addAuthAllowlistEntry.useMutation({
+    onSuccess: async () => {
+      setEmail("");
+      setPinnedUserID("");
+      setNote("");
+      setAddError(null);
+      setPinFieldError(null);
+      setEmailFieldError(null);
+      // Without this the new pin is invisible for up to 15s — including on
+      // the very next load of this same page — and the natural response is
+      // to click Add again, which the unique index then refuses as
+      // PIN_ALREADY_USED / EMAIL_ALREADY_PINNED: a confusing error caused
+      // entirely by the client's own stale cache.
+      await utils.admin.listAuthAllowlist.invalidate();
+    },
+    onError: (e) => {
+      setAddError(friendlyError(e));
+      setPinFieldError(zodFieldError(e, "pinnedUserID"));
+      setEmailFieldError(zodFieldError(e, "email"));
+    },
+  });
+
+  // MIRROR ONLY, for immediate feedback. Deliberately NEVER used to withhold
+  // the mutation: the server's extUserIDSchema is the sole authority, and a
+  // client check that disagreed with it would either block a value the
+  // server would have accepted (with no way for the operator to override) or
+  // — worse — pass a value the server actually refuses through to nothing,
+  // since the button would then just be disabled with no explanation. Every
+  // click of Add reaches the server; this only colours the hint underneath
+  // the field before that round trip lands.
+  const pinnedTrimmed = pinnedUserID.trim();
+  const pinLooksValid = pinnedTrimmed === "" || EXT_ID.test(pinnedTrimmed);
+
+  const submitAdd = () => {
+    setAddError(null);
+    setPinFieldError(null);
+    setEmailFieldError(null);
+    add.mutate({
+      email,
+      pinnedUserID,
+      note: note.trim() || undefined,
+    });
+  };
+
+  /* ---------------------------------------------------------------------- */
+  /* REMOVE                                                                 */
+  /* ---------------------------------------------------------------------- */
+  const [removing, setRemoving] = useState<Row | null>(null);
+
+  return (
+    <div className="space-y-6">
+      {loadFailed && (
+        <Alert variant="destructive">
+          <AlertTitle>Could not load the allowlist</AlertTitle>
+          <AlertDescription>
+            The table below is empty because the entries could not be
+            fetched, not because none exist. Every warning this panel would
+            otherwise raise — an unhydrated account, a mismatched key, an
+            invalid pin — is invisible until this loads.{" "}
+            {loadError?.message ?? "Something went wrong."}
+            <div className="mt-3">
+              <Button size="sm" variant="outline" onClick={() => void refetch()}>
+                Try again
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* ---------- THE TABLE OF EXISTING PINS ------------------------------ */}
+      <div className="overflow-x-auto rounded-xl bg-white shadow-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Pinned ID</TableHead>
+              <TableHead>Roles</TableHead>
+              <TableHead>Note</TableHead>
+              <TableHead>Added</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loadFailed ? (
+              <TableRow>
+                <TableCell colSpan={7}>
+                  <EmptyState
+                    title="Could not load the allowlist"
+                    hint="This is not a list of zero entries — nothing could be read."
+                  />
+                </TableCell>
+              </TableRow>
+            ) : (
+              !isLoading &&
+              rows.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={7}>
+                    <EmptyState
+                      title="No allowlist entries"
+                      hint="Every resident signs in on their own @u.nus.edu address. Add an entry only for a principal who genuinely has none — hall office staff, typically."
+                    />
+                  </TableCell>
+                </TableRow>
+              )
+            )}
+            {isLoading && (
+              <TableRow>
+                <TableCell colSpan={7} className="text-sm text-gray-500">
+                  Loading…
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((r) => (
+              <AllowlistRow key={r.pinnedUserID} row={r} onRemove={setRemoving} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* ---------- THE ADD FORM --------------------------------------------
+          Not gated on `pinLooksValid` — see that constant's own comment. Only
+          gated on the fields being non-empty and no mutation in flight, so a
+          click ALWAYS reaches the server, which is the only real judge. */}
+      <div className="space-y-3 rounded-xl bg-white p-4 shadow-lg">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">
+            Pin a new address
+          </h2>
+          <p className="mt-0.5 text-xs text-gray-500">
+            This issues a brand-new identity. There is no undo button for a
+            role granted under it — revoke the roles first, from Manage
+            roles, before ever removing the entry (see the warning on the
+            Remove confirmation).
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="al-email">Email</Label>
+            <Input
+              id="al-email"
+              type="email"
+              autoComplete="off"
+              spellCheck={false}
+              maxLength={254}
+              placeholder="ngocanh.mai@nus.edu.sg"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            {emailFieldError && (
+              <p className="text-sm text-red-600">{emailFieldError}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="al-pin">Pinned ID</Label>
+            <Input
+              id="al-pin"
+              autoComplete="off"
+              spellCheck={false}
+              maxLength={36}
+              className="font-mono uppercase"
+              placeholder={
+                email.trim() ? suggestPin(email) : "EXT:NGOCANH_MAI"
+              }
+              value={pinnedUserID}
+              onChange={(e) => setPinnedUserID(e.target.value.toUpperCase())}
+            />
+            {/* Convenience only — fills the box with the convention computed
+                from whatever is currently in Email. The operator can still
+                type anything the server will accept; this never disables the
+                field or the Add button. */}
+            {email.trim() && (
+              <button
+                type="button"
+                className="text-xs text-emerald-700 hover:underline"
+                onClick={() => setPinnedUserID(suggestPin(email))}
+              >
+                Use {suggestPin(email)}
+              </button>
+            )}
+            {pinnedTrimmed !== "" && !pinLooksValid && (
+              <p className="text-sm text-amber-700">
+                Doesn&rsquo;t look like{" "}
+                <span className="font-mono">EXT:&lt;SLUG&gt;</span> yet —
+                uppercase letters, digits and underscore, 3–32 characters
+                after the colon. The server has the final say; this is only a
+                hint before you submit.
+              </p>
+            )}
+            {pinFieldError && (
+              <p className="text-sm text-red-600">{pinFieldError}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="al-note">
+            Note <span className="text-gray-400">(optional)</span>
+          </Label>
+          <Textarea
+            id="al-note"
+            maxLength={200}
+            rows={2}
+            placeholder="Why this address exists. Rendered to every admin who opens this panel."
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
+
+        {addError && (
+          <Alert variant="destructive">
+            <AlertDescription>{addError}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-end">
+          <Button
+            className="bg-emerald-700 text-white hover:bg-emerald-800"
+            disabled={!email.trim() || !pinnedUserID.trim() || add.isPending}
+            onClick={submitAdd}
+          >
+            {add.isPending ? "Adding…" : "Add entry"}
+          </Button>
+        </div>
+      </div>
+
+      {removing && (
+        <RemoveEntryDialog
+          row={removing}
+          onClose={() => setRemoving(null)}
+          onRemoved={async () => {
+            setRemoving(null);
+            await utils.admin.listAuthAllowlist.invalidate();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ========================================================================== */
+/* One row                                                                    */
+/* ========================================================================== */
+
+function AllowlistRow({
+  row,
+  onRemove,
+}: {
+  row: Row;
+  onRemove: (row: Row) => void;
+}) {
+  /* THE LOUD RED CASE. `namespaceViolation` means `~/lib/identity.ts`'s
+   * `isExtUserID` rejects the STORED `pinnedUserID` — read back at query time
+   * by the router, not re-derived here. That can only happen from a hand
+   * edit in Atlas or a code path that skipped `extUserIDSchema` entirely,
+   * because every write this app makes goes through that schema first (M4).
+   *
+   * WHAT BREAKS IF IGNORED: nothing, in the dangerous direction — this is the
+   * mechanism working, not failing. M2 (`pinnedUserIDFor`, re-validated at
+   * EVERY session read) drops a row shaped like this on the floor before it
+   * ever reaches `resolvePrincipalID`, so it mints no identity at all. The
+   * actual risk is the OPERATOR'S mental model: a row sitting in this table
+   * looking like every other row, quietly doing nothing, while whoever it
+   * was meant for cannot sign in and nobody knows why. That is the entire
+   * reason this gets a full red row instead of a small icon.
+   *
+   * ALSO WHY REMOVE IS DISABLED BELOW: `removeAuthAllowlistEntry`'s own input
+   * schema is `extUserIDSchema` — the SAME regex this row just failed — so
+   * the mutation would refuse its own input before the resolver ever runs.
+   * This panel cannot delete what it cannot validate; only a developer
+   * working directly against Mongo can clear this row.
+   */
+  if (row.namespaceViolation) {
+    return (
+      <TableRow className="border-l-4 border-l-red-600 bg-red-50">
+        <TableCell className="font-mono text-xs">{row.email}</TableCell>
+        <TableCell className="font-mono text-xs text-red-700">
+          {row.pinnedUserID}
+        </TableCell>
+        <TableCell colSpan={5} className="text-sm text-red-800">
+          <span className="flex items-start gap-1.5">
+            <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              <strong>Invalid — mints no identity.</strong> This value does
+              not match the <span className="font-mono">EXT:</span>{" "}
+              namespace, so it is dropped at every read and nobody can ever
+              sign in on it. It cannot have been written by this panel — only
+              a direct database edit produces this shape. It also cannot be
+              removed from here: the remove mutation validates its input
+              against the same pattern this row already fails. Ask a
+              developer to delete it directly.
+            </span>
+          </span>
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="max-w-[16rem] truncate font-mono text-xs">
+        {row.email}
+      </TableCell>
+      <TableCell className="font-mono text-xs">{row.pinnedUserID}</TableCell>
+      <TableCell>
+        {row.roles.length === 0 ? (
+          <span className="text-xs text-gray-400">No roles yet</span>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {row.roles.map((r) => (
+              <RoleBadge key={r} role={r} />
+            ))}
+          </div>
+        )}
+      </TableCell>
+      <TableCell className="max-w-[16rem] truncate text-xs text-gray-600">
+        {row.note ?? "—"}
+      </TableCell>
+      <TableCell className="whitespace-nowrap text-xs text-gray-500">
+        {when(row.addedAt)}
+        <br />
+        <span className="font-mono">{row.addedBy}</span>
+      </TableCell>
+      <TableCell>
+        <StatusCell row={row} />
+      </TableCell>
+      <TableCell className="text-right">
+        <Button
+          size="sm"
+          variant="outline"
+          className="border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800"
+          onClick={() => onRemove(row)}
+        >
+          <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+          Remove
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function StatusCell({ row }: { row: Row }) {
+  /* `hasUser: false`. WHAT BREAKS IF IGNORED: nothing crashes — the entry
+   * just does nothing. `resolvePrincipalID` would happily mint the pinned
+   * id the moment this address signs in, but there is no `User` row for the
+   * PrismaAdapter to attach it to, and no session comes out. An operator who
+   * added this row believing it "provisions" the staff member has actually
+   * done half the job; the other half — creating the User row with this
+   * exact `userID` (F7 in the plan) — has to happen separately. */
+  if (!row.hasUser) {
+    return (
+      <span
+        className="flex items-center gap-1.5 text-xs text-amber-700"
+        title="No account exists on this address yet — provision it, or the entry does nothing."
+      >
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        No account yet
+      </span>
+    );
+  }
+
+  /* `keyMismatch: true`. WHAT BREAKS IF IGNORED: the account CAN sign in and
+   * hold roles — sessions resolve on `pinnedUserID`, not on `User.userID` —
+   * but `facilitiesBooking.ts` joins a booking back to its owner on
+   * `User.userID`, so every booking this person makes renders with a blank
+   * owner name to whoever is looking at the roster or the facility
+   * dashboard. The fix is a developer correcting the stored `User.userID` to
+   * match this pin; there is no button for it here because a blanket "make
+   * these match" write on someone else's identity key does not belong on a
+   * one-click surface. */
+  if (row.keyMismatch) {
+    return (
+      <span
+        className="flex items-center gap-1.5 text-xs text-amber-700"
+        title="The provisioned account's stored ID doesn't hold this pin. Their bookings will render with a blank owner name until a developer corrects it."
+      >
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        Key mismatch
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="text-xs text-emerald-700"
+      title="The pin is well-formed, an account is provisioned under it, and the account's stored ID matches. Sessions on this address resolve normally."
+    >
+      Live{row.displayName ? ` · ${row.displayName}` : ""}
+    </span>
+  );
+}
+
+/* ========================================================================== */
+/* Remove confirmation                                                        */
+/* ========================================================================== */
+
+/**
+ * Same primitive DeleteUserDialog uses for the same reason: this needs to
+ * show WHY a removal might be refused, and a native `confirm()` can only show
+ * a sentence.
+ *
+ * No typed-confirmation text, unlike DeleteUserDialog — removing a pin does
+ * not touch a booking, a post or a matric record, so the blast radius here is
+ * "this address can no longer sign in", which the copy states plainly rather
+ * than making the operator retype the email to prove they read it.
+ */
+function RemoveEntryDialog({
+  row,
+  onClose,
+  onRemoved,
+}: {
+  row: Row;
+  onClose: () => void;
+  onRemoved: () => void;
+}) {
+  const [reason, setReason] = useState("");
+
+  const remove = api.admin.removeAuthAllowlistEntry.useMutation({
+    onSuccess: onRemoved,
+  });
+
+  const error: ClientErrorLike = remove.error ?? null;
+
+  /* PRE-EMPTIVE REFUSAL, computed from data this panel already has loaded —
+   * `listAuthAllowlist` hydrates `roles` for exactly this reason, so no
+   * second query is needed to know the server will refuse. Mirrors
+   * DeleteUserDialog's rule: A REFUSAL REMOVES THE CONFIRM CONTROL, it does
+   * not merely disable it, because a disabled destructive button reads as
+   * "try harder" and an absent one plus a sentence naming the remedy reads as
+   * "do this other thing first" — which is what PIN_STILL_HOLDS_ROLES means.
+   * Stale by up to the list's own staleness window; the server re-checks
+   * live regardless (that check is REFUSAL 2 in removeAuthAllowlistEntry),
+   * so a role granted in the seconds between this render and the click is
+   * still caught, just with a less friendly error. */
+  const blockedByRoles = row.roles.length > 0;
+
+  return (
+    <AlertDialog
+      open
+      onOpenChange={(o) => {
+        if (!o && !remove.isPending) onClose();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove this allowlist entry?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {row.email} · <span className="font-mono">{row.pinnedUserID}</span>{" "}
+            · this revokes the identity — the address can no longer sign in —
+            but does not touch anything already stored under the id.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {blockedByRoles ? (
+          <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <p className="font-medium">This entry can&rsquo;t be removed.</p>
+            {/* A <div>, not a <p>: RoleBadge renders a <div> (shadcn's Badge),
+                and a block element inside a <p> is invalid HTML that the
+                browser silently re-parses, splitting this paragraph in two
+                and producing a hydration mismatch. */}
+            <div>
+              Its ID still holds{" "}
+              <span className="inline-flex flex-wrap items-center gap-1 align-middle">
+                {row.roles.map((r) => (
+                  <RoleBadge key={r} role={r} />
+                ))}
+              </span>
+              . Revoke {row.roles.length === 1 ? "it" : "them"} from Manage
+              roles first — otherwise removing the pin leaves the roles
+              standing under an identity nothing can reach any more, and a
+              future entry re-issued on this or any other address would
+              inherit them silently the moment it was granted.
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            <Label htmlFor="al-remove-reason">
+              Reason <span className="text-gray-400">(optional)</span>
+            </Label>
+            <Textarea
+              id="al-remove-reason"
+              value={reason}
+              maxLength={500}
+              rows={2}
+              placeholder="Recorded on the audit entry."
+              onChange={(e) => setReason(e.target.value)}
+            />
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{friendlyError(error)}</AlertDescription>
+          </Alert>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            Cancel
+          </AlertDialogCancel>
+          {/* A plain Button, not AlertDialogAction — Radix would dismiss the
+              dialog on click before the mutation's error (or the pending
+              state) could be shown, same reasoning as DeleteUserDialog. */}
+          {!blockedByRoles && (
+            <Button
+              className="bg-red-700 text-white hover:bg-red-800"
+              disabled={remove.isPending}
+              onClick={() =>
+                remove.mutate({
+                  pinnedUserID: row.pinnedUserID,
+                  reason: reason.trim() || undefined,
+                })
+              }
+            >
+              {remove.isPending ? "Removing…" : "Remove"}
+            </Button>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/admin/_components/audit/AuditLogTable.tsx
+++ b/src/app/admin/_components/audit/AuditLogTable.tsx
@@ -4,7 +4,13 @@ import { useMemo, useState } from "react";
 import { format, formatDistanceToNow } from "date-fns";
 
 import { api, type RouterOutputs } from "~/trpc/react";
-import { userIDSchema } from "~/server/api/services/roles";
+// From services/roles.ts, NOT routers/admin.ts. This file is `"use client"`,
+// and routers/admin.ts imports `node:crypto` and `~/env` at module scope —
+// value-importing a schema from it would drag both into the browser bundle.
+// services/roles.ts is runtime-pure precisely so client components can share
+// the server's vocabulary (see its header), which is what makes I-12's "one
+// predicate, not two" affordable here.
+import { roleTargetUserIDSchema } from "~/server/api/services/roles";
 import {
   Accordion,
   AccordionContent,
@@ -102,12 +108,25 @@ export default function AuditLogTable({
    * the server's own schema means the trailing space is normalised away and the
    * filter applies, which is what the operator meant.
    *
-   * And when a filter is present but genuinely unparseable we FAIL CLOSED: the
-   * query does not run at all. Showing everything is the one outcome an audit
-   * surface must never produce silently.
+   * `roleTargetUserIDSchema`, NOT the bare `userIDSchema`, and this is the
+   * SAME upgrade `listAuditLog`'s own input made server-side (admin.ts): an
+   * `EXT:`-namespaced allowlist pin is now a legal audit target AND actor — it
+   * is the one principal whose whole identity was issued by hand, so its
+   * history is exactly what an operator most needs to filter to. The strict
+   * `/^E\d{7}$/`-only parse `userIDSchema` applies would FAIL CLOSED on a pin
+   * exactly as it does on a typo: unparseable, filter dropped, query disabled
+   * below. That is silent under-filtering, not a refusal — the box would look
+   * accepted while quietly excluding the one identity it was asked to isolate.
+   * `roleTargetUserIDSchema` is `userIDSchema.or(extUserIDSchema)`, so an
+   * E-format id behaves byte-identically to before and only the EXT branch is
+   * new.
+   *
+   * And when a filter is present but genuinely unparseable we still FAIL
+   * CLOSED: the query does not run at all. Showing everything is the one
+   * outcome an audit surface must never produce silently.
    */
-  const actorParsed = userIDSchema.safeParse(actorUserID);
-  const targetParsed = userIDSchema.safeParse(targetUserID);
+  const actorParsed = roleTargetUserIDSchema.safeParse(actorUserID);
+  const targetParsed = roleTargetUserIDSchema.safeParse(targetUserID);
   const actorInvalid = actorUserID.trim() !== "" && !actorParsed.success;
   const targetInvalid = targetUserID.trim() !== "" && !targetParsed.success;
   const filterInvalid = actorInvalid || targetInvalid;

--- a/src/app/admin/_components/bulk/BulkImportWizard.tsx
+++ b/src/app/admin/_components/bulk/BulkImportWizard.tsx
@@ -102,11 +102,13 @@ export default function BulkImportWizard({
               | "admin"
               | "jcrc"
               | "cca_head"
+              | "scrc"
             )[],
             expectedBefore: r.expectedBefore as (
               | "admin"
               | "jcrc"
               | "cca_head"
+              | "scrc"
             )[],
             via: r.via,
             confidence: r.confidence,
@@ -171,7 +173,7 @@ export default function BulkImportWizard({
               rows: rows.map((r) => ({
                 lineNo: r.lineNo,
                 identifier: r.identifier,
-                roles: r.roles as ("admin" | "jcrc" | "cca_head")[],
+                roles: r.roles as ("admin" | "jcrc" | "cca_head" | "scrc")[],
               })),
             });
           }}

--- a/src/app/admin/_components/bulk/CcaHeadBulkWizard.tsx
+++ b/src/app/admin/_components/bulk/CcaHeadBulkWizard.tsx
@@ -92,6 +92,7 @@ export default function CcaHeadBulkWizard() {
               | "admin"
               | "jcrc"
               | "cca_head"
+              | "scrc"
             )[],
             via: r.via,
             confidence: r.confidence,

--- a/src/app/admin/_components/bulk/PendingGrantsPanel.tsx
+++ b/src/app/admin/_components/bulk/PendingGrantsPanel.tsx
@@ -199,7 +199,12 @@ export default function PendingGrantsPanel() {
               create.mutate({
                 rows: splitPasted(identifiers).map((identifier) => ({
                   identifier,
-                  roles: selectedRoles as ("admin" | "jcrc" | "cca_head")[],
+                  roles: selectedRoles as (
+                    | "admin"
+                    | "jcrc"
+                    | "cca_head"
+                    | "scrc"
+                  )[],
                 })),
                 expiresInDays: days,
                 reason: reason.trim() || undefined,

--- a/src/app/admin/_components/facilities/FacilityAccessTable.tsx
+++ b/src/app/admin/_components/facilities/FacilityAccessTable.tsx
@@ -37,6 +37,7 @@ const ROLE_LABEL: Record<string, string> = {
   resident: "Residents only",
   jcrc: "JCRC only",
   cca_head: "CCA heads only",
+  scrc: "Hall Office",
 };
 
 /**
@@ -276,6 +277,7 @@ export default function FacilityAccessTable() {
                       | "resident"
                       | "jcrc"
                       | "cca_head"
+                      | "scrc"
                     )[],
                   })
                 }

--- a/src/app/admin/_components/users/ManageRolesDialog.tsx
+++ b/src/app/admin/_components/users/ManageRolesDialog.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { useSession } from "next-auth/react";
 
 import { api } from "~/trpc/react";
+// Runtime-pure by design (roles.ts header) — safe to value-import in a client
+// component, which is the whole reason the vocabulary lives there.
+import { forbiddenRoleCombination } from "~/server/api/services/roles";
 import {
   BASELINE_ROLE,
   GRANTABLE_ROLES,
@@ -41,6 +44,7 @@ const ROLE_LABEL: Record<string, string> = {
   admin: "Admin",
   jcrc: "JCRC",
   cca_head: "CCA Head",
+  scrc: "Hall Office",
 };
 
 /**
@@ -58,6 +62,7 @@ const LOCKED_REASON: Record<string, string> = {
   // everyone including admins. The server answers USE_CCA_HEAD_ENDPOINT.
   cca_head:
     "CCA headship is managed from the CCAs surface, so the scoped record stays in sync.",
+  scrc: "Only an admin can grant or remove the Hall Office role.",
 };
 
 export default function ManageRolesDialog({
@@ -123,12 +128,26 @@ export default function ManageRolesDialog({
       );
       return;
     }
+    // G8, mirrored client-side for the MESSAGE only. The server refuses this
+    // combination at assertCanMutateRoles and audits the denial; without this
+    // the operator would get the bare code `CANNOT_HOLD_JCRC_AND_SCRC` in the
+    // error strip, which is what every other denial here renders but is
+    // unusually opaque for a rule that is about policy rather than permission.
+    // Imported from services/roles rather than re-listed, so the UI cannot
+    // drift from the invariant it is describing — and it is NOT a guard: it
+    // saves a round trip, and removing it changes nothing but the wording.
+    if (forbiddenRoleCombination(selected)) {
+      setFormError(
+        "Nobody can hold both JCRC and Hall Office. The Hall Office appoints the JCRC, so one account holding both could grant JCRC in bulk and bypass the Hall Office kill switch. Remove one before saving.",
+      );
+      return;
+    }
     setRoles.mutate({
       // canonicalUserID, NEVER legacyUserID — the latter holds an A-format
       // matric for ~515 rows and a grant keyed on it creates a row no session
       // will ever match (I-1).
       userID: targetUserID,
-      roles: selected as ("admin" | "jcrc" | "cca_head")[],
+      roles: selected as ("admin" | "jcrc" | "cca_head" | "scrc")[],
       reason: reason.trim() || undefined,
     });
   };

--- a/src/app/admin/_components/users/UserDetailDialog.tsx
+++ b/src/app/admin/_components/users/UserDetailDialog.tsx
@@ -518,7 +518,7 @@ function DetailBody({
    */
   const confirmable = needsFields.filter(
     (f): f is ProfileField =>
-      (REQUIRED_PROFILE_FIELDS as string[]).includes(f) &&
+      (REQUIRED_PROFILE_FIELDS as readonly string[]).includes(f) &&
       !(gaps as string[]).includes(f),
   );
   const deleteEnabled = impact.data?.enabled ?? false;

--- a/src/app/admin/_components/users/UserRoleTable.tsx
+++ b/src/app/admin/_components/users/UserRoleTable.tsx
@@ -64,7 +64,7 @@ export default function UserRoleTable() {
       role:
         roleFilter === "all"
           ? undefined
-          : (roleFilter as "admin" | "jcrc" | "cca_head"),
+          : (roleFilter as "admin" | "jcrc" | "cca_head" | "scrc"),
       limit: 25,
     },
     {
@@ -211,6 +211,23 @@ export default function UserRoleTable() {
                           <span className="text-gray-400">—</span>
                         )}
                       </span>
+                      {/* An `EXT:` id is NOT derived from the email — it was
+                          ISSUED, by an admin, as a row on the authentication
+                          allowlist. Labelled because an operator who sees
+                          `EXT:NGOCANH_MAI` with no explanation next to an
+                          @nus.edu.sg address has every reason to file it as a
+                          bug, and the remedy they would reach for (deleting the
+                          account) is the one thing the delete refusal exists to
+                          stop. The server already computes this — same
+                          namespace test the session path authorizes on. */}
+                      {u.pinned && (
+                        <span
+                          className="rounded border border-amber-300 bg-amber-50 px-1 py-px text-[10px] font-medium text-amber-800"
+                          title="This account's sign-in and identity were granted by an entry on the authentication allowlist (/admin/allowlist), not derived from an @u.nus.edu address."
+                        >
+                          Pinned
+                        </span>
+                      )}
                       {u.keyMismatch && <KeyMismatchIcon />}
                     </div>
                   </TableCell>

--- a/src/app/admin/_lib/types.ts
+++ b/src/app/admin/_lib/types.ts
@@ -32,6 +32,16 @@ export type AdminUserRow = {
   hasAccount: boolean;
   /** Server-computed: canonicalUserID(email) !== null. Never guessed here. */
   eligible: boolean;
+  /**
+   * The identity was ISSUED by an `AuthAllowlist` row rather than derived from
+   * an @u.nus.edu address — i.e. `canonicalUserID` sits in the `EXT:` namespace.
+   *
+   * Server-computed on BOTH arms of listUsers, deliberately: a field present on
+   * one arm only would make this union un-flatMappable, which is the exact
+   * problem this type exists to solve. Never derived in the browser — the shape
+   * test that decides it is the same one the session path authorizes on.
+   */
+  pinned: boolean;
   keyMismatch: boolean;
   /** Stored roles, with `admin` redacted for viewers without seeAdminIdentities. */
   roles: string[];

--- a/src/app/admin/_lib/userDetail.ts
+++ b/src/app/admin/_lib/userDetail.ts
@@ -188,6 +188,30 @@ const MESSAGE_COPY: Record<string, string> = {
   // mounted; this covers the paths that skip the preview.
   ABSENT_CANONICAL_ID:
     "This account has no NUSNET id, so its records can't be located and it can't be deleted safely. Ask a developer to clear it out first.",
+  // Same reason as the two above: it arrives as a PRECONDITION_FAILED on the
+  // paths that skip the preview, and the generic "something changed" line would
+  // be wrong — this is a standing property of the account.
+  PINNED_ALLOWLIST_ACCOUNT:
+    "This account's sign-in was granted by an authentication allowlist entry. Remove its roles, then its allowlist entry, then delete it — otherwise the entry survives and anyone re-created on that address inherits this identity.",
+  // admin.addAuthAllowlistEntry / removeAuthAllowlistEntry refusals. Mapped so
+  // the allowlist panel shows the REASON and the REMEDY rather than a raw
+  // FORBIDDEN string, on the surface where a wrong click issues an identity.
+  EMAIL_IS_CANONICAL:
+    "That's an @u.nus.edu address, so it already has a NUSNET identity of its own. Pinning it here would give one person two accounts. It doesn't need an allowlist entry — it can already sign in.",
+  PIN_ALREADY_HAS_ROLES:
+    "Something already holds roles under that ID. Revoke them from Manage roles first — otherwise whoever you pin to it would inherit them silently.",
+  EMAIL_ALREADY_PINNED:
+    "That email address already has an allowlist entry. Remove the existing one first; an address may be pinned to exactly one ID.",
+  PIN_ALREADY_USED:
+    "That ID is already pinned to another address. IDs are not reusable — pick a different one, or remove the existing entry first.",
+  PIN_STILL_HOLDS_ROLES:
+    "That entry's ID still holds roles. Revoke them from Manage roles first, so the removal leaves nothing behind that a future entry could inherit.",
+  NO_SUCH_PIN: "That allowlist entry no longer exists. Reload the page.",
+  // The unique index rejected the insert but neither probe found the offending
+  // row — i.e. it was removed between the two. Nothing was written; a retry is
+  // genuinely the right instruction here, unlike every other refusal above.
+  ALLOWLIST_CONFLICT:
+    "That entry collided with an existing one, which has since been removed. Nothing was saved — try again.",
   // Passed through verbatim: the server, EditProfileModal and the mirror schema
   // above all use this exact string, and it is already operator-readable.
   "Enter your real name — not your NUSNET ID.":
@@ -372,6 +396,14 @@ export function refusalCopy(
       return "This account's stored ID doesn't match its email, so its records can't be attributed safely. This is the split-account case — ask a developer to run a merge script instead.";
     case "SHARED_CANONICAL_ID":
       return "Another account resolves to the same NUSNET id as this one (usually a stray space or a different capitalisation in the email). Deleting either one would take the other's roles, bookings and matric with it, because those records are filed under the shared id. Ask a developer to run the account merge (scripts/remediation/merge-by-canonical.mjs) first.";
+    // The account's identity was ISSUED by an allowlist pin rather than derived
+    // from an @u.nus.edu address, and the delete cascade does not know about
+    // that collection — it would leave the pin behind, so re-creating a User row
+    // on the same address would re-attach the identity. Worded as an ORDER OF
+    // OPERATIONS, because that is exactly what the two paired refusals enforce
+    // (this one, and PIN_STILL_HOLDS_ROLES on the allowlist surface).
+    case "PINNED_ALLOWLIST_ACCOUNT":
+      return "This account's sign-in was granted by an entry on the authentication allowlist, and deleting it here would leave that entry behind — anyone re-created on the same address would inherit this identity. Remove its roles from Manage roles, then remove its allowlist entry, then delete the account.";
     default:
       // Same call as the unknown-collection fallback above: an unmapped refusal
       // must still BLOCK and still be visible, never silently disappear and let

--- a/src/app/admin/allowlist/layout.tsx
+++ b/src/app/admin/allowlist/layout.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Per-segment guard (03 §3, §13), the same shape as ../facilities/layout.tsx
+ * and ../audit/layout.tsx. `modifyAdmins` is ADMIN-ONLY (roles.ts) — strictly
+ * narrower than `reachDashboard` (admin || jcrc) — so AdminShell hiding the
+ * tab from a jcrc is not a guard: without this file a jcrc typing
+ * /admin/allowlist would render the one surface that ISSUES IDENTITIES. A
+ * jcrc who could read or write here could pin their own non-NUS address to a
+ * fresh EXT: key and hand it any role — the exact attack
+ * services/authAllowlist.ts (M1-M4) and admin.ts's AuthAllowlist block exist
+ * to make structurally impossible from the write side (M4). This file is what
+ * stops the markup streaming at all.
+ *
+ * Recomputed from a LIVE getUserRoles read, not inherited as a prop from the
+ * parent layout — see ../audit/layout.tsx's note for why a prop is not a
+ * guard: the parent's `capabilities` was computed once, at that layout's own
+ * render, and a demotion between the two renders must still be caught here.
+ */
+export default async function AllowlistLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    roles = await getUserRoles(db, session.user.userID);
+  } catch {
+    redirect("/admin"); // fail closed
+  }
+
+  if (!computeCapabilities(roles).modifyAdmins) redirect("/admin");
+  return <>{children}</>;
+}

--- a/src/app/admin/allowlist/page.tsx
+++ b/src/app/admin/allowlist/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import AuthAllowlistPanel from "../_components/allowlist/AuthAllowlistPanel";
+
+export default function AdminAllowlistPage() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-semibold text-gray-900">
+          Authentication allowlist
+        </h1>
+        <p className="text-sm text-gray-500">
+          Every resident&rsquo;s identity is derived from their
+          @u.nus.edu address. This is the ONE exception: a row here pins a
+          non-NUS address — hall office staff on @nus.edu.sg — to an
+          admin-issued key in the <code className="font-mono">EXT:</code>{" "}
+          namespace, so that address can sign in and hold roles at all. There
+          is no other way onto this list; it cannot be self-served, and it is
+          not a role grant by itself, only the identity a role can later be
+          granted to.
+        </p>
+      </div>
+      <AuthAllowlistPanel />
+    </div>
+  );
+}

--- a/src/app/admin/ccas/_components/CcaHeadsManager.tsx
+++ b/src/app/admin/ccas/_components/CcaHeadsManager.tsx
@@ -28,7 +28,16 @@ export default function CcaHeadsManager({ ccaID }: { ccaID: number }) {
   const grant = api.admin.grantCcaHead.useMutation({ onSuccess: refresh });
   const revoke = api.admin.revokeCcaHead.useMutation({ onSuccess: refresh });
 
-  const rows = heads.data?.heads ?? [];
+  // `userID` is typed `string | null` because cca.listHeads NULLS it for the
+  // read-only (hall office) tier — a canonical E-id is an email one derivation
+  // later, so that tier must not receive one. THIS page is manager-gated, so it
+  // always takes the untouched branch and never actually sees a null; the
+  // narrowing below is how that fact is stated to the compiler rather than
+  // asserted away with a `!`. A row without an id could not be Removed anyway,
+  // since `userID` is exactly what revokeCcaHead writes.
+  const rows = (heads.data?.heads ?? []).filter(
+    (h): h is typeof h & { userID: string } => h.userID !== null,
+  );
   const error = grant.error?.message ?? revoke.error?.message ?? null;
 
   return (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Users, ShieldCheck, Landmark, UserCog } from "lucide-react";
+import { Users, ShieldCheck, Landmark, UserCog, Building2 } from "lucide-react";
 
 import { api } from "~/trpc/react";
 import AdminStatCard from "./_components/AdminStatCard";
@@ -24,6 +24,17 @@ export default function AdminOverviewPage() {
           label="CCA heads"
           value={data?.ccaHead ?? "—"}
           icon={UserCog}
+        />
+        {/* Hall Office. Shown to every manager as a plain count, unlike the
+            Admins card below: how many accounts can appoint the JCRC is
+            ordinary operational information, and a jcrc who cannot see that
+            number cannot notice it going from 2 to 5. It is a COUNT only —
+            WHO holds it is /admin/users' role filter, which is a different
+            question with its own guard. */}
+        <AdminStatCard
+          label="Hall Office"
+          value={data?.scrc ?? "—"}
+          icon={Building2}
         />
         {/* getStats returns `admins: null` for a caller without
             seeAdminIdentities, so the card is omitted because the DATA is

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -84,6 +84,18 @@ export async function POST(req: Request) {
     // resident baseline, so this rejection was a lockout, not just an
     // inconvenience. The @nus.edu.sg clause is now subsumed: the anchored
     // regex admits u.nus.edu and nothing else.
+    //
+    // DELIBERATELY NOT WIDENED TO THE AuthAllowlist COLLECTION, unlike
+    // src/app/api/reset-password/request-verification-code/route.ts, which is.
+    // SELF-REGISTRATION STAYS @u.nus.edu-ONLY, FOREVER. This is the boundary
+    // that keeps the allowlist from becoming a signup path: a pin lets an
+    // ADMIN-CREATED account set its first password, it must never let a
+    // stranger create an account. A staff address is provisioned by an admin
+    // (scripts/remediation/provision-ext-account.mjs, or
+    // admin.addAuthAllowlistEntry) and never self-served. Widening this line
+    // would mean anyone holding a pinned address could mint their own `User`
+    // row with their own password and their own displayName, outside the
+    // audited provisioning path.
     if (!isNusStudentEmail(email)) {
       return NextResponse.json({ error: "Invalid Email" }, { status: 400 });
     }

--- a/src/app/api/reset-password/request-verification-code/route.ts
+++ b/src/app/api/reset-password/request-verification-code/route.ts
@@ -5,6 +5,8 @@ import { db } from "~/server/db";
 import { env } from "~/env";
 import { sendPasswordResetEmail } from "~/lib/email";
 import { rateLimit, clientIp } from "~/lib/rateLimit";
+import { isNusStudentEmail, normalizeEmail } from "~/lib/identity";
+import { pinnedUserIDFor } from "~/server/api/services/authAllowlist";
 
 interface RequestResetPayload {
   email: string;
@@ -12,10 +14,85 @@ interface RequestResetPayload {
 
 const TOKEN_TTL_MS = 15 * 60 * 1000;
 
+/**
+ * THE CONSTANT RESPONSE — the one and only success-shaped reply this route
+ * emits, constructed HERE and nowhere else.
+ *
+ * A function rather than a shared object because NextResponse bodies are
+ * single-use streams; a module-level constant would be consumed by the first
+ * request and empty for the second. The point of centralising it is that
+ * "every non-error path returns a byte-identical reply" stops being a claim
+ * two call sites have to keep agreeing on and becomes a property of there
+ * being ONE construction site. Adding a field, a header or a status here
+ * changes every path at once, which is the only safe way to change it.
+ *
+ * WHAT IT MUST BE INDISTINGUISHABLE ACROSS (see the ORDER note in POST):
+ *   - the address is not eligible at all (neither @u.nus.edu nor allowlisted)
+ *   - the address is eligible but no User row exists
+ *   - the address is eligible, the User row exists, and a link was sent
+ * Those three are the whole answer set an attacker wants.
+ */
+function sameResponse() {
+  return NextResponse.json(
+    {
+      message: "If an account exists for that email, a reset link has been sent.",
+    },
+    { status: 200 },
+  );
+}
+
+/**
+ * ORDER OF OPERATIONS IS THE SECURITY PROPERTY OF THIS ROUTE. Read this before
+ * moving any block.
+ *
+ * THIS ENDPOINT IS UNAUTHENTICATED. Every observable it produces — status,
+ * body, headers — is a free read of server state for anybody on the internet.
+ * The rule it now follows:
+ *
+ *   REFUSE ONLY ON FACTS THE CLIENT COULD HAVE COMPUTED ITSELF.
+ *
+ * "The body has no email field" is such a fact. "This address is on the
+ * AuthAllowlist" is emphatically not: it is server state, and it is the single
+ * highest-value bit in the system.
+ *
+ * THE ORACLE THIS REPLACED, STATED PLAINLY SO IT IS NOT RE-INTRODUCED. The
+ * eligibility check used to sit ABOVE the rate limiter and return
+ * `400 {"error":"Invalid Email"}`. Once the first AuthAllowlist row exists:
+ *
+ *     POST {email:"ngocanh.mai@nus.edu.sg"}  -> 200 + generic message
+ *     POST {email:"someone.else@nus.edu.sg"} -> 400 + "Invalid Email"
+ *
+ * Status AND body differed, no throttle budget was consumed (the 400 returned
+ * before any rate-limit key was even computed), and the address space is
+ * guessable — `firstname.lastname@nus.edu.sg`. Sweeping it enumerates exactly
+ * which staff addresses carry an `EXT:` authorization key, which is the target
+ * list for every other attack on this feature. The pre-allowlist code did not
+ * have this hole: `endsWith("@u.nus.edu")` gave EVERY @nus.edu.sg address the
+ * same 400, so the bit did not exist to be read.
+ *
+ * TWO CHANGES CLOSE IT, and both are needed:
+ *   1. The rate limiter moved ABOVE the eligibility decision, so a rejected
+ *      probe costs the same budget as an accepted one. A sweep is now bounded
+ *      at 20 addresses per IP per 15 minutes rather than unlimited.
+ *   2. The rejection returns `sameResponse()` — the SAME object the success
+ *      path returns — instead of a distinguishable 400.
+ *
+ * WHAT REMAINS, HONESTLY. A sent email is a network round-trip to Resend, so
+ * the eligible-and-registered path is measurably slower than the ineligible
+ * one. That timing channel is PRE-EXISTING IN KIND — the route has always been
+ * slower for a registered @u.nus.edu address than an unregistered one, and its
+ * own constant-response comment already accepted that — and it is now metered
+ * by (1), which is the mitigation that actually bounds it. Do not "fix" it by
+ * making the send fire-and-forget: a Resend failure currently propagates to a
+ * 500, and that is the only way an operator learns delivery is broken.
+ */
 export async function POST(req: Request) {
   try {
     const { email }: RequestResetPayload = await req.json();
 
+    // ADDRESS-INDEPENDENT, so it is not an oracle: it says something about the
+    // REQUEST, not about any account. The client already checks this itself
+    // before submitting, so it reveals nothing it did not already know.
     if (!email) {
       return NextResponse.json(
         { error: "Please enter your email." },
@@ -23,13 +100,27 @@ export async function POST(req: Request) {
       );
     }
 
-    const normalizedEmail = email.toLowerCase();
+    // I-12: THE shared normalizer. What was here was `email.toLowerCase()`
+    // with NO `.trim()`, so a pasted "  e1234567@u.nus.edu " was rejected.
+    const normalizedEmail = normalizeEmail(email);
 
-    if (!normalizedEmail.endsWith("@u.nus.edu")) {
-      return NextResponse.json({ error: "Invalid Email" }, { status: 400 });
-    }
-
-    // Throttle by email and by IP (#5).
+    /* ---- THROTTLE FIRST (#5) --------------------------------------------
+     * MOVED ABOVE THE ELIGIBILITY DECISION, and that position is the fix, not
+     * a tidy-up. Below it, a rejected probe returned before any rate-limit key
+     * was computed, so probing was free AND unlimited — the two properties that
+     * turn a one-bit difference into a full enumeration of the staff address
+     * space. Metering the refusal is what bounds a sweep to 20 addresses per IP
+     * per 15 minutes, and it is also the only thing that bounds the timing
+     * channel noted in the header.
+     *
+     * A CONSEQUENCE, ACCEPTED DELIBERATELY: the per-email bucket is now keyed
+     * on addresses that may not exist, so junk keys can land in `RateLimit`.
+     * The per-IP bucket caps that at 20 per IP per window, and these rows carry
+     * an `expiresAt`. That is a strictly better trade than free probing.
+     *
+     * The 429 is NOT an oracle: it depends on request volume, never on any
+     * property of the address, and it is reachable by every address equally.
+     */
     const [byEmail, byIp] = await Promise.all([
       rateLimit(`reset:${normalizedEmail}`, 5, 15 * 60 * 1000),
       rateLimit(`reset-ip:${clientIp(req)}`, 20, 15 * 60 * 1000),
@@ -42,42 +133,77 @@ export async function POST(req: Request) {
       );
     }
 
-    const existingUser = await db.user.findFirst({
-      where: { email: { equals: normalizedEmail, mode: "insensitive" } },
-    });
+    /* ---- D-7 eligibility, through the ONE shared predicate ---------------
+     * THIS SITE HELD A PRIVATE COPY OF THE DOMAIN RULE, AND A BUGGY ONE:
+     * `normalizedEmail.endsWith("@u.nus.edu")`. A SUFFIX TEST IS NOT AN
+     * ANCHORED MATCH, so `bob@evil.com@u.nus.edu` passed it — harmless only by
+     * accident, because the `db.user.findFirst` below then missed.
+     * 00-overview.md §374 claims the credentials `authorize` check and the
+     * register and reset-password routes were all centralised on the domain
+     * rule. That claim was false for exactly this one. `isNusStudentEmail` is
+     * anchored, rejects the double-@ form by its character class, and is the
+     * same function the sign-in gate uses.
+     *
+     * THE ALLOWLIST CONSULT IS WHAT MAKES ADMIN-PROVISIONED STAFF ACCOUNTS
+     * USABLE AT ALL. Such a row is created with NO passwordHash — auth.ts's
+     * credentials `authorize` returns null on `!user?.passwordHash`, so the
+     * account cannot be logged into until one exists — which makes THIS ROUTE
+     * THE ONLY WAY IN. Without this branch the provisioned account is a
+     * permanent dead end and the failure looks like a mail-delivery problem.
+     *
+     * NOTE WHAT IS NOT WIDENED: src/app/api/register/route.ts. Self-registration
+     * stays @u.nus.edu-only, forever. That is the boundary that keeps
+     * AuthAllowlist from becoming a signup path — an allowlist row lets an
+     * admin-created account SET A PASSWORD, never lets a stranger CREATE one.
+     *
+     * IT IS A `let eligible`, NOT AN EARLY RETURN. The ineligible path must
+     * fall through to the SAME `sameResponse()` every other path reaches; an
+     * early return here is precisely what re-creates the oracle, whatever
+     * status it carries. `isNusStudentEmail` is short-circuited first so a
+     * student address never issues the allowlist query.
+     *
+     * Fails closed: pinnedUserIDFor returns null on any fault and never throws,
+     * so a database problem degrades this to the pre-allowlist behaviour.
+     */
+    const eligible =
+      isNusStudentEmail(normalizedEmail) ||
+      (await pinnedUserIDFor(db, normalizedEmail)) !== null;
 
-    // Only send when the account actually exists, but always return the same
-    // response so this endpoint doesn't reveal which emails are registered.
-    if (existingUser) {
-      const token = randomBytes(32).toString("hex");
-
-      // Invalidate any earlier outstanding tokens for this account.
-      await db.passwordResetSession.deleteMany({
-        where: { email: normalizedEmail },
+    if (eligible) {
+      const existingUser = await db.user.findFirst({
+        where: { email: { equals: normalizedEmail, mode: "insensitive" } },
       });
 
-      await db.passwordResetSession.create({
-        data: {
-          email: normalizedEmail,
-          token,
-          expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
-        },
-      });
+      // Only send when the account actually exists, but always return the same
+      // response so this endpoint doesn't reveal which emails are registered.
+      if (existingUser) {
+        const token = randomBytes(32).toString("hex");
 
-      const base = env.APP_URL ?? env.NEXTAUTH_URL;
-      const resetUrl = `${base}/reset-password?token=${token}`;
+        // Invalidate any earlier outstanding tokens for this account.
+        await db.passwordResetSession.deleteMany({
+          where: { email: normalizedEmail },
+        });
 
-      // Delivered to the account's own @u.nus.edu address (not a client-supplied one).
-      await sendPasswordResetEmail(existingUser.email, resetUrl);
+        await db.passwordResetSession.create({
+          data: {
+            email: normalizedEmail,
+            token,
+            expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+          },
+        });
+
+        const base = env.APP_URL ?? env.NEXTAUTH_URL;
+        const resetUrl = `${base}/reset-password?token=${token}`;
+
+        // Delivered to the account's own stored address, never a client-supplied
+        // one — the lookup above is case-insensitive, so the two can differ.
+        await sendPasswordResetEmail(existingUser.email, resetUrl);
+      }
     }
 
-    return NextResponse.json(
-      {
-        message:
-          "If an account exists for that email, a reset link has been sent.",
-      },
-      { status: 200 },
-    );
+    // THE ONLY EXIT for every non-error path: ineligible, eligible-but-absent,
+    // and eligible-and-sent all land here. See sameResponse().
+    return sameResponse();
   } catch (err) {
     console.error("Error requesting password reset:", err);
     return NextResponse.json(

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,7 +2,10 @@
 
 import React, { useState } from "react";
 import { signOut, useSession } from "next-auth/react";
-import type { ProfileField } from "~/lib/profileCompleteness";
+import {
+  isMinimalProfileRole,
+  type ProfileField,
+} from "~/lib/profileCompleteness";
 import {
   User,
   Mail,
@@ -102,6 +105,15 @@ const ProfilePage: React.FC = () => {
           onSuccess={handleEditSuccess}
           forced={forcedIncomplete}
           requiredFields={forcedIncomplete ? missingFields : undefined}
+          /* Read from the SESSION's live role list, and derived with the SAME
+             predicate the server gate uses (isMinimalProfileRole), so the
+             dialog cannot disagree with the gate about who is exempt. It is
+             passed unconditionally — NOT only when `forcedIncomplete` — because
+             the block guard it relaxes is on the normal edit path too: an
+             exempt account with a perfectly complete profile still has no block
+             and would otherwise be unable to save a name change. Purely
+             cosmetic: the server re-derives the exemption on every write. */
+          minimalProfile={isMinimalProfileRole(session?.user?.roles ?? [])}
           // Forced completion refreshes the session so MatricGate re-evaluates
           // and this dialog unmounts itself once the profile is complete.
           onSaved={async () => {

--- a/src/app/scrc/_components/CcaBrowsePanel.tsx
+++ b/src/app/scrc/_components/CcaBrowsePanel.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+import ScrcCcaPicker, { type ScrcCcaOption } from "./ScrcCcaPicker";
+import ScrcRosterView from "./ScrcRosterView";
+
+/**
+ * Look in on any CCA's roster. Pick a CCA, read who is in it, done.
+ *
+ * Structurally /admin/ccas' page minus everything that writes: no
+ * CcaHeadsManager (grant/revoke headship is manager-tier), no RosterPanel (see
+ * the long note in ScrcRosterView for why), no export. If a control ever needs
+ * adding here, the question to answer first is which server procedure would
+ * back it — every write in this area is guarded by assertHeadsCca or
+ * manageCcaHeads, and the hall office holds neither.
+ */
+export default function CcaBrowsePanel() {
+  const [selected, setSelected] = useState<ScrcCcaOption | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl bg-white p-6 shadow-lg">
+        <h2 className="text-lg font-semibold text-gray-900">CCA rosters</h2>
+        <p className="mb-4 mt-1 text-sm text-gray-500">
+          Pick a CCA to see its heads and members.
+        </p>
+        <ScrcCcaPicker
+          value={selected?.ccaID ?? null}
+          onChange={(cca) => setSelected(cca)}
+        />
+      </section>
+
+      {selected ? (
+        <ScrcRosterView ccaID={selected.ccaID} />
+      ) : (
+        <p className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-sm text-gray-500">
+          Choose a CCA above to see who’s in it.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/scrc/_components/DisabledNotice.tsx
+++ b/src/app/scrc/_components/DisabledNotice.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { PowerOff } from "lucide-react";
+
+/**
+ * THE FIRST THING ANYONE WILL SEE ON THIS PAGE.
+ *
+ * `scrc` ships with its kill switch OFF (scrcFlag.ts fails closed: no row, or an
+ * unreachable Atlas, both mean disabled), so every procedure this surface calls
+ * refuses with SCRC_DISABLED until an admin writes `scrc.enabled = "on"`. That
+ * is a CONFIGURATION STATE, not a failure — a red "something went wrong" box
+ * here would send the first hall-office member to open the page straight to the
+ * dev team for a system behaving exactly as designed.
+ *
+ * So it renders calm and grey, in the shape of the empty states elsewhere in the
+ * app, and says what has to happen next. It is NOT an error alert, and it must
+ * not become one.
+ *
+ * EVENTS_DISABLED gets the same treatment for the same reason: the events kill
+ * switch is independent, so the Events panel can legitimately be dark while the
+ * other two work.
+ *
+ * CCA_MANAGEMENT_DISABLED is handled here even though no procedure this surface
+ * calls throws it today (`cca.listAllForOversight` and `cca.getRoster` are both
+ * behind `scrc.enabled`, not `cca.management.enabled`). Kept so that if a future
+ * guard is added to either, it degrades into this calm state rather than into a
+ * red crash — which is exactly the regression this component exists to prevent.
+ */
+const DISABLED_COPY: Record<string, { title: string; hint: string }> = {
+  SCRC_DISABLED: {
+    title: "Hall Office tools aren’t switched on yet",
+    hint: "The role exists and you can reach this page, but the tools behind it are still turned off. An admin switches them on with the scrc.enabled setting; it takes effect within about fifteen seconds, with no redeploy.",
+  },
+  EVENTS_DISABLED: {
+    title: "Events aren’t switched on yet",
+    hint: "The Events feature is turned off for the whole hall, so there is nothing to look in on. An admin switches it on with the events.enabled setting.",
+  },
+  CCA_MANAGEMENT_DISABLED: {
+    title: "CCA management isn’t switched on yet",
+    hint: "The CCA machinery is turned off for the whole hall. An admin switches it on with the cca.management.enabled setting.",
+  },
+};
+
+/**
+ * Is this tRPC error message a kill switch rather than a fault? Returns the copy
+ * to render, or null to let the caller fall through to its normal error state.
+ *
+ * Matches on the message STRING because that is the contract these procedures
+ * publish (every one of them throws FORBIDDEN with one of these as the message).
+ * Deliberately exact-match, never `includes()`: a substring test would swallow a
+ * future, genuinely different error whose message happened to mention one of
+ * these, and render it as "not switched on yet" — which would be a lie that
+ * looks intentional.
+ */
+export function disabledCopy(message: string | null | undefined) {
+  if (!message) return null;
+  return DISABLED_COPY[message] ?? null;
+}
+
+export default function DisabledNotice({ message }: { message: string }) {
+  const copy = disabledCopy(message);
+  if (!copy) return null;
+  return (
+    <div className="rounded-xl bg-white p-10 text-center shadow-lg">
+      <PowerOff className="mx-auto h-8 w-8 text-gray-300" />
+      <p className="mt-2 text-sm font-medium text-gray-900">{copy.title}</p>
+      <p className="mx-auto mt-1 max-w-lg text-sm text-gray-500">{copy.hint}</p>
+    </div>
+  );
+}

--- a/src/app/scrc/_components/EventsOversightPanel.tsx
+++ b/src/app/scrc/_components/EventsOversightPanel.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarClock, ChevronRight } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { EVENT_STATUSES, type EventStatus } from "~/lib/schemas/event";
+import {
+  formatDateRange,
+  formatDateTime,
+  STATUS_META,
+} from "~/app/events/_lib/format";
+
+import DisabledNotice, { disabledCopy } from "./DisabledNotice";
+
+/**
+ * The hall office watching the events pipeline. READ-ONLY, ALL THE WAY DOWN.
+ *
+ * THERE ARE NO Approve / Reject / Publish / Cancel / Export CONTROLS HERE, AND
+ * THERE MUST NOT BE. Every one of those is a decision with a named owner:
+ * approve and reject belong to the JCRC (event.decide, reviewEvents); publish
+ * and cancel belong to the CCA head who proposed the event; the attendee export
+ * is head-scoped because it is a list of residents' contact details. The server
+ * agrees — there is deliberately no getForOversight counterpart to `decide` —
+ * so a button added here would only produce a FORBIDDEN and an audit row. The
+ * point of oversight is to see what is happening, not to take part in it.
+ *
+ * The status label vocabulary is imported (EVENT_STATUSES + STATUS_META) rather
+ * than retyped, so the filter cannot drift from normalizeStatus'. Note the
+ * spelling: "canceled", one l.
+ */
+
+const ALL = "all" as const;
+
+function StatusPill({ status }: { status: EventStatus }) {
+  const meta = STATUS_META[status];
+  return (
+    <span
+      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* One event                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * TWO LAYERS, AND BOTH ARE MEANT TO HOLD.
+ *
+ * The SERVER is the boundary: `event.getForOversight` nulls six fields for the
+ * hall-office tier — `description`, `proposalUrl`, `decisionReason`,
+ * `createdBy`, `decidedBy`, `updatedBy` (SCRC_HIDDEN_EVENT_FIELDS in
+ * routers/event.ts). The first three are the internal proposal and the
+ * reviewer's private feedback; the last three each hold a canonical E-format
+ * userID, which is an email address one derivation later. An admin viewing this
+ * same page is a manager and receives them unredacted.
+ *
+ * This component is the SECOND layer, and it names every field it renders rather
+ * than spreading the record, so a field that is un-redacted server-side later —
+ * or that arrives in full because the viewer is an admin — still does not reach
+ * the DOM by accident. NOTHING IS SPREAD. Do not reach for `{...event}`.
+ *
+ * Deliberately not rendered, beyond the six the server already blanks:
+ *
+ *   bookingID /      facility-booking plumbing, meaningless outside the head's
+ *   autoBookFailed   own dashboard where it is actionable
+ *
+ * If one of those is genuinely needed later, add it deliberately with a reason,
+ * one field at a time — and if it is one of the six, un-redact it on the server
+ * first, because rendering it here would otherwise just print null.
+ */
+function EventOversightDetail({
+  eventID,
+  onBack,
+}: {
+  eventID: number;
+  onBack: () => void;
+}) {
+  const { data, isPending, error } = api.event.getForOversight.useQuery(
+    { eventID },
+    { retry: false },
+  );
+
+  const back = (
+    <button
+      type="button"
+      onClick={onBack}
+      className="text-sm text-emerald-700 hover:underline"
+    >
+      ← Back to all events
+    </button>
+  );
+
+  if (isPending) {
+    return (
+      <div className="space-y-3">
+        {back}
+        <div className="h-64 animate-pulse rounded-xl bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    if (error && disabledCopy(error.message)) {
+      return <DisabledNotice message={error.message} />;
+    }
+    return (
+      <div className="space-y-3">
+        {back}
+        <div className="rounded-xl bg-white p-6 shadow-lg">
+          <p className="text-sm text-gray-900">
+            {error?.message === "NO_SUCH_EVENT"
+              ? "This event no longer exists."
+              : "This event couldn’t be loaded."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const { event, ccaName } = data;
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      {back}
+
+      <div className="rounded-xl bg-white p-6 shadow-lg">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-xl font-semibold text-gray-900">
+            {event.title?.trim() || "Untitled event"}
+          </h2>
+          <StatusPill status={event.status} />
+        </div>
+        <p className="mt-1 text-sm text-gray-500">
+          {ccaName ?? `CCA #${event.ccaID}`}
+        </p>
+
+        <dl className="mt-4 grid gap-3 border-t border-gray-100 pt-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-gray-500">When</dt>
+            {/* startTime/endTime are UNIX epoch SECONDS, not Dates — formatDateRange
+                multiplies by 1000. Handing them straight to new Date() would put
+                every event in January 1970. */}
+            <dd className="text-gray-900">
+              {formatDateRange(event.startTime, event.endTime)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Where</dt>
+            <dd className="text-gray-900">{event.location ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Capacity</dt>
+            <dd className="text-gray-900">
+              {event.capacity != null ? event.capacity : "Unlimited"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Last updated</dt>
+            {/* updatedAt IS a Date (a Prisma DateTime), unlike startTime. The two
+                conventions sit side by side in one row; do not "tidy" them into
+                one helper. */}
+            <dd className="text-gray-900">
+              {event.updatedAt
+                ? event.updatedAt.toLocaleString("en-SG", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                    hour12: true,
+                  })
+                : "—"}
+            </dd>
+          </div>
+        </dl>
+
+        {/* The RESIDENT-FACING blurb (publicDescription), never the internal
+            proposal `description`. Only exists once a head has published. */}
+        {event.publicDescription?.trim() && (
+          <div className="mt-4 border-t border-gray-100 pt-4">
+            <p className="text-sm text-gray-500">What residents see</p>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-gray-900">
+              {event.publicDescription}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-400">
+        This is a read-only view. Approving, rejecting, publishing and cancelling
+        stay with the JCRC and the CCA head.
+      </p>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* The list                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export default function EventsOversightPanel() {
+  const [status, setStatus] = useState<EventStatus | typeof ALL>(ALL);
+  const [openEvent, setOpenEvent] = useState<number | null>(null);
+
+  // PAGED. listForOversight is cursor-paged over the whole Event collection, so
+  // a plain useQuery would silently show only the first page and quietly hide
+  // every older event — the failure mode that looks exactly like "there aren't
+  // any". Paging follows nextCursor and nothing else.
+  const {
+    data,
+    isPending,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = api.event.listForOversight.useInfiniteQuery(
+    { status: status === ALL ? undefined : status },
+    {
+      getNextPageParam: (last) => last.nextCursor ?? undefined,
+      retry: false,
+    },
+  );
+
+  if (openEvent !== null) {
+    return (
+      <EventOversightDetail
+        eventID={openEvent}
+        onBack={() => setOpenEvent(null)}
+      />
+    );
+  }
+
+  // Both kill switches land here — `events.enabled` is checked before
+  // `scrc.enabled`, so either can be the reason, and each has its own copy.
+  if (error && disabledCopy(error.message)) {
+    return <DisabledNotice message={error.message} />;
+  }
+
+  const events = data?.pages.flatMap((p) => p.events) ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Events</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Every event in the hall, most recently touched first.
+          </p>
+        </div>
+        <Select
+          value={status}
+          onValueChange={(v) => setStatus(v as EventStatus | typeof ALL)}
+        >
+          <SelectTrigger className="w-full bg-white sm:w-52">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All statuses</SelectItem>
+            {EVENT_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {STATUS_META[s].label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* KNOWN, and the server documents it: listForOversight filters the RAW
+          `status` column, while the status it returns is normalizeStatus'd.
+          Event.status is a nullable String, and normalizeStatus maps null to
+          "draft" — so a row stored as null reads "Draft" in this list but will
+          NOT appear under the Draft filter. Left alone deliberately upstream;
+          said out loud here so the next person does not file it as a bug. */}
+      {status === "draft" && (
+        <p className="text-xs text-gray-400">
+          Older events with no status recorded show as drafts in the full list,
+          but don’t match this filter. Choose “All statuses” to see them.
+        </p>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <p className="flex items-center justify-between gap-4 text-sm text-red-800">
+            <span>The events list couldn’t be loaded.</span>
+            <Button size="sm" variant="outline" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </p>
+        </div>
+      )}
+
+      {isPending && <div className="h-48 animate-pulse rounded-xl bg-gray-200" />}
+
+      {!isPending && !error && events.length === 0 && (
+        <div className="rounded-xl bg-white p-10 text-center shadow-lg">
+          <CalendarClock className="mx-auto h-8 w-8 text-gray-300" />
+          <p className="mt-2 text-sm font-medium text-gray-900">
+            Nothing to show
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            {status === ALL
+              ? "No events have been created yet."
+              : `No events are ${STATUS_META[status].label.toLowerCase()} right now.`}
+          </p>
+        </div>
+      )}
+
+      {events.length > 0 && (
+        <ul className="space-y-2">
+          {events.map((e) => (
+            <li key={e.eventID}>
+              <button
+                type="button"
+                onClick={() => setOpenEvent(e.eventID)}
+                className="flex w-full items-center gap-4 rounded-xl bg-white p-4 text-left shadow-sm ring-1 ring-gray-100 transition hover:ring-emerald-200"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-2 truncate text-sm font-semibold text-gray-900">
+                    <span className="truncate">
+                      {e.title?.trim() || "Untitled event"}
+                    </span>
+                    <StatusPill status={e.status} />
+                  </p>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    {e.ccaName ?? `CCA #${e.ccaID}`} ·{" "}
+                    {/* epoch SECONDS — formatDateTime does the ×1000. */}
+                    {formatDateTime(e.startTime)}
+                    {e.location ? ` · ${e.location}` : ""}
+                  </p>
+                </div>
+                <ChevronRight className="h-5 w-5 shrink-0 text-gray-300" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hasNextPage && (
+        <div className="pt-2 text-center">
+          <Button
+            variant="outline"
+            disabled={isFetchingNextPage}
+            onClick={() => void fetchNextPage()}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/scrc/_components/JcrcRosterPanel.tsx
+++ b/src/app/scrc/_components/JcrcRosterPanel.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { UserMinus, UserPlus } from "lucide-react";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Skeleton } from "~/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import DisabledNotice, { disabledCopy } from "./DisabledNotice";
+
+/**
+ * THE hall office's only write: add or remove `jcrc` on one account.
+ *
+ * It talks to admin.listJcrcRoster / resolveJcrcCandidate / setJcrcRole and to
+ * NOTHING ELSE. In particular it never touches admin.listUsers (which pages the
+ * whole hall and returns email, displayName and block for every account) or
+ * admin.setUserRoles (whose payload is a client-supplied FINAL role set). Those
+ * three narrow procedures exist precisely so this surface does not need the wide
+ * ones; reaching for a wide one here would quietly undo that.
+ */
+
+/**
+ * Both shapes are taken from the router's inferred output rather than retyped,
+ * so a change to either procedure surfaces here as a type error instead of as a
+ * quietly-wrong render.
+ */
+type JcrcRow = RouterOutputs["admin"]["listJcrcRoster"]["items"][number];
+type CandidateResult = RouterOutputs["admin"]["resolveJcrcCandidate"];
+
+/** What the confirmation dialog is about to do. */
+type Pending = {
+  userID: string;
+  /** What to call the person in the dialog. Name, else email, else the id. */
+  label: string;
+  grant: boolean;
+};
+
+/**
+ * setJcrcRole's refusals, in the words of someone who does not know what a
+ * capability is. Every one of these is a settled answer, not a glitch, so none
+ * of them says "try again".
+ */
+function mutationCopy(message: string): string {
+  switch (message) {
+    case "SCRC_CANNOT_SELF_TARGET":
+      return "You can’t change your own JCRC access. Ask an admin.";
+    case "SCRC_TARGET_UNAVAILABLE":
+      // ONE MESSAGE FOR EVERY TARGET-DEPENDENT REFUSAL, and the flatness is the
+      // security property. The server returns this for "no account", "never
+      // signed in", "holds admin", "holds Hall Office" and "the change would do
+      // nothing" — indistinguishably, because a message that varies with a
+      // property of the target turns this button into an enumeration of that
+      // property across the whole hall (see setJcrcRole in routers/admin.ts).
+      // It is the same answer resolveJcrcCandidate gives as NOT_AVAILABLE, so
+      // the lookup box and this button cannot be played against each other.
+      // Do NOT split it apart to be more helpful; the real reason is on the
+      // audit row, where an admin can read it.
+      return "That account can’t be given or removed from the JCRC. It may already be in the state you asked for, or it may not be an account the hall office can change. An admin can see why in the audit log.";
+    case "CANNOT_GRANT_JCRC":
+      return "Your account isn’t allowed to hand out JCRC access.";
+    case "CONFLICT_ROLES_CHANGED":
+      return "Someone else changed this account’s access while this page was open. Reload and take another look before trying again.";
+    case "CAPABILITY_REQUIRED:manageJcrcRoster":
+      return "Your account no longer has permission to manage the JCRC.";
+    default:
+      // SCRC_DISABLED is NOT handled here — it is a kill switch, not a refusal,
+      // so the caller checks disabledCopy() FIRST and only falls through to this
+      // function when the message is a real denial. See `mutationError` below.
+      return "That didn’t go through. Try again.";
+  }
+}
+
+/**
+ * The lookup result, in plain words.
+ *
+ * ONE MESSAGE FOR EVERY NEGATIVE, and the flatness is the security property, not
+ * an omission. The server collapses "no such identifier", "resolved but has
+ * never signed in" and "resolved to an admin" into a single NOT_AVAILABLE
+ * precisely because a distinguishable third answer let an scrc holder enumerate
+ * the admin roster (see JcrcCandidateResult in routers/admin.ts). Copy that
+ * split them apart again — "…or they have admin access", "ask them to log in
+ * once" — would hand back the exact bit the server just spent a redesign
+ * withholding, from the client, where it is cheapest to read.
+ *
+ * So this text must cover all three causes without hinting at which one applies,
+ * and it must stay that way. If someone asks for a friendlier "they've never
+ * logged in" message, the answer is no.
+ */
+function candidateCopy(result: CandidateResult): string | null {
+  switch (result.status) {
+    case "FOUND":
+      return null; // rendered as a card, not a sentence
+    case "AMBIGUOUS":
+      return "That matric matches more than one account, so it can’t be used. Try their NUSNET id or email instead.";
+    case "NOT_AVAILABLE":
+      return "No account is available to receive JCRC access under that NUSNET id, email or matric. Check the spelling — and note that someone who has never signed in to the app can’t be given access until they log in once.";
+  }
+}
+
+export default function JcrcRosterPanel() {
+  const utils = api.useUtils();
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [reason, setReason] = useState("");
+
+  // The lookup box's state, declared BEFORE the mutation because setJcrcRole's
+  // onSuccess clears it.
+  const [identifier, setIdentifier] = useState("");
+  const [looking, setLooking] = useState(false);
+  const [result, setResult] = useState<CandidateResult | null>(null);
+  const [lookupError, setLookupError] = useState<string | null>(null);
+
+  /* ------------------------------ the roster ------------------------------ */
+
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = api.admin.listJcrcRoster.useInfiniteQuery(
+    { limit: 25 },
+    {
+      // PAGING FOLLOWS nextCursor AND NOTHING ELSE. listJcrcRoster drops
+      // admin-holding rows AFTER slicing the page, so a page can come back with
+      // fewer items than `limit` — or with none at all — and still have more
+      // roster behind it. "Stop when the page is short" would silently truncate
+      // the JCRC list.
+      getNextPageParam: (last) => last.nextCursor ?? undefined,
+      // A FORBIDDEN is a settled answer, not a transient failure, and the kill
+      // switch being off is the expected first-run state. Retrying it three
+      // times is log noise and a slow, ambiguous UI.
+      retry: false,
+    },
+  );
+
+  const rows: JcrcRow[] = data?.pages.flatMap((p) => p.items) ?? [];
+
+  // The other half of the same rule. If every row on the pages fetched so far
+  // was an admin, `rows` is empty while more roster remains — rendering "nobody
+  // holds jcrc" there would be a flat lie. Keep pulling until there is either
+  // something to show or genuinely nothing left.
+  useEffect(() => {
+    if (!isLoading && rows.length === 0 && hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [isLoading, rows.length, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  /* ------------------------------ the write ------------------------------- */
+
+  const setRole = api.admin.setJcrcRole.useMutation({
+    onSuccess: async () => {
+      setPending(null);
+      setReason("");
+      // Also clears the lookup card: the grant it was offering has happened, and
+      // a stale `holdsJcrc: false` would keep offering it.
+      setResult(null);
+      setIdentifier("");
+      await utils.admin.listJcrcRoster.invalidate();
+    },
+  });
+
+  /* ----------------------------- the lookup ------------------------------- */
+
+  /**
+   * EXPLICIT SUBMIT ONLY, never a debounced live query.
+   *
+   * Every successful resolveJcrcCandidate writes a `scrc.candidate.read` audit
+   * row, because it is the only enumeration-shaped surface the hall office has.
+   * Wiring it to onChange would mean typing one email address produced a dozen
+   * audit rows for a dozen partial addresses — which both destroys the value of
+   * the record and probes eleven accounts nobody asked about. Hence
+   * utils.fetch() on a click, the same idiom HeadCandidateInput uses for
+   * cca.resolveHeadCandidate.
+   */
+  const lookup = async () => {
+    const id = identifier.trim();
+    if (!id) return;
+    setLooking(true);
+    setResult(null);
+    setLookupError(null);
+    try {
+      setResult(await utils.admin.resolveJcrcCandidate.fetch({ identifier: id }));
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "";
+      setLookupError(
+        disabledCopy(message)?.title ?? "That lookup didn’t work. Try again.",
+      );
+    } finally {
+      setLooking(false);
+    }
+  };
+
+  /* ------------------------------- render --------------------------------- */
+
+  // The kill switch, before anything else: with `scrc.enabled` off the roster
+  // query is the first thing to refuse, and the whole panel is inert.
+  if (error && disabledCopy(error.message)) {
+    return <DisabledNotice message={error.message} />;
+  }
+
+  const found = result?.status === "FOUND" ? result : null;
+  const statusLine = result ? candidateCopy(result) : null;
+  const mutationError = setRole.error
+    ? (disabledCopy(setRole.error.message)?.title ??
+      mutationCopy(setRole.error.message))
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl bg-white p-6 shadow-lg">
+        <h2 className="text-lg font-semibold text-gray-900">Add to the JCRC</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Look someone up by NUSNET id, NUS email or matric, check it is the
+          right person, then give them JCRC access.
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-end gap-2">
+          <div className="flex-1 space-y-1.5">
+            <label
+              htmlFor="jcrc-lookup"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Who
+            </label>
+            <Input
+              id="jcrc-lookup"
+              value={identifier}
+              maxLength={120}
+              disabled={looking || setRole.isPending}
+              placeholder="NUSNET id, email, or matric"
+              onChange={(e) => {
+                setIdentifier(e.target.value);
+                // Drop the previous answer the moment the question changes, so a
+                // card for the last person can never be confirmed against the
+                // id now in the box.
+                setResult(null);
+                setLookupError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void lookup();
+                }
+              }}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={looking || !identifier.trim() || setRole.isPending}
+            onClick={() => void lookup()}
+          >
+            {looking ? "Looking up…" : "Look up"}
+          </Button>
+        </div>
+
+        {lookupError && (
+          <p className="mt-2 text-sm text-amber-700">{lookupError}</p>
+        )}
+        {statusLine && (
+          <p className="mt-2 text-sm text-amber-700">{statusLine}</p>
+        )}
+
+        {found && (
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-gray-900">
+                {found.displayName ?? found.email ?? found.userID}
+              </p>
+              <p className="truncate text-xs text-gray-500">
+                {found.email ?? "No email on file"}
+                <span className="ml-2 font-mono">{found.userID}</span>
+              </p>
+            </div>
+            {/* holdsJcrc is why the resolver returns it: offering "Grant" to
+                someone who already has it would look like it did nothing. */}
+            {found.holdsJcrc ? (
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-gray-500">
+                  Already on the JCRC
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                  disabled={setRole.isPending}
+                  onClick={() =>
+                    setPending({
+                      userID: found.userID,
+                      label:
+                        found.displayName ?? found.email ?? found.userID,
+                      grant: false,
+                    })
+                  }
+                >
+                  <UserMinus className="mr-1.5 h-3.5 w-3.5" />
+                  Remove
+                </Button>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                disabled={setRole.isPending}
+                onClick={() =>
+                  setPending({
+                    userID: found.userID,
+                    label: found.displayName ?? found.email ?? found.userID,
+                    grant: true,
+                  })
+                }
+              >
+                <UserPlus className="mr-1.5 h-3.5 w-3.5" />
+                Give JCRC access
+              </Button>
+            )}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-3 flex items-end justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              Current JCRC
+            </h2>
+            <p className="mt-1 text-sm text-gray-500">
+              Everyone who currently holds JCRC access.
+            </p>
+          </div>
+        </div>
+
+        {error && !disabledCopy(error.message) && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+            <p className="flex items-center justify-between gap-4 text-sm text-red-800">
+              <span>The JCRC list couldn’t be loaded.</span>
+              <Button size="sm" variant="outline" onClick={() => void refetch()}>
+                Retry
+              </Button>
+            </p>
+          </div>
+        )}
+
+        <div className="overflow-hidden rounded-xl bg-white shadow-lg">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>User ID (NUSNET)</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading &&
+                // Skeletons inside REAL rows/cells so the column widths — and
+                // therefore the header — do not jump when data lands.
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={`sk-${i}`}>
+                    {Array.from({ length: 4 }).map((__, j) => (
+                      <TableCell key={j}>
+                        <Skeleton className="h-4 w-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+
+              {!isLoading && rows.length === 0 && !hasNextPage && !error && (
+                <TableRow>
+                  <TableCell colSpan={4}>
+                    <p className="py-10 text-center text-sm text-gray-500">
+                      Nobody holds JCRC access right now.
+                    </p>
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {rows.map((r, i) => {
+                // `canonicalUserID: null` means the stored key did not survive
+                // asStoredCanonicalUserID — there is no id to key a role change
+                // on, so this row is a record to look at, never a target. There
+                // is also nothing else unique about such a row, hence the index
+                // in the React key.
+                const targetable = r.canonicalUserID !== null;
+                const label =
+                  r.displayName ?? r.email ?? r.canonicalUserID ?? "Unknown";
+                return (
+                  <TableRow key={`${r.canonicalUserID ?? "absent"}-${i}`}>
+                    <TableCell className="font-medium text-gray-900">
+                      {r.displayName ??
+                        // hasAccount false = a live grant with no User row
+                        // behind it (a claimed pending grant, a hand-seeded
+                        // account). Shown as the bare id, NEVER omitted: hiding
+                        // it would hide a live grant from the person whose job
+                        // is to manage it.
+                        (r.hasAccount ? (
+                          <span className="text-gray-400">No name on file</span>
+                        ) : (
+                          <span className="text-gray-500">
+                            No account signed in yet
+                          </span>
+                        ))}
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-xs">
+                        {r.canonicalUserID ?? (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-600">
+                      {r.email ?? <span className="text-gray-400">—</span>}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                        disabled={!targetable || setRole.isPending}
+                        title={
+                          targetable
+                            ? undefined
+                            : "This grant has no canonical NUSNET id, so there is no key to change roles on. An admin has to clean it up."
+                        }
+                        onClick={() => {
+                          if (!r.canonicalUserID) return;
+                          setPending({
+                            userID: r.canonicalUserID,
+                            label,
+                            grant: false,
+                          });
+                        }}
+                      >
+                        <UserMinus className="mr-1.5 h-3.5 w-3.5" />
+                        Remove
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+
+        {hasNextPage && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              variant="outline"
+              disabled={isFetchingNextPage}
+              onClick={() => void fetchNextPage()}
+            >
+              {isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        )}
+      </section>
+
+      <AlertDialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open && !setRole.isPending) {
+            setPending(null);
+            setReason("");
+            setRole.reset();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pending?.grant
+                ? `Give ${pending.label} JCRC access?`
+                : `Remove ${pending?.label}’s JCRC access?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pending?.grant
+                ? "They’ll be able to review event proposals, browse every CCA roster, and manage CCA heads. Nothing else about their account changes."
+                : "They’ll lose the JCRC tools straight away. Nothing else about their account changes — any CCA headship they hold stays."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="jcrc-reason"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Reason <span className="text-gray-400">(optional)</span>
+            </label>
+            {/* Goes into the audit row. Optional because the server treats it as
+                optional; asking for it here is what makes the record readable
+                six months later. */}
+            <textarea
+              id="jcrc-reason"
+              value={reason}
+              maxLength={500}
+              rows={2}
+              disabled={setRole.isPending}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+              placeholder="e.g. AY25/26 JCRC handover"
+            />
+          </div>
+
+          {mutationError && (
+            <p className="text-sm text-red-600">{mutationError}</p>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={setRole.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            {/* Not AlertDialogAction: that closes the dialog on click, which
+                would dismiss it before the mutation resolves and hide any
+                error. A plain button keeps it open until onSuccess closes it. */}
+            <button
+              type="button"
+              disabled={setRole.isPending || pending === null}
+              onClick={() => {
+                if (!pending) return;
+                setRole.mutate({
+                  userID: pending.userID,
+                  grant: pending.grant,
+                  reason: reason.trim() || undefined,
+                });
+              }}
+              className={`inline-flex h-10 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 ${
+                pending?.grant
+                  ? "bg-emerald-600 hover:bg-emerald-700 focus-visible:ring-emerald-500"
+                  : "bg-red-600 hover:bg-red-700 focus-visible:ring-red-500"
+              }`}
+            >
+              {setRole.isPending
+                ? "Saving…"
+                : pending?.grant
+                  ? "Give JCRC access"
+                  : "Remove JCRC access"}
+            </button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/scrc/_components/ScrcCapabilityContext.tsx
+++ b/src/app/scrc/_components/ScrcCapabilityContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Capabilities } from "~/server/api/services/roles";
+
+/**
+ * THE only place in src/app/scrc/ that may inspect authority — the same rule
+ * AdminCapabilityContext states for src/app/admin/, for the same reason.
+ *
+ * The rule every other file under src/app/scrc/ obeys: no component branches on
+ * a role string. Every conditional render reads a named boolean off this object.
+ * The gate is
+ *   grep -rn 'roles.includes\|isAdmin\|"scrc"' src/app/scrc/
+ * returning zero hits outside this file.
+ *
+ * That is a maintainability rule, not a security one — the layout guard plus the
+ * per-procedure guards are the security (I-7); everything here is cosmetic. In
+ * particular NOTHING here knows whether the `scrc.enabled` kill switch is on:
+ * computeCapabilities is synchronous and DB-free by design, so the switch is
+ * only ever learned from a procedure refusing with SCRC_DISABLED. That is why
+ * the panels render a switched-off state rather than hiding themselves.
+ *
+ * The type comes from `~/server/api/services/roles`, which is deliberately
+ * runtime-pure (its PrismaClient import is type-only), so importing it from a
+ * client component pulls in no server code. Do not "fix" this by copying the
+ * Capabilities shape locally — two copies of a capability set is how a surface
+ * starts rendering a control the server will refuse.
+ */
+const Ctx = createContext<Capabilities | null>(null);
+
+export function ScrcCapabilityProvider({
+  value,
+  children,
+}: {
+  value: Capabilities;
+  children: React.ReactNode;
+}) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useScrcCapabilities(): Capabilities {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useScrcCapabilities outside ScrcCapabilityProvider");
+  return v;
+}

--- a/src/app/scrc/_components/ScrcCcaPicker.tsx
+++ b/src/app/scrc/_components/ScrcCcaPicker.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons";
+
+import { api, type RouterOutputs } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+
+import DisabledNotice, { disabledCopy } from "./DisabledNotice";
+
+export type ScrcCcaOption =
+  RouterOutputs["cca"]["listAllForOversight"]["ccas"][number];
+
+/**
+ * The hall office's CCA picker. Visually identical to
+ * admin/_components/bulk/CcaPicker — a searchable combobox rather than a
+ * <Select>, because there are 89 CCAs and a plain 89-item dropdown is a
+ * scroll-and-hope control; typing filters on the NAME and on the ID because an
+ * operator working from a spreadsheet usually has one or the other.
+ *
+ * A SEPARATE COMPONENT AND NOT A REUSE OF CcaPicker, deliberately. CcaPicker
+ * reads api.admin.listCcas, which sits behind roleManagerProcedure — the hall
+ * office would get a flat FORBIDDEN and an empty dropdown with no explanation.
+ * cca.listAllForOversight exists exactly so this surface has a CCA list of its
+ * own; it also means the picker goes dark with the `scrc.enabled` switch, which
+ * is correct, and which is why it renders the switched-off state itself rather
+ * than an error.
+ *
+ * The list is NOT an authorization. Every ccaID it hands back is authorised
+ * again, per-CCA, by assertMayViewCcaRoster inside cca.getRoster.
+ */
+export default function ScrcCcaPicker({
+  value,
+  onChange,
+}: {
+  value: number | null;
+  onChange: (cca: ScrcCcaOption | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const { data, isPending, error } = api.cca.listAllForOversight.useQuery(
+    undefined,
+    // A FORBIDDEN is a settled answer, and the kill switch being off is the
+    // expected first-run state — retrying it three times is log noise.
+    { retry: false },
+  );
+
+  const ccas = data?.ccas ?? [];
+  const selected = ccas.find((c) => c.ccaID === value) ?? null;
+
+  if (error) {
+    if (disabledCopy(error.message)) {
+      return <DisabledNotice message={error.message} />;
+    }
+    return (
+      <p className="text-sm text-red-600">
+        The CCA list couldn’t be loaded. Reload the page.
+      </p>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={isPending}
+          className="w-full justify-between bg-white sm:w-96"
+        >
+          {isPending
+            ? "Loading CCAs…"
+            : selected
+              ? `${selected.ccaName} (${selected.ccaID})`
+              : "Choose a CCA"}
+          <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command
+          filter={(itemValue, search) =>
+            itemValue.toLowerCase().includes(search.toLowerCase().trim()) ? 1 : 0
+          }
+        >
+          <CommandInput placeholder="Search by name or id…" />
+          <CommandList>
+            <CommandEmpty>No CCA matches that.</CommandEmpty>
+            <CommandGroup>
+              {ccas.map((c) => (
+                <CommandItem
+                  key={c.ccaID}
+                  // The searchable text. Name AND id, so "142" finds it too.
+                  value={`${c.ccaName} ${c.ccaID} ${c.category}`}
+                  onSelect={() => {
+                    onChange(c);
+                    setOpen(false);
+                  }}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === c.ccaID ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="flex-1">{c.ccaName}</span>
+                  <span className="ml-2 font-mono text-xs text-gray-400">
+                    {c.ccaID}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/scrc/_components/ScrcRosterView.tsx
+++ b/src/app/scrc/_components/ScrcRosterView.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Eye } from "lucide-react";
+
+import { api } from "~/trpc/react";
+import RosterTable from "~/app/_components/RosterTable";
+import RosterDriftNote from "~/app/_components/RosterDriftNote";
+
+import DisabledNotice, { disabledCopy } from "./DisabledNotice";
+
+/**
+ * ONE CCA'S ROSTER, READ-ONLY. Heads and members. Nothing else, ever.
+ *
+ * WHY THIS IS NOT RosterPanel.
+ *
+ * RosterPanel renders the same two tables, and reusing it would have been one
+ * import. It also wires three things the hall office must not reach, and every
+ * one of them is a prop default away from switching on:
+ *
+ *   - cca.removeMembers, behind `manageMembers`. Membership writes are
+ *     head-scoped (assertHeadsCca); the hall office reads rosters and touches
+ *     nothing.
+ *   - cca.memberDirectory, behind `enableDirectory` — the roster PLUS every
+ *     member's matric, block, telegram handle and bio, plus the Excel export of
+ *     all of it. That is a different sensitivity class from "names and grant
+ *     dates", it is head-only server-side, and there is no reason for the hall
+ *     office to hold the hall's contact details.
+ *   - a `via === "manageCcaHeads"` branch, which is a manager-tier label this
+ *     surface has no business rendering.
+ *
+ * A future "just pass enableDirectory here too" is exactly the change this file
+ * exists to make someone stop and argue for. If you find yourself importing
+ * RosterPanel into src/app/scrc/, that is the signal.
+ *
+ * RosterTable and RosterDriftNote ARE reused, because they are display-only —
+ * they hold no queries and no mutations, and with `selection` and `details`
+ * omitted (as they are here, and must stay) they render a plain table. That is
+ * the same read-only configuration /admin/ccas uses. Duplicating them would
+ * fork the amber unresolved-row rendering, which is the one part of a roster
+ * everybody needs to see the same way.
+ */
+export default function ScrcRosterView({ ccaID }: { ccaID: number }) {
+  const { data, isPending, error } = api.cca.getRoster.useQuery(
+    { ccaID },
+    // A FORBIDDEN is a settled answer, not a transient failure. Retrying it
+    // three times is log noise and a slow, ambiguous UI.
+    { retry: false },
+  );
+
+  if (isPending) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <div className="h-6 w-48 animate-pulse rounded bg-gray-200" />
+        <div className="h-32 animate-pulse rounded-lg bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error) {
+    if (disabledCopy(error.message)) {
+      return <DisabledNotice message={error.message} />;
+    }
+    if (error.message === "NOT_A_HEAD_OF_THIS_CCA") {
+      return (
+        <div className="rounded-lg border border-gray-200 bg-white px-4 py-6">
+          <p className="text-sm font-medium text-gray-900">
+            You can’t see this CCA’s roster
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            If that looks wrong, contact an admin.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-6">
+        <p className="text-sm font-medium text-red-900">
+          This roster couldn’t be loaded
+        </p>
+        <p className="mt-1 text-sm text-red-700">
+          Reload the page. If it keeps happening, contact an admin.
+        </p>
+      </div>
+    );
+  }
+
+  const { cca, heads, members, drift } = data;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-xl font-semibold text-gray-900">
+            {cca.ccaName ?? `Unknown CCA (#${cca.ccaID})`}
+          </h2>
+          {/* Says what this view IS, and does NOT branch on `via`. getRoster
+              reports via: "readOnly" for scrc and via: "manageCcaHeads" for an
+              admin who wanders in here, but this surface draws no controls for
+              either of them — so the label is a property of the page, not of
+              the caller, and a branch would only invite one. */}
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+            <Eye className="h-3 w-3" />
+            Read-only
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-gray-500">
+          {cca.category ?? "Uncategorised"}
+        </p>
+      </header>
+
+      {/* The CCA record itself is missing — the CcaBadges amber idiom, applied
+          to the whole roster rather than one row. */}
+      {drift.ccaMissing && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          There is no CCA with this id any more, but these membership records
+          still point at it.
+        </div>
+      )}
+
+      <RosterDriftNote drift={drift} />
+
+      {/* NO `selection` and NO `details` on either table, and there must never
+          be one. `selection` draws removal checkboxes; `details` triggers the
+          cca.memberDirectory fetch (matric/block/telegram/bio + Excel export)
+          this surface is explicitly not entitled to. Omitting them is what
+          makes RosterTable safe to share here. */}
+      {/* showEmail={false} because the SERVER already nulled every address on
+          this tier (cca.getRoster -> redactRosterForReadOnly). This is not the
+          boundary and must never be mistaken for one — it only stops the table
+          drawing an Email header over a column the server declined to fill,
+          which reads as a bug rather than as a decision. Flipping it to true
+          would show an empty column, not an address. */}
+      <RosterTable
+        title="Heads"
+        entries={heads}
+        emptyCopy="Nobody is currently listed as a head of this CCA."
+        showEmail={false}
+      />
+      <RosterTable
+        title="Members"
+        entries={members}
+        emptyCopy="No members are listed for this CCA yet."
+        showEmail={false}
+      />
+    </div>
+  );
+}

--- a/src/app/scrc/_components/ScrcShell.tsx
+++ b/src/app/scrc/_components/ScrcShell.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { Capabilities } from "~/server/api/services/roles";
+import { ScrcCapabilityProvider } from "./ScrcCapabilityContext";
+
+/**
+ * The client half of the /scrc segment: it carries the capability set the server
+ * layout computed, and owns the one persistent heading.
+ *
+ * Thinner than AdminShell on purpose. AdminShell also owns a tab strip because
+ * /admin is many ROUTES; the hall office is one route with three panels, so the
+ * panel switcher lives in page.tsx next to the panels it switches between and
+ * this component stays a provider plus a header.
+ */
+export default function ScrcShell({
+  capabilities,
+  children,
+}: {
+  capabilities: Capabilities;
+  children: React.ReactNode;
+}) {
+  return (
+    <ScrcCapabilityProvider value={capabilities}>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold text-gray-900">Hall Office</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Appoint the JCRC, and look in on CCA rosters and events.
+          </p>
+        </header>
+        {children}
+      </div>
+    </ScrcCapabilityProvider>
+  );
+}

--- a/src/app/scrc/layout.tsx
+++ b/src/app/scrc/layout.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { getUserRoles } from "~/server/api/services/access";
+import { computeCapabilities } from "~/server/api/services/roles";
+import Header from "~/app/_components/header";
+import ScrcShell from "./_components/ScrcShell";
+
+/** Session-dependent. Never static, never ISR — a cached hall-office shell would
+ *  be served to whoever asked for it next. */
+export const dynamic = "force-dynamic";
+
+/**
+ * The route guard for the Hall Office (scrc) surface. DEFENCE IN DEPTH, not the
+ * security boundary: a client can call api.admin.setJcrcRole.mutate() from the
+ * console on any page in the app, so every procedure behind this layout carries
+ * its own live capability check plus the `scrc.enabled` switch (I-7). What this
+ * buys is that no hall-office markup ever streams to someone who holds neither
+ * `admin` nor `scrc`.
+ *
+ * Structurally a copy of cca/layout.tsx, and DELIBERATELY a copy rather than a
+ * shared helper: each narrow segment recomputes from its own live read. The
+ * duplication is the point — a shared guard is one edit away from being widened
+ * for one caller and silently widened for all of them.
+ *
+ * NOTE what this does NOT establish. `reachScrcDashboard` answers "is this
+ * surface for you" and nothing else. It says nothing about WHICH CCA's roster
+ * may be read (assertMayViewCcaRoster decides that per ccaID) and nothing about
+ * whether any given account may be granted `jcrc` (assertCanMutateRoles decides
+ * that per target).
+ *
+ * THE `scrc.enabled` KILL SWITCH IS NOT CHECKED HERE, deliberately, following
+ * the /admin/manage-ccas layout precedent: this layout answers "may you be in
+ * this room"; the switch answers "is the machinery live", and that belongs in
+ * the procedures — a page-level switch check would leave every procedure
+ * reachable from the console anyway, while making the flag look like it was
+ * enforced by the page. assertScrcEnabled's own comment names this file as the
+ * place with deliberately no check. The role ships with the switch OFF, so the
+ * first person here reaches the page and every panel reports SCRC_DISABLED
+ * calmly; that is the intended first-run experience, not a bug.
+ */
+export default async function ScrcLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  let roles: string[] = [];
+  try {
+    // LIVE database read, NOT session.user.roles (I-5). The session copy is
+    // render-only and the JWT lives 30 days; a hall-office grant revoked this
+    // morning must close this page now.
+    roles = await getUserRoles(db, session.user.userID);
+  } catch {
+    // Fail CLOSED, and swallow rather than rethrow — a segment's own error.tsx
+    // does NOT catch an error thrown by that segment's layout.tsx, so a rethrow
+    // would blank the whole app shell rather than deny one route.
+    redirect("/");
+  }
+
+  const capabilities = computeCapabilities(roles);
+  // redirect("/") and not a 403: an unauthorised viewer should not learn that
+  // /scrc exists at all.
+  if (!capabilities.reachScrcDashboard) redirect("/");
+
+  return (
+    <div className="mb-14 min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+      {/* Must match the nav link's `name` in header.tsx ("Hall Office") —
+          isActive() compares currentPage to link.name before falling back to
+          the pathname. */}
+      <Header currentPage="Hall Office" />
+      {/* max-w-7xl, matching /admin rather than /cca: this surface is panels and
+          tables, not a sidebar plus a content column, so a capped measure keeps
+          the tables readable on a wide screen. */}
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* The capability set crosses to the client ONCE, here, as a prop.
+            Nothing below re-derives authority from a role string. */}
+        <ScrcShell capabilities={capabilities}>{children}</ScrcShell>
+      </main>
+    </div>
+  );
+}

--- a/src/app/scrc/page.tsx
+++ b/src/app/scrc/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarCheck, ShieldCheck, Users2 } from "lucide-react";
+
+import type { Capabilities } from "~/server/api/services/roles";
+import { useScrcCapabilities } from "./_components/ScrcCapabilityContext";
+import JcrcRosterPanel from "./_components/JcrcRosterPanel";
+import CcaBrowsePanel from "./_components/CcaBrowsePanel";
+import EventsOversightPanel from "./_components/EventsOversightPanel";
+
+/**
+ * The Hall Office dashboard: three panels, one route.
+ *
+ * A CLIENT component, unlike /cca/page.tsx, because there is nothing to decide
+ * server-side — the layout already did the live role read and the redirect, and
+ * every panel's real gate is the procedure it calls. All this owns is which of
+ * the three is on screen.
+ *
+ * `requires` names a CAPABILITY, never a role (D-2), exactly as AdminShell's tab
+ * list does. IT CONTROLS RENDERING ONLY: hiding a tab is not a guard, and each
+ * panel's procedures re-read the capability live and check the `scrc.enabled`
+ * kill switch themselves (I-7).
+ *
+ * All three capabilities are currently true for both `admin` and `scrc`, so in
+ * practice nobody sees a partial tab set. The filter is here anyway so that
+ * narrowing one of them later is a one-line change rather than a hunt for the
+ * places that assumed all three travelled together.
+ */
+const PANELS = [
+  {
+    key: "jcrc",
+    label: "JCRC",
+    icon: ShieldCheck,
+    requires: "manageJcrcRoster",
+    Panel: JcrcRosterPanel,
+  },
+  {
+    key: "ccas",
+    label: "CCA rosters",
+    icon: Users2,
+    requires: "viewCcaRostersReadOnly",
+    Panel: CcaBrowsePanel,
+  },
+  {
+    key: "events",
+    label: "Events",
+    icon: CalendarCheck,
+    requires: "viewEventsReadOnly",
+    Panel: EventsOversightPanel,
+  },
+] as const satisfies readonly {
+  key: string;
+  label: string;
+  icon: unknown;
+  requires: keyof Capabilities;
+  Panel: React.ComponentType;
+}[];
+
+export default function ScrcPage() {
+  const capabilities = useScrcCapabilities();
+  // `=== true` and not a truthiness test: `assignableRoles` is a (possibly
+  // empty) ARRAY on this same object, and [] is truthy. A future panel keyed on
+  // one of those fields would otherwise render for everyone.
+  const panels = PANELS.filter((p) => capabilities[p.requires] === true);
+
+  const [active, setActive] = useState(panels[0]?.key);
+  const current = panels.find((p) => p.key === active) ?? panels[0];
+
+  if (!current) {
+    // reachScrcDashboard without any of the three. Not reachable today, but a
+    // blank page with no explanation is the worst possible way to find out that
+    // it became reachable.
+    return (
+      <div className="rounded-xl bg-white p-10 text-center shadow-lg">
+        <p className="text-sm font-medium text-gray-900">
+          There’s nothing here for your account
+        </p>
+        <p className="mt-1 text-sm text-gray-500">
+          You can reach the Hall Office page, but none of its tools are open to
+          you. Contact an admin.
+        </p>
+      </div>
+    );
+  }
+
+  const { Panel } = current;
+
+  return (
+    <div className="space-y-6">
+      {/* The same tab idiom as AdminShell's nav — emerald underline on the
+          active entry — because this is the same kind of surface and inventing
+          a second look for it would only make the app read as two apps. State,
+          not routing: /scrc is one route. */}
+      <nav className="border-b border-gray-200">
+        <div className="flex gap-6 overflow-x-auto">
+          {panels.map((p) => {
+            const isActive = p.key === current.key;
+            return (
+              <button
+                key={p.key}
+                type="button"
+                onClick={() => setActive(p.key)}
+                aria-current={isActive ? "page" : undefined}
+                className={`flex items-center gap-2 whitespace-nowrap border-b-2 py-3 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "border-emerald-600 text-emerald-700"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                <p.icon className="h-4 w-4" />
+                {p.label}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+
+      <Panel />
+    </div>
+  );
+}

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -47,7 +47,40 @@ export function isNusStudentEmail(email: string | null | undefined): boolean {
 }
 
 /**
- * A canonical, non-empty identity key derived from an @u.nus.edu address.
+ * A well-formed, non-empty PRINCIPAL KEY. Exactly two things can be one:
+ *
+ *   1. a NUSNET id derived from an @u.nus.edu address — `canonicalUserID()`;
+ *   2. an admin-pinned allowlist id in the `EXT:` namespace — `asExtUserID()`
+ *      (08-userid-keydrift.md §3 Branch C, for a principal with no NUS
+ *      address).
+ *
+ * Those two functions are the only DERIVERS, and they both live in this file,
+ * so the set of things that can be derived into an authorization key is
+ * enumerable by reading one module.
+ *
+ * THERE IS A THIRD ENTRY POINT AND IT IS WEAKER THAN THE OTHER TWO. SAY SO.
+ * `asStoredCanonicalUserID` re-admits a value read back out of Mongo, and it
+ * gates on `isCanonicalResidentID` — a SHAPE test: non-empty, and no '@'. It
+ * therefore brands strings that NEITHER minting function could ever have
+ * produced. `asStoredCanonicalUserID("hello")` is a branded "hello". Read as a
+ * security statement, "nothing new can become a key" is FALSE, and it should
+ * not be written here as though it were true.
+ *
+ * What is actually true, and what the property rests on: it is sound only over
+ * a value that a KEYED WRITER put in a *ID column, and both of its call sites
+ * feed it exactly that — `UserRole.userID`, never `session.user.userID` and
+ * never a client-supplied field. Its own doc comment states the rule and the
+ * misuse; this paragraph exists so the summary above does not quietly cancel
+ * it. If a third call site ever hands it something an operator or a request
+ * body supplied, the enumerability claim at the top of this comment stops
+ * holding — and nothing in the type system will say so, because the brand is
+ * exactly what that function hands out.
+ *
+ * The NAME still says "canonical" because widening it to `PrincipalUserID`
+ * would have touched ~30 call sites, each one a chance to get a guard wrong,
+ * for zero runtime difference (the brand is erased). What widened is the
+ * MEANING, stated here; what did not widen is the guarantee, which was never
+ * "this came from NUS" — see isCanonicalResidentID's provenance note.
  *
  * The brand exists so the ABSENT identity can leave the `string` domain
  * entirely (09 §5.2, D-B). Before C9 absence was `""` — an in-band member of
@@ -64,6 +97,57 @@ export function isNusStudentEmail(email: string | null | undefined): boolean {
  * serialized shape changes and nothing needs the brand back after JSON.parse.
  */
 export type CanonicalUserID = string & { readonly __brand: "CanonicalUserID" };
+
+/**
+ * THE EXTERNAL IDENTITY NAMESPACE. An admin-pinned key for a principal that has
+ * no @u.nus.edu address — hall office staff, whose addresses are @nus.edu.sg
+ * (08-userid-keydrift.md §3 Branch C). One `AuthAllowlist` row pins one address
+ * to one of these.
+ *
+ * THE ':' IS THE WHOLE MECHANISM (M1). NUS_STUDENT_EMAIL's capture class is
+ * `[A-Z0-9._%-]` — it does not contain ':' — so `canonicalUserID()` can NEVER
+ * return a string matching this pattern, for ANY input, because every character
+ * it can return comes from that class. The two key spaces are PROVABLY
+ * DISJOINT, not conventionally separate.
+ *
+ * That is what makes the attack in 05-verification.md §164 —
+ * `{ email: "attacker@gmail.com", pinnedUserID: "E1633673" }`, which would
+ * hand an admin's authorization key to a stranger with NO grant path and
+ * therefore NO escalation guard firing — UNREPRESENTABLE rather than merely
+ * refused. `isExtUserID("E1633673")` is false, and the parity gate asserts it.
+ *
+ * Uppercase and `_` only, so a pin is legible in `RoleAuditLog.actorUserID` and
+ * greppable across collections. Length-bounded at both ends: the 3-char floor
+ * keeps `EXT:` alone from being a key, and the 32-char ceiling stops an id
+ * being used to smuggle a payload into an audit row.
+ *
+ * A pin is ADMIN-SUPPLIED AND VALIDATED, never auto-derived at read time — see
+ * services/authAllowlist.ts.
+ */
+export const EXT_ID = /^EXT:[A-Z0-9_]{3,32}$/;
+
+/** Pure shape test over the EXT namespace. See EXT_ID for why ':' matters. */
+export function isExtUserID(id: string | null | undefined): boolean {
+  return typeof id === "string" && EXT_ID.test(id);
+}
+
+/**
+ * The ONE minting function for the EXT half of the brand — the exact mirror of
+ * `asStoredCanonicalUserID` for the canonical half, and A RUNTIME CHECK, NEVER
+ * A CAST. Every EXT id in this codebase passes through here.
+ *
+ * It is what `pinnedUserIDFor` calls on the value it READ BACK OUT OF MONGO
+ * (mechanism M2), which is the half that survives a compromised write path: a
+ * row typed by hand in Atlas, or written by some future code path that skipped
+ * the zod schema, mints NO IDENTITY AT ALL rather than a bad one. The
+ * admin-only audited write (M4) alone would not give you that — it only
+ * governs the writes it can see.
+ */
+export function asExtUserID(
+  id: string | null | undefined,
+): CanonicalUserID | null {
+  return isExtUserID(id) ? (id as CanonicalUserID) : null;
+}
 
 /**
  * Returns null for anything that is not a valid @u.nus.edu address.
@@ -107,8 +191,23 @@ export function canonicalUserID(
  * Calling this on an admin-supplied `targetUserID` and concluding that the
  * principal is NUS-verified is exactly the misuse that breaks it — a pasted
  * bulk list would mint stored `resident` rows for principals whose NUS
- * provenance was never established. Note also that an `EXT:`-namespaced
- * allowlist pin would pass this test.
+ * provenance was never established.
+ *
+ * AN `EXT:`-NAMESPACED ALLOWLIST PIN PASSES THIS TEST. Not hypothetically —
+ * `AuthAllowlist` exists and pins are stored in `UserRole.userID`, so
+ * `isCanonicalResidentID("EXT:NGOCANH_MAI")` is true today, and the parity gate
+ * asserts it as a documented false positive. It is DESIRED there: it is what
+ * lets `asStoredCanonicalUserID` re-admit a pin read out of `UserRole` so the
+ * admin roster row is a usable grant target.
+ *
+ * IT IS SAFE ONLY BECAUSE EVERY BASELINE WRITER TAKES AN EMAIL AND
+ * CANONICALIZES INTERNALLY (I-8d). `ensureBaseline` returns false at its
+ * `!userID` clause — `canonicalUserID("ngocanh.mai@nus.edu.sg")` is null —
+ * BEFORE this predicate is ever consulted, so an EXT principal receives no
+ * `resident` baseline mechanically rather than by convention (08 §3.4). A
+ * future function that takes an ID and mints a baseline breaks this, and the
+ * breakage is silent. That property is the load-bearing one; do not remove it
+ * without removing this false positive too.
  *
  * Deliberately NOT E_FORMAT.test(id): see canonicalUserID above (L-27).
  *

--- a/src/lib/profileCompleteness.ts
+++ b/src/lib/profileCompleteness.ts
@@ -9,17 +9,162 @@
  *
  * The mandatory set is a product decision: a real display name, a Telegram
  * handle, a block, and a matriculation number. Bio stays optional.
+ *
+ * THE FIRST AND ONLY EXCEPTION to an always-on gate. This gate was deliberately
+ * built with NO kill switch (see the session callback in src/server/auth.ts:
+ * "evaluated for EVERY identified session"), so carving anything out of it is a
+ * significant act and is contained on purpose. The default `roles = []` on
+ * `computeProfileGaps` is load-bearing: a caller that forgets to pass roles gets
+ * the STRICT set, so the failure mode of forgetting is over-prompting, never
+ * over-admitting. Read MINIMAL_PROFILE_ROLES below before adding anything to it.
  */
 
 export type ProfileField = "displayName" | "telegramHandle" | "block" | "matric";
 
-/** The fields a user must have before they may use the app. */
-export const REQUIRED_PROFILE_FIELDS: ProfileField[] = [
+/**
+ * A required-field set that is STRUCTURALLY INCAPABLE OF BEING EMPTY.
+ *
+ * `readonly` blocks `.push` / `.pop` / index assignment; the `[A, ...A[]]`
+ * shape makes `= []` a compile error. Both halves are needed and both exist
+ * because the comments below make a claim — "nobody can make the exempt set
+ * empty by accident" — and a claim that only a comment enforces is not a
+ * mechanism. An empty required set is not "one fewer field"; it is the gate
+ * switched off, which is a much larger decision than any edit to this file
+ * should be able to express by accident.
+ */
+type NonEmptyProfileFields = readonly [ProfileField, ...ProfileField[]];
+
+/**
+ * The fields a user must have before they may use the app — the STRICT set, and
+ * the closed vocabulary of field names.
+ *
+ * UNCHANGED by the role-aware exemption below, deliberately: the admin surfaces
+ * (UserDetailDialog, and the "known field" filter in userAdmin's WALL 2) filter
+ * against this constant and must keep seeing all four names, or a field a deploy
+ * does not recognise gets dropped. Only the PER-USER derivation
+ * (`requiredProfileFieldsFor`) is role-aware.
+ */
+export const REQUIRED_PROFILE_FIELDS: NonEmptyProfileFields = Object.freeze([
   "displayName",
   "telegramHandle",
   "block",
   "matric",
-];
+] as const);
+
+/**
+ * THE EXEMPTION LIST — and it is a `Record`, not an array, ON PURPOSE.
+ *
+ * The key is a role string; the value is the JUSTIFICATION for exempting it. A
+ * bare `["scrc"]` would let a future edit widen an always-on gate with a
+ * five-character diff and no argument attached to it. A justification map forces
+ * whoever adds a role to write down WHY in the same edit, in the same file the
+ * reviewer is already reading, next to every other reason. That is the whole
+ * point of the shape — do not "simplify" it to a list or a Set.
+ *
+ * THE ROLE STRING IS DUPLICATED FROM src/server/api/services/roles.ts ON
+ * PURPOSE. This module must stay server-import-free (see the header): it is
+ * value-imported by `"use client"` components, and importing SCRC_ROLE from the
+ * server tree would drag the server module — and eventually Prisma — into the
+ * browser bundle. The duplication is made safe by a COMPILE-TIME SUBSET
+ * ASSERTION at the bottom of roles.ts (`_minimalRolesAreRealRoles`), which types
+ * `Object.keys(MINIMAL_PROFILE_ROLES)` as `readonly Role[]`. A typo or an
+ * invented role here is therefore a `tsc --noEmit` error, not a silently inert
+ * exemption that nobody notices for months.
+ *
+ * REVIEWER CHECK: this object should have exactly one key. If it has grown, the
+ * question to ask is whether the gate still protects anybody.
+ */
+export const MINIMAL_PROFILE_ROLES = Object.freeze({
+  scrc: "Hall office staff. Not a resident: no matric to hold, no hall block to live in, and no reason to publish a Telegram handle to residents. Their display name is the only field the app renders about them.",
+} as const);
+
+/**
+ * THE FLOOR. An exemption reduces the required set TO THIS CONSTANT — never to
+ * `[]`. `displayName` stays mandatory for exempt roles because it is the one
+ * field the app renders about them (on booking listings, via the owner join), so
+ * an empty or NUSNET-shaped one is an impersonation surface exactly as it is for
+ * a resident. `isDisplayNameValid` therefore still runs for exempt roles; see
+ * `computeProfileGaps`.
+ *
+ * NOBODY CAN MAKE THE EXEMPT SET EMPTY BY ACCIDENT, and that is now enforced
+ * rather than asserted: `NonEmptyProfileFields` makes `= []` a compile error and
+ * `readonly` + `Object.freeze` block mutation at compile time and at runtime
+ * respectively. An empty floor would turn the exemption into "no gate at all",
+ * which is a different and much larger decision than "one fewer field", and it
+ * should not be expressible as a typo.
+ */
+export const MINIMAL_REQUIRED_PROFILE_FIELDS: NonEmptyProfileFields =
+  Object.freeze(["displayName"] as const);
+
+/**
+ * Does this role set earn the minimal profile requirement?
+ *
+ * ONE PREDICATE, consulted by the profile gate AND by the matric gate
+ * (`matricProcedure` / `requireMatric` in src/server/api/trpc.ts). Two gates, one
+ * definition, one place to widen, and greppable. Without the matric gate sharing
+ * it, flipping the unrelated `rbac.matric.enforcement` switch would silently
+ * strip the hall office's booking rights months later with no obvious cause.
+ *
+ * Takes `readonly string[]` rather than a `Role[]` so it can be handed a raw
+ * session role list without a cast at every call site.
+ *
+ * `some`, NOT `every` — MOST-PRIVILEGED-EXEMPTION-WINS, and that is intended.
+ * A holder of `["resident", "scrc"]` IS exempt. The alternative (`every`) would
+ * mean a hall-office member who also happens to hold `resident` is gated on a
+ * matric they do not have, which is the exact lockout this exemption exists to
+ * prevent — and `resident` is minted by ensureBaseline for anyone with an
+ * @u.nus.edu address, so the combination is not exotic. It is also consistent
+ * with how the rest of the role system composes (`assignableBy` unions,
+ * `canBookWithRoles` is `some`): holding MORE roles never takes something away.
+ * Moot for the two EXT accounts this shipped for — they receive no `resident`
+ * baseline at all (08 §3.4) — but it is the rule for anyone who is granted
+ * `scrc` on a normal NUS account, and `scrc` is admin-grantable only.
+ *
+ * `hasOwnProperty.call` and NOT `MINIMAL_PROFILE_ROLES[r] !== undefined`: the
+ * latter walks the prototype chain, so a stored role string of `"constructor"`
+ * or `"__proto__"` would resolve to a truthy Object.prototype member and exempt
+ * its holder from the profile gate. Unreachable today — `normalizeStoredRoles`
+ * drops anything outside GRANTABLE_ROLES before these ever reach a session —
+ * but the safe spelling costs nothing and does not depend on that staying true.
+ */
+export function isMinimalProfileRole(
+  roles: readonly string[] | null | undefined,
+): boolean {
+  if (!roles) return false;
+  return roles.some((r) =>
+    Object.prototype.hasOwnProperty.call(MINIMAL_PROFILE_ROLES, r),
+  );
+}
+
+/**
+ * The required-field set for a specific user, given their roles.
+ *
+ * This is the ONLY per-user derivation. `REQUIRED_PROFILE_FIELDS` itself is
+ * unchanged and stays the strict global vocabulary — the admin surfaces filter
+ * against it and must keep seeing all four field names.
+ *
+ * Note the default: NO argument, or an empty list, yields the STRICT set. Every
+ * call site that has not been taught about roles keeps byte-identical behaviour,
+ * and the failure mode of forgetting to thread roles through is over-prompting.
+ */
+export function requiredProfileFieldsFor(
+  roles: readonly string[] | null | undefined,
+): ProfileField[] {
+  // A COPY, not the constant itself — and the reason CHANGED when the two
+  // source arrays became `readonly` + `Object.freeze`d, so it is restated
+  // rather than left to rot. It is no longer "a caller could splice the
+  // constant and rewrite the gate for every user in this lambda"; that is now
+  // impossible. It is that this function's declared return type is a MUTABLE
+  // `ProfileField[]`, and the value is handed to client components as a prop.
+  // Returning a frozen array behind a mutable type would turn an ordinary
+  // `.sort()` or `.push()` in a consumer into a runtime TypeError in
+  // production. Hand back something that is actually what the signature says.
+  return [
+    ...(isMinimalProfileRole(roles)
+      ? MINIMAL_REQUIRED_PROFILE_FIELDS
+      : REQUIRED_PROFILE_FIELDS),
+  ];
+}
 
 /** Human copy for each field, used in the completion dialog's checklist. */
 export const PROFILE_FIELD_LABEL: Record<ProfileField, string> = {
@@ -67,14 +212,51 @@ export type ProfileSnapshot = {
 };
 
 /**
+ * Is one field satisfied? Split out so `computeProfileGaps` can ITERATE the
+ * required set rather than restate it as a fixed list of `if`s. That is not a
+ * style preference: the previous body hardcoded all four checks, so the required
+ * set and the gap computation were two independent statements of the same thing
+ * and a role-aware set could silently disagree with them. Iterating
+ * `requiredProfileFieldsFor()` makes disagreement unrepresentable.
+ *
+ * The `switch` is exhaustive over `ProfileField`, so adding a field to the type
+ * without teaching this function about it is a compile error.
+ */
+function isFieldSatisfied(
+  field: ProfileField,
+  profile: ProfileSnapshot,
+): boolean {
+  switch (field) {
+    case "displayName":
+      return isDisplayNameValid(profile.displayName);
+    case "telegramHandle":
+      return Boolean((profile.telegramHandle ?? "").trim());
+    case "block":
+      return profile.block != null;
+    case "matric":
+      return Boolean((profile.matric ?? "").trim());
+  }
+}
+
+/**
  * The required fields this user has NOT satisfied. Empty => their profile is
  * complete and proper, and the gate lets them through.
+ *
+ * `roles` DEFAULTS TO `[]`, AND THAT DEFAULT IS LOAD-BEARING. An empty role list
+ * is never exempt, so every call site that does not pass roles — today and in
+ * any future edit — gets the STRICT four-field set, byte for byte what this
+ * function returned before roles existed. An exemption is reachable only by a
+ * caller that deliberately hands over a role list. Forgetting therefore
+ * OVER-PROMPTS (a recoverable annoyance) and can never OVER-ADMIT.
+ *
+ * Order of the result follows the required-field list, so the completion
+ * dialog's "Please add X, Y and Z" copy reads in a stable order.
  */
-export function computeProfileGaps(profile: ProfileSnapshot): ProfileField[] {
-  const gaps: ProfileField[] = [];
-  if (!isDisplayNameValid(profile.displayName)) gaps.push("displayName");
-  if (!(profile.telegramHandle ?? "").trim()) gaps.push("telegramHandle");
-  if (profile.block == null) gaps.push("block");
-  if (!(profile.matric ?? "").trim()) gaps.push("matric");
-  return gaps;
+export function computeProfileGaps(
+  profile: ProfileSnapshot,
+  roles: readonly string[] = [],
+): ProfileField[] {
+  return requiredProfileFieldsFor(roles).filter(
+    (field) => !isFieldSatisfied(field, profile),
+  );
 }

--- a/src/lib/schemas/profile.ts
+++ b/src/lib/schemas/profile.ts
@@ -71,14 +71,32 @@ export const updateProfileInput = z.object({
       message: "Telegram handle must be 5–32 characters: letters, digits or _",
     }),
 
-  // Required, matching signup, which mandates it. The page must initialise the
-  // select to UNSET rather than defaulting to a block the user never chose —
-  // the old `user?.block ?? 8` pre-selected Block 8 and let it be saved by
-  // accident. Nullability is not the fix; an unset control is.
+  // The page must initialise the select to UNSET rather than defaulting to a
+  // block the user never chose — the old `user?.block ?? 8` pre-selected Block 8
+  // and let it be saved by accident. Nullability is not the fix; an unset
+  // control is.
+  //
+  // OPTIONAL, NOT NULLABLE. `undefined` means "leave the stored value alone";
+  // there is deliberately NO value that means "clear it" — the same posture as
+  // `matric` in the admin router's update schema, and the reason is the same: a
+  // field that can be blanked by omission gets blanked by a client that forgot
+  // to send it. When a value IS sent it must still be one of BLOCKS, so this
+  // widens WHEN the field is written, never WHAT may be written.
+  //
+  // Why it became optional: a hall-office (`scrc`) account has no hall block to
+  // live in and is exempt from that half of the profile gate (see
+  // src/lib/profileCompleteness.ts). With `block` required here, that account
+  // could never submit this form at all — the shared schema, which the client
+  // mirrors with a real safeParse, would refuse the save.
+  //
+  // A RESIDENT'S BEHAVIOUR IS BYTE-IDENTICAL: EditProfileModal still refuses a
+  // blank block before it ever parses (that guard is now gated on
+  // `minimalProfile`), so a resident's payload always carries one.
   block: z
     .number()
     .int()
-    .refine((n) => (BLOCKS as readonly number[]).includes(n), "Invalid block"),
+    .refine((n) => (BLOCKS as readonly number[]).includes(n), "Invalid block")
+    .optional(),
 });
 
 export type UpdateProfileInput = z.input<typeof updateProfileInput>;

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -9,7 +9,15 @@ import {
   createTRPCRouter,
   protectedProcedure,
   roleManagerProcedure,
+  scrcProcedure,
 } from "../trpc";
+import { assertScrcEnabled } from "../services/scrcFlag";
+import {
+  allowlistPinExists,
+  pinnedUserIDsFor,
+  resetAuthAllowlistCache,
+} from "../services/authAllowlist";
+import { isExtUserID, normalizeEmail } from "~/lib/identity";
 import {
   evaluateBooking,
   getEnforcementMode,
@@ -23,20 +31,25 @@ import {
   FACILITY_ROLES,
   GRANTABLE_ROLES,
   JCRC_ROLE,
+  SCRC_ROLE,
   assignableBy,
   asStoredCanonicalUserID,
   canonicalUserID,
   type CanonicalUserID,
   computeCapabilities,
+  forbiddenRoleCombination,
   isGrantableRole,
   isEFormatUserID,
   isNusStudentEmail,
   legacyMirror,
   revocableFromOthersBy,
   userIDSchema,
+  extUserIDSchema,
+  roleTargetUserIDSchema,
   type Capabilities,
   type GrantableRole,
 } from "../services/roles";
+import { MATRIC_RE } from "~/lib/schemas/profile";
 
 /**
  * The admin / role-management router (02-backend-authz.md §§6-8).
@@ -87,6 +100,40 @@ import {
 const roleSchema = z.enum(GRANTABLE_ROLES);
 
 /**
+ * `extUserIDSchema` / `roleTargetUserIDSchema` are DEFINED IN
+ * ../services/roles.ts, beside `userIDSchema`, and imported here — not declared
+ * locally. That module is runtime-pure and client-importable; this one pulls in
+ * `node:crypto` and `~/env`, so a `"use client"` component that needed the
+ * schema (AuditLogTable's filter parse) could not import it from here without
+ * dragging both into the browser bundle.
+ *
+ * THE ENUMERATION OF WHERE roleTargetUserIDSchema IS APPLIED IS THE CONTAINMENT,
+ * so it is written out rather than left implicit. Three sites in this file:
+ *
+ *   setUserRoles   — the ONLY way to grant `scrc` to an allowlist-pinned
+ *                    hall-office account.
+ *   explainAccess  — read-only, audited; the only tool for triaging "why can't
+ *                    the hall office book room N".
+ *   listAuditLog   — read-only, adminProcedure; the surface whose whole job is
+ *                    oversight of this role.
+ *
+ * Every OTHER target site in this file stays on the bare `userIDSchema`:
+ *
+ *   resolveIdentifier (bulk import + pending grants) — so a pasted `EXT:…` in a
+ *       1000-row CSV comes back UNRESOLVED. THIS IS THE CONTAINMENT ON M4: the
+ *       EXT namespace is unreachable from a spreadsheet.
+ *   createPendingGrants / revokePendingGrant — a pending grant is redeemed at
+ *       FIRST LOGIN against a canonical id; a deferred grant to a pinned
+ *       identity would be a second, unaudited provisioning path.
+ *   grantCcaHead / revokeCcaHead / transferCcaHead — the hall office must not
+ *       become a CCA head.
+ *   setJcrcRole / listJcrcRoster / resolveJcrcCandidate — all three target
+ *       RESIDENTS. EXCLUSIVE_ROLE_PAIRS makes an `scrc` target impossible
+ *       anyway (G8 denies jcrc+scrc), so widening them would only let the hall
+ *       office aim its one power at the EXT namespace for no purpose.
+ */
+
+/**
  * Facilities require a DIFFERENT vocabulary than users are granted: `resident`
  * is requirable but not grantable, and `admin` is grantable but must never be
  * stored as a requirement (it is an implicit bypass; storing it invites someone
@@ -101,6 +148,120 @@ const facilityRoleSchema = z.enum(FACILITY_ROLES);
  * catastrophic-backtracking vector, and role managers are students.
  */
 const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * The shape `resolveJcrcCandidate` returns.
+ *
+ * DELIBERATELY NOT `HeadCandidateResult`, which it originally mirrored. That
+ * union distinguishes NOT_FOUND from NOT_SIGNED_IN, and this procedure ALSO had
+ * to refuse a target holding `admin`. Three negative outcomes plus a positive
+ * one turned the admin refusal into an ORACLE: a non-existent address answered
+ * NOT_SIGNED_IN or NOT_FOUND, an ordinary account answered FOUND, and only an
+ * ADMIN answered NOT_FOUND-after-resolving — so the branch written to hide
+ * admins was the one thing that uniquely marked them, and a loop over the hall's
+ * addresses enumerated the admin list exactly.
+ *
+ * So there are now TWO outcomes, not four. NOT_AVAILABLE is returned, byte for
+ * byte, for every negative: the identifier did not resolve, it resolved to
+ * somebody who has never signed in, it resolved to an admin, or it resolved to
+ * another HALL-OFFICE account. No status, no message, no field, and no shape
+ * difference separates them. It carries NO userID — echoing the resolved id back
+ * would have re-opened the same oracle one field lower down.
+ *
+ * The `scrc` case joined that list late, and only because of COMPOSITION: alone,
+ * reporting a hall-office account as FOUND leaked nothing this role could not
+ * already see, but paired with setJcrcRole's opaque refusal it eliminated every
+ * other cause and identified them exactly. See the screen in the procedure.
+ *
+ * AMBIGUOUS survives as its own status, and that is a considered exception. It
+ * is decided ENTIRELY by `userMatric.findMany().length > 1`, before any role or
+ * account lookup happens at all, so it cannot separate an admin from anyone
+ * else — an admin with a unique matric answers NOT_AVAILABLE like every other
+ * refusal, and a resident with a duplicated one answers AMBIGUOUS. The only bit
+ * it discloses is "the matric YOU just typed is claimed by more than one
+ * account", which the identical branch in cca.resolveHeadCandidate already
+ * discloses to every CCA head, and which the operator needs in order to know to
+ * try a NUSNET id instead.
+ *
+ * `holdsJcrc` on the FOUND branch lets the UI offer Revoke instead of Grant.
+ */
+export type JcrcCandidateResult =
+  | {
+      status: "FOUND";
+      userID: string;
+      displayName: string | null;
+      email: string | null;
+      holdsJcrc: boolean;
+    }
+  /** A matric matched more than one account. Decided before any role lookup. */
+  | { status: "AMBIGUOUS" }
+  /**
+   * No usable grant target. Covers "no such identifier", "never signed in" and
+   * "holds admin", indistinguishably and on purpose. Do NOT add a field, a
+   * reason code or a sub-status to this branch — the whole point is that the
+   * caller cannot tell which of the three it got.
+   */
+  | { status: "NOT_AVAILABLE" };
+
+/**
+ * Guard messages that describe THE TARGET rather than the CALLER, and which
+ * `admin.setJcrcRole` therefore flattens to `SCRC_TARGET_UNAVAILABLE` before
+ * they reach a hall-office client.
+ *
+ * WHY A LIST AND NOT A BLANKET CATCH. `sanitizeErrors` in trpc.ts rewrites
+ * INTERNAL_SERVER_ERROR only; every FORBIDDEN message is passed through to the
+ * client verbatim, by design, because for admin and jcrc the specific reason IS
+ * the product. That is right for them and wrong for `scrc`, whose reachable
+ * target set is the whole hall: a message that varies with a property of the
+ * target turns one repeatable call into an enumeration of that property.
+ *
+ * Each entry, and what it would otherwise disclose:
+ *   CANNOT_MODIFY_AN_ADMIN     — G3. "this account holds admin". The one that
+ *                                reopened the oracle resolveJcrcCandidate had
+ *                                just been rewritten to close.
+ *   CANNOT_HOLD_JCRC_AND_SCRC  — G8. "this account holds scrc", i.e. an
+ *                                enumeration of the hall office itself.
+ *   NOT_A_CANONICAL_USERID     — G7. Unreachable from setJcrcRole (userIDSchema
+ *                                already enforces E-format at the boundary),
+ *                                listed so it stays closed if that ever changes.
+ *   CANNOT_REMOVE_LAST_ADMIN   — applyRoleChange. Unreachable here for the same
+ *                                structural reason (this mutation only ever
+ *                                adds or removes `jcrc`), listed for the same
+ *                                defensive reason.
+ *   USE_CCA_HEAD_ENDPOINT      — G4, when `cca_head` lands in the delta. "this
+ *                                account heads a CCA". Race-only from
+ *                                setJcrcRole: the requested set is built from a
+ *                                pre-check read, so `cca_head` can only enter
+ *                                the delta if the target gains or loses a
+ *                                headship between that read and the guard's.
+ *   CANNOT_REVOKE_SCRC_FROM_OTHERS
+ *                              — G4 removals. `revocableFromOthersBy(["scrc"])`
+ *                                is exactly {jcrc}, so this fires if `scrc` ever
+ *                                appears in the removal set — again only via the
+ *                                same race, and again it would answer "this
+ *                                account holds scrc".
+ *
+ * The last two are the races this allowlist is FOR: it exists precisely because
+ * the pre-checks in setJcrcRole read the target in an earlier statement than the
+ * guards do, and a list that covered only the messages the pre-checks already
+ * pre-empt would be documentation rather than a backstop.
+ *
+ * DELIBERATELY ABSENT: CANNOT_GRANT_JCRC, CANNOT_REVOKE_JCRC_FROM_OTHERS,
+ * NOT_A_ROLE_MANAGER, CANNOT_SELF_ASSIGN, CAPABILITY_REQUIRED:*, SCRC_DISABLED
+ * and CONFLICT_ROLES_CHANGED. Every one of those is identical for every target
+ * — they describe the ACTOR or a race — so they leak nothing and are worth far
+ * more to the operator stated plainly.
+ *
+ * If a future guard's message depends on the target, add it here.
+ */
+const TARGET_DISCRIMINATING = new Set<string>([
+  "CANNOT_MODIFY_AN_ADMIN",
+  "CANNOT_HOLD_JCRC_AND_SCRC",
+  "NOT_A_CANONICAL_USERID",
+  "CANNOT_REMOVE_LAST_ADMIN",
+  "USE_CCA_HEAD_ENDPOINT",
+  "CANNOT_REVOKE_SCRC_FROM_OTHERS",
+]);
 
 const listInput = z.object({
   search: z.string().trim().max(100).optional(),
@@ -327,9 +488,21 @@ const forbid = (msg: string): never => {
  * THE privilege-escalation firewall. Computes the resulting role set for a
  * `set`-style request and validates it, or throws and audits the denial.
  *
- *  G1 CALLER      caller must hold admin or jcrc. Also enforced by the
+ *  G1 CALLER      caller must hold admin, jcrc or scrc. Also enforced by the
  *                 procedure middleware — belt and braces, because this function
  *                 is the thing every future surface will call.
+ *                 `scrc` (hall office) was added when it gained
+ *                 ASSIGNABLE_BY.scrc = ["jcrc"]: G1 is a REACHABILITY gate, and
+ *                 leaving it out would have refused the hall office here with
+ *                 NOT_A_ROLE_MANAGER before its (narrow, legitimate) delta was
+ *                 ever evaluated by G4. What `scrc` may actually do to whom is
+ *                 still decided entirely by G3/G4/G5/G6 and the maps — this
+ *                 line grants nothing.
+ *                 Deliberately NOT rewritten as `assignableBy(actorRoles).size
+ *                 === 0`, which would be tidier and WRONG: a jcrc's set is
+ *                 empty, so that form would newly deny jcrc HERE with
+ *                 NOT_A_ROLE_MANAGER instead of at G4 with CANNOT_GRANT_JCRC,
+ *                 silently changing the denyReason on existing audit rows.
  *  G2 VOCABULARY  every requested role must be a known GRANTABLE role. Zod
  *                 rejects most of these first; this survives a router that
  *                 forgets. `resident` fails G2 by design (I-8e).
@@ -350,10 +523,24 @@ const forbid = (msg: string): never => {
  *                 Scoped to non-admins deliberately: an admin already outranks
  *                 every role, and blocking them would leave the bootstrap admin
  *                 unable to give themselves jcrc with no in-app path to fix it.
- *  G7 KEY         the target must be an E-format userID (I-1). Without this the
+ *  G7 KEY         the target must be an E-format userID (I-1), OR an `EXT:`
+ *                 allowlist pin WITH A LIVE AuthAllowlist ROW. Without this the
  *                 dashboard writes rows keyed on an A-format matric that no
  *                 session ever matches: the grant appears to succeed and does
- *                 nothing.
+ *                 nothing. It is a REACHABILITY guard, not an authorization one
+ *                 — which is why the EXT branch demands a row rather than a
+ *                 shape: a pin is admin-typed, so `EXT:TYPO` is a well-formed
+ *                 key that no session can produce, i.e. exactly the failure this
+ *                 guard exists to prevent. The `||` short-circuits, so an
+ *                 E-format target still pays nothing.
+ *  G8 EXCLUSION   the RESULTING set must not contain a mutually exclusive pair
+ *                 (EXCLUSIVE_ROLE_PAIRS in roles.ts — today, jcrc + scrc). The
+ *                 only guard here that constrains the SHAPE of the result
+ *                 rather than the actor or the delta, and the only one an
+ *                 ADMIN cannot override: an admin may grant either role to
+ *                 anyone, and still may not produce that combination in one
+ *                 person, because the hole it opens is not about who granted
+ *                 it. Read EXCLUSIVE_ROLE_PAIRS for what composes.
  *
  * It re-reads BOTH actor and target roles from the database rather than
  * trusting the session (I-5); this also closes the TOCTOU where the actor is
@@ -414,8 +601,33 @@ export async function assertCanMutateRoles(opts: {
     return forbid(reason);
   };
 
-  if (!isEFormatUserID(targetUserID)) await deny("NOT_A_CANONICAL_USERID"); // G7
-  if (!actorIsAdmin && !actorRoles.includes(JCRC_ROLE)) {
+  // G7 KEY. E-format, OR A PROVEN ALLOWLIST PIN.
+  //
+  // NOT A WIDER REGEX — A PROOF. G7 asks "can any session ever produce this
+  // target key" (see its entry in the guard table above): it is a REACHABILITY
+  // guard, not an authorization one, and it exists because a grant keyed on
+  // something no session matches SUCCEEDS AND DOES NOTHING, silently.
+  //
+  // An `EXT:` id does correspond to a session — but ONLY if an AuthAllowlist
+  // row exists, and the shape alone cannot tell you that: a pin is
+  // admin-supplied, so `EXT:NGOCANH_MIA` is a well-formed typo that would write
+  // a UserRole row no login ever reaches. So the EXT branch demands a LIVE ROW.
+  // That makes this branch strictly STRONGER than the shape test it sits beside,
+  // not weaker.
+  //
+  // COSTS NOTHING FOR EXISTING TRAFFIC: `||` short-circuits, so an E-format
+  // target never evaluates the right side and never issues the query. Same
+  // denyReason on failure, so no existing audit string moves and every historic
+  // NOT_A_CANONICAL_USERID row keeps meaning what it meant.
+  const targetKeyed =
+    isEFormatUserID(targetUserID) ||
+    (isExtUserID(targetUserID) && (await allowlistPinExists(db, targetUserID)));
+  if (!targetKeyed) await deny("NOT_A_CANONICAL_USERID"); // G7
+  if (
+    !actorIsAdmin &&
+    !actorRoles.includes(JCRC_ROLE) &&
+    !actorRoles.includes(SCRC_ROLE)
+  ) {
     await deny("NOT_A_ROLE_MANAGER"); // G1
   }
   for (const r of requestedRoles) {
@@ -426,6 +638,19 @@ export async function assertCanMutateRoles(opts: {
   }
 
   const requested = [...new Set(requestedRoles)] as GrantableRole[];
+
+  // G8 EXCLUSION. Evaluated on the RESULTING SET, not the delta: a payload that
+  // merely omits one half of a forbidden pair is still a payload that produces
+  // the other half, and a delta check would wave through a set that already
+  // contained both. Placed after G2 (so every member is known) and before G4 (so
+  // the answer is "that combination is forbidden" rather than a confusing
+  // "you may not grant jcrc" aimed at someone who may). See
+  // EXCLUSIVE_ROLE_PAIRS — this is the invariant that stops a jcrc+scrc holder
+  // reaching setUserRoles and bulkAssign with the scrc grant power attached and
+  // the scrc kill switch bypassed.
+  const combination = forbiddenRoleCombination(requested);
+  if (combination) await deny(combination); // G8
+
   const added = requested.filter((r) => !before.includes(r));
   const removed = before.filter((r) => !requested.includes(r));
 
@@ -529,6 +754,24 @@ export async function applyRoleChange(opts: {
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
       message: "NON_GRANTABLE_IN_REMOVAL",
+    });
+  }
+
+  // G8's backstop at the chokepoint, ASSERTED rather than assumed, exactly like
+  // the line above. `after` comes from assertCanMutateRoles, which already
+  // refused a forbidden pair — so this can only fire if someone adds a caller
+  // that skips the guard, which is precisely the mistake worth failing loudly
+  // on. Checking `after` is sufficient and not merely convenient: the written
+  // set below is (stored non-grantable) ∪ after, and both halves of every
+  // EXCLUSIVE_ROLE_PAIR are grantable, so nothing in the first term can
+  // reintroduce a pair. INTERNAL_SERVER_ERROR, not FORBIDDEN — a client cannot
+  // cause this, and calling it a permission problem would misdirect whoever
+  // reads the log.
+  const combination = forbiddenRoleCombination(after);
+  if (combination) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `EXCLUSIVE_PAIR_AT_CHOKEPOINT:${combination}`,
     });
   }
 
@@ -824,6 +1067,12 @@ async function assertMayManageCcaHeadOf(
     });
     return forbid(reason);
   };
+  // G7, AND DELIBERATELY NOT WIDENED TO THE EXT NAMESPACE — unlike the copy in
+  // assertCanMutateRoles above. CCA-head grants stay E-format-only: the hall
+  // office must not become a CCA head (phase 1 non-goal #6), and `cca_head` is
+  // the role that hands out assertHeadsCca and with it every CCA write, the
+  // member directory and the attendee PII export. There is no requirement that
+  // an EXT principal ever head a CCA, so the narrower test stands.
   if (!isEFormatUserID(targetUserID)) await deny("NOT_A_CANONICAL_USERID"); // G7
   if (!actorRoles.includes(ADMIN_ROLE)) {
     const targetRoles = await getUserRoles(db, targetUserID);
@@ -919,6 +1168,12 @@ export const adminRouter = createTRPCRouter({
               displayName: u?.displayName ?? null,
               block: null as string | null,
               hasAccount: Boolean(u),
+              // Same field on both branches of this procedure, deliberately: a
+              // field present on one arm only turns the return type into a
+              // union and every client reader into a narrowing exercise. Here
+              // the key is read straight out of UserRole, so the namespace test
+              // is all that is needed.
+              pinned: isExtUserID(r.userID),
               eligible: true,
               keyMismatch: false,
               roles: redact(r.roles?.length ? r.roles : r.role ? [r.role] : []),
@@ -955,12 +1210,42 @@ export const adminRouter = createTRPCRouter({
       const nextCursor =
         users.length > limit ? (page[page.length - 1]?.id ?? null) : null;
 
+      /* ---- ALLOWLIST-PINNED ROWS ------------------------------------------
+       * WITHOUT THIS BLOCK AN ADMIN CANNOT GRANT `scrc` AT ALL, and the cause
+       * looks like a permissions bug rather than a missing lookup.
+       *
+       * `canonicalUserID(u.email)` is null for an @nus.edu.sg staff address, so
+       * the row below would render `canonicalUserID: null` -> UserRoleTable
+       * prints "—" and DISABLES its Manage-roles button (`disabled={!u.
+       * canonicalUserID}`), which is the only path to setUserRoles in the UI.
+       *
+       * Resolved as a BATCH, and only for the rows that actually failed to
+       * canonicalize — usually zero, occasionally a handful of legacy Google
+       * rows. One extra indexed `in` query per page, on a <=100-row admin-only
+       * page, skipped entirely when there is nothing to resolve. `cidOf` below
+       * is the single derivation both call sites use, so the row's
+       * `canonicalUserID`, `eligible` and `roles` cannot disagree about which
+       * key this account has.
+       *
+       * NOTE the pins go through pinnedUserIDsFor, which applies the SAME
+       * asExtUserID namespace filter per row (M2) that the session path does —
+       * so a poisoned row renders here exactly as it authorizes: as nothing.
+       */
+      const unresolved = page
+        .filter((u) => canonicalUserID(u.email) === null)
+        .map((u) => u.email);
+      const pins = unresolved.length
+        ? await pinnedUserIDsFor(ctx.db, unresolved)
+        : new Map<string, CanonicalUserID>();
+      const cidOf = (email: string): CanonicalUserID | null =>
+        canonicalUserID(email) ?? pins.get(normalizeEmail(email)) ?? null;
+
       // C9: `.filter(Boolean)` removed the absent ids at RUNTIME but not in the
       // type, so the `in:` filter below was typed as if it could carry one. A
       // type predicate makes the existing runtime behaviour checkable. No
       // runtime change: null was already dropped, exactly as "" was.
       const canonicalIDs = page
-        .map((u) => canonicalUserID(u.email))
+        .map((u) => cidOf(u.email))
         .filter((id): id is CanonicalUserID => id !== null);
       const roleRows = await ctx.db.userRole.findMany({
         where: { userID: { in: canonicalIDs } },
@@ -974,7 +1259,7 @@ export const adminRouter = createTRPCRouter({
 
       return {
         items: page.map((u) => {
-          const cid = canonicalUserID(u.email);
+          const cid = cidOf(u.email);
           return {
             id: u.id,
             canonicalUserID: cid, // the key ALL mutations must submit; null => none
@@ -983,6 +1268,14 @@ export const adminRouter = createTRPCRouter({
             displayName: u.displayName,
             block: u.block,
             hasAccount: true,
+            /**
+             * TRUE for an allowlist-pinned staff address, and that is now the
+             * CORRECT answer rather than a widening: such an account CAN sign
+             * in (maySignIn consults the same collection) and DOES hold a
+             * principal key. `keyMismatch` below stays false for them because
+             * provisioning writes `User.userID` = the pin.
+             */
+            pinned: cid !== null && isExtUserID(cid),
             eligible: cid !== null, // false => cannot sign in under D-7
             keyMismatch: Boolean(u.userID && u.userID !== cid),
             // C9: `byID.get(cid)` with an absent cid was the same S5 lookup as
@@ -1000,7 +1293,7 @@ export const adminRouter = createTRPCRouter({
 
   getStats: roleManagerProcedure.query(async ({ ctx }) => {
     const c = caps(ctx.session.user.roles);
-    const [totalUsers, jcrc, ccaHead, admins] = await Promise.all([
+    const [totalUsers, jcrc, ccaHead, scrc, admins] = await Promise.all([
       ctx.db.user.count(),
       ctx.db.userRole.count({
         where: { OR: [{ roles: { has: JCRC_ROLE } }, { role: JCRC_ROLE }] },
@@ -1010,6 +1303,16 @@ export const adminRouter = createTRPCRouter({
           OR: [{ roles: { has: CCA_HEAD_ROLE } }, { role: CCA_HEAD_ROLE }],
         },
       }),
+      // Hall office. A COUNT, visible to every manager, deliberately unlike
+      // `admins` below — the hall office is an appointed body whose size is
+      // ordinary operational information, not the `seeAdminIdentities` line.
+      // Counting it here is also the cheapest standing answer to "how many
+      // accounts can appoint the JCRC", which is the number worth watching.
+      // The legacy `role` scalar is included for symmetry only: `scrc` is
+      // absent from PRECEDENCE and so is never mirrored into it.
+      ctx.db.userRole.count({
+        where: { OR: [{ roles: { has: SCRC_ROLE } }, { role: SCRC_ROLE }] },
+      }),
       ctx.db.userRole.count({
         where: { OR: [{ roles: { has: ADMIN_ROLE } }, { role: ADMIN_ROLE }] },
       }),
@@ -1018,15 +1321,587 @@ export const adminRouter = createTRPCRouter({
       totalUsers,
       jcrc,
       ccaHead,
+      scrc,
       admins: c.seeAdminIdentities ? admins : null,
     };
   }),
+
+  /* ---------------------------------------------------------------------- */
+  /* HALL OFFICE (scrc) — the /scrc surface                                  */
+  /*                                                                         */
+  /* Three procedures, all on scrcProcedure (admin | scrc), all asserting    */
+  /* `manageJcrcRoster` AND the `scrc.enabled` kill switch. They exist as a  */
+  /* deliberately NARROW alternative to listUsers + setUserRoles, which the  */
+  /* hall office must not reach:                                            */
+  /*                                                                         */
+  /*   - listUsers pages the WHOLE HALL and returns email, displayName and   */
+  /*     block for every account. listJcrcRoster pages the small UserRole    */
+  /*     collection filtered to jcrc — a roster the hall office itself       */
+  /*     appoints — and DROPS admin-holding rows entirely.                   */
+  /*   - setUserRoles takes a client-supplied FINAL role set. setJcrcRole    */
+  /*     takes a boolean and constructs the set server-side from the         */
+  /*     target's current roles ± jcrc, so an scrc payload is INCAPABLE OF   */
+  /*     EXPRESSING the removal of any other role. G4 would catch that       */
+  /*     anyway; not being able to say it is stronger than being refused.    */
+  /*                                                                         */
+  /* setUserRoles, listUsers and roleManagerProcedure are all UNCHANGED —    */
+  /* zero regression risk for admin and jcrc is the whole point of adding    */
+  /* three procedures instead of widening two.                              */
+  /* ---------------------------------------------------------------------- */
+
+  /**
+   * The current JCRC, for the hall office's revoke list.
+   *
+   * Pages `UserRole` (small) rather than `User` (the whole hall), legacy-tolerant
+   * on the singular `role` scalar exactly as listUsers' role-filtered branch is.
+   *
+   * ADMIN ROWS ARE DROPPED, NOT REDACTED (R14). An admin who also holds jcrc
+   * matches the filter, and returning them — even with the roles array stripped —
+   * would tell the hall office that someone is unusually privileged, which is the
+   * `seeAdminIdentities` line. Dropping them also means `scrc` is never shown a
+   * target that G3 (CANNOT_MODIFY_AN_ADMIN) would refuse.
+   *
+   * `roles` is NOT in the projection at all. There is nothing to redact if it
+   * never leaves.
+   *
+   * THIS IS THE ONE PLACE THE HALL OFFICE IS GIVEN CANONICAL IDS AND EMAILS ON
+   * PURPOSE, and it is worth being explicit since every other read-only surface
+   * strips them (cca.getRoster, cca.listHeads, event.getForOversight all redact
+   * identity for this tier). The exception is justified, not an oversight:
+   *   - the JCRC is an appointed body this role EXISTS to administer, and its
+   *     membership is effectively public in the hall;
+   *   - `canonicalUserID` is not decoration, it is the argument setJcrcRole
+   *     needs in order to revoke — without it the revoke button cannot work;
+   *   - it is bounded by construction. This lists holders of ONE role, admins
+   *     excluded, not the hall.
+   * Nothing here generalises to the other surfaces. Do not cite it as precedent
+   * for returning an id anywhere else on this tier.
+   */
+  listJcrcRoster: scrcProcedure
+    .input(
+      z.object({
+        limit: z.number().int().min(1).max(100).default(25),
+        cursor: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      requireCapability(caps(ctx.session.user.roles), "manageJcrcRoster");
+      await assertScrcEnabled(ctx.db);
+
+      const { limit, cursor } = input;
+      const roleRows = await ctx.db.userRole.findMany({
+        where: { OR: [{ roles: { has: JCRC_ROLE } }, { role: JCRC_ROLE }] },
+        take: limit + 1,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+        orderBy: { id: "asc" },
+      });
+      const page = roleRows.slice(0, limit);
+      // Computed from the RAW page, before the admin filter below. If it were
+      // computed from the filtered list, a page consisting entirely of admins
+      // would return no cursor and the client would stop paging mid-roster.
+      const nextCursor =
+        roleRows.length > limit ? (page[page.length - 1]?.id ?? null) : null;
+
+      const visible = page.filter((r) => {
+        const stored = r.roles?.length ? r.roles : r.role ? [r.role] : [];
+        return !stored.includes(ADMIN_ROLE);
+      });
+
+      // Hydrate. There is no reverse E-format -> email Mongo query, so probe the
+      // conventional address and left-join in memory, exactly as listUsers does.
+      // A jcrc row with no User row (a claimed pending grant, a hand-seeded
+      // account) renders as a bare id — never as an omission, which would hide a
+      // live grant from the person whose job is to manage it.
+      const emails = visible.map((r) => `${r.userID.toLowerCase()}@u.nus.edu`);
+      const users = await ctx.db.user.findMany({
+        where: { email: { in: emails, mode: "insensitive" } },
+        // NEVER a bare findMany: passwordHash must not reach the client, and
+        // passwordHash-less Google-adapter rows throw on a full read (I-2).
+        select: { email: true, displayName: true },
+      });
+      // C9, copied verbatim from listUsers and load-bearing for the same reason:
+      // a key that canonicalizes to ABSENT is DROPPED rather than stored under
+      // "". Without this, `byCanonical.get("")` would match a ""-keyed UserRole
+      // row and attribute a stranger's email and displayName to that grant.
+      // Unreachable while no ""-keyed row exists; do not "simplify" it away.
+      const byCanonical = new Map<string, (typeof users)[number]>(
+        users.flatMap((u) => {
+          const cid = canonicalUserID(u.email);
+          return cid === null ? [] : [[cid, u] as const];
+        }),
+      );
+
+      return {
+        items: visible.map((r) => {
+          const u = byCanonical.get(r.userID);
+          return {
+            // Minted through the checked entry point so a ""-keyed row arrives
+            // at the client as ABSENT rather than as a usable grant target.
+            canonicalUserID: asStoredCanonicalUserID(r.userID),
+            email: u?.email ?? null,
+            displayName: u?.displayName ?? null,
+            hasAccount: Boolean(u),
+          };
+        }),
+        nextCursor,
+      };
+    }),
+
+  /**
+   * One identifier in, one person out — the hall office's GRANT target picker.
+   * It exists so that `scrc` never needs listUsers.
+   *
+   * TWO PROPERTIES, both of which this procedure got WRONG in its first form and
+   * both of which are the reason it is written the way it is now.
+   *
+   * 1. THE NEGATIVE ANSWER IS SINGLE-VALUED. It originally returned NOT_FOUND
+   *    for an unresolvable identifier, NOT_SIGNED_IN for a resolvable one with
+   *    no UserRole row, FOUND for an ordinary account, and NOT_FOUND again for a
+   *    target holding `admin`. Those four collapse to a three-way partition in
+   *    which "resolves, but answers NOT_FOUND" is TRUE EXACTLY WHEN THE TARGET
+   *    IS AN ADMIN. The clause written to conceal admins was the one that
+   *    identified them, and a loop over @u.nus.edu addresses enumerated the
+   *    admin roster precisely — the `seeAdminIdentities` line, crossed by the
+   *    role that has the least business crossing it.
+   *    So every negative now returns the SAME `{ status: "NOT_AVAILABLE" }`,
+   *    with no userID, no reason code and no shape difference. Read
+   *    JcrcCandidateResult's comment before adding anything to that branch.
+   *    KNOWN RESIDUAL, accepted: the three negatives still differ in how many
+   *    queries they run (0, 1 and 2), so they differ in latency. That is a
+   *    timing side channel over network jitter on a per-request audited surface,
+   *    not a status code; padding it would cost a fake query on every miss and
+   *    still not equalise it. Not worth it. Do not "fix" it by re-splitting the
+   *    status.
+   *
+   * 2. EVERY CALL IS AUDITED, INCLUDING THE MISSES. The audit write originally
+   *    sat below the early returns, so precisely the calls worth investigating —
+   *    the misses and the admin hits, i.e. an enumeration sweep — wrote NOTHING,
+   *    while the comment claimed otherwise. `record()` is now called on every
+   *    exit path, and it carries the probed identifier and the outcome CLASS
+   *    (which is recorded server-side and never returned; that asymmetry is the
+   *    entire design). Volume of `scrc.candidate.read` rows for one actor is the
+   *    detection signal, and it only exists if the misses are in there.
+   *
+   * The audit rows are written with `ok: true` even for a miss: `ok: false` is
+   * how the guards mark an AUTHORIZATION denial, and a lookup that found nobody
+   * is not one. Keeping them in one class is what makes "count this actor's
+   * probes" a single query.
+   *
+   * On the FOUND branch it returns displayName and email ONLY — never matric,
+   * telegramHandle or bio. Those live behind userAdmin.get, which is
+   * manager-level and separately guarded. The email is returned deliberately:
+   * the operator is about to hand someone JCRC access and has to eyeball WHO,
+   * this is one target at a time rather than an enumeration, and the audit row
+   * names exactly which target was disclosed.
+   */
+  resolveJcrcCandidate: scrcProcedure
+    .input(z.object({ identifier: z.string().trim().min(1).max(120) }))
+    .query(async ({ ctx, input }): Promise<JcrcCandidateResult> => {
+      requireCapability(caps(ctx.session.user.roles), "manageJcrcRoster");
+      await assertScrcEnabled(ctx.db);
+
+      const raw = input.identifier.trim();
+
+      /**
+       * The audit row, on EVERY exit path. `outcome` is the server-side truth
+       * the caller is NOT told: UNRESOLVED / AMBIGUOUS / NEVER_SIGNED_IN /
+       * TARGET_IS_ADMIN / TARGET_HOLDS_SCRC / FOUND. FOUR of those six are
+       * returned to the client as the same opaque NOT_AVAILABLE — the record is
+       * where the difference is allowed to exist, because only an admin can read
+       * it (`readAuditLog`).
+       *
+       * The probed string is recorded, truncated. It is the only way an admin
+       * investigating a sweep can see WHAT was swept; a row saying merely "a
+       * lookup happened" would not distinguish one operator doing their job
+       * from a dictionary attack. It is bounded at 120 chars by the input schema
+       * and sliced again here so a future schema change cannot grow the field.
+       */
+      const record = async (outcome: string, targetUserID?: string) =>
+        writeAudit(ctx.db, {
+          actorUserID: ctx.session.user.userID,
+          actorRoles: [...(ctx.session.user.roles ?? [])],
+          targetUserID,
+          action: "scrc.candidate.read",
+          reason: `probe=${raw.slice(0, 120)} outcome=${outcome}`,
+          ok: true,
+        });
+
+      // Resolve to a canonical userID by tier. Matric is the only tier that can
+      // be AMBIGUOUS, because it is looked up in a non-unique collection — and
+      // it is decided HERE, before any role or account read, which is what makes
+      // it safe to keep as a distinct status (see JcrcCandidateResult).
+      let candidateID: string | null = null;
+      if (raw.includes("@")) {
+        candidateID = canonicalUserID(raw); // email → canonical, or null
+      } else if (isEFormatUserID(raw.toUpperCase())) {
+        candidateID = raw.toUpperCase(); // NUSNET id is already canonical
+      } else if (MATRIC_RE.test(raw.toUpperCase())) {
+        const rows = await ctx.db.userMatric.findMany({
+          where: { matric: raw.toUpperCase() },
+          select: { userID: true },
+        });
+        if (rows.length > 1) {
+          await record("AMBIGUOUS");
+          return { status: "AMBIGUOUS" };
+        }
+        candidateID = rows[0]?.userID ?? null;
+      }
+
+      if (candidateID === null) {
+        await record("UNRESOLVED");
+        return { status: "NOT_AVAILABLE" };
+      }
+
+      // Must have signed in: a UserRole row is written at account creation and
+      // topped up every session, so "has a row" is a reliable proxy for "has
+      // logged in at least once". A grant to someone with no row would be keyed
+      // on an id no session ever matches — it would appear to succeed and do
+      // nothing (I-1).
+      const roleRow = await ctx.db.userRole.findUnique({
+        where: { userID: candidateID },
+        select: { roles: true, role: true },
+      });
+      if (!roleRow) {
+        // targetUserID IS recorded here even though the caller is told nothing:
+        // the id resolved, so the audit trail can say which one was probed.
+        await record("NEVER_SIGNED_IN", candidateID);
+        return { status: "NOT_AVAILABLE" };
+      }
+
+      const stored = roleRow.roles?.length
+        ? roleRow.roles
+        : roleRow.role
+          ? [roleRow.role]
+          : [];
+      if (stored.includes(ADMIN_ROLE)) {
+        await record("TARGET_IS_ADMIN", candidateID);
+        return { status: "NOT_AVAILABLE" };
+      }
+      // SCREENED FOR THE SAME REASON AS ADMIN, AND THE OMISSION WAS A HOLE THAT
+      // ONLY OPENED WHEN THE TWO PROCEDURES WERE COMPOSED. Each was safe alone:
+      // this one screened admins, and setJcrcRole collapsed five causes into one
+      // opaque SCRC_TARGET_UNAVAILABLE. But a caller could run both —
+      //
+      //   1. resolve(x) -> FOUND, holdsJcrc:false   rules out never-signed-in
+      //                                             (a row exists), admin
+      //                                             (screened) and already-jcrc
+      //   2. setJcrcRole(x, grant:true) -> UNAVAILABLE
+      //
+      // — and step 2 could then only mean TARGET_HOLDS_SCRC. The pair uniquely
+      // identified hall-office accounts, which PART 6 open question 3 decided
+      // this role must not be able to enumerate. Screening `scrc` here removes
+      // step 1's ability to rule the other causes out, so the two answers stop
+      // composing into a third.
+      //
+      // The lesson, worth more than the fix: an opaque failure is only opaque
+      // relative to what ELSE the caller can ask. Any new read added to this
+      // surface must be checked against setJcrcRole's cause set, not just on its
+      // own.
+      if (stored.includes(SCRC_ROLE)) {
+        await record("TARGET_HOLDS_SCRC", candidateID);
+        return { status: "NOT_AVAILABLE" };
+      }
+
+      // Best-effort display. There is no reverse canonical→User query, so guess
+      // the email like listUsers does, and fall back to the stored key.
+      const user = await ctx.db.user.findFirst({
+        where: {
+          OR: [
+            {
+              email: {
+                equals: `${candidateID.toLowerCase()}@u.nus.edu`,
+                mode: "insensitive",
+              },
+            },
+            { userID: candidateID },
+          ],
+        },
+        // Never a bare read: passwordHash must not leave the server, and a
+        // Google-adapter row lacking it throws on deserialization (I-2).
+        select: { displayName: true, email: true },
+      });
+
+      await record("FOUND", candidateID);
+
+      return {
+        status: "FOUND",
+        userID: candidateID,
+        displayName: user?.displayName ?? null,
+        email: user?.email ?? null,
+        holdsJcrc: stored.includes(JCRC_ROLE),
+      };
+    }),
+
+  /**
+   * THE hall-office write: add or remove `jcrc` on one account. Nothing else.
+   *
+   * It is a dedicated mutation rather than a widening of setUserRoles because
+   * the FINAL SET IS CONSTRUCTED SERVER-SIDE from the target's current roles ±
+   * jcrc. An scrc caller therefore cannot express the removal of another user's
+   * `cca_head`, `scrc` or `admin` — not "is refused when they try", but has no
+   * way to say it. setUserRoles' payload could say all of that and would then
+   * depend entirely on G4 to catch it, on a surface G4 has never had to defend.
+   *
+   * SELF-TARGETING IS REFUSED OUTRIGHT, before the guards. G6 already denies a
+   * non-admin self-granting a role they lack, so this is the second of two
+   * independent guards — but G6's condition is `!actorRoles.includes(r)`, so if
+   * a hall-office member is ever ALSO granted `jcrc` by an admin, G6 stops
+   * firing and self-targeting becomes reachable through exactly this surface.
+   * Belt and braces at the surface that created the risk. The denial is audited
+   * with its own denyReason so it is greppable independently of G6's.
+   *
+   * The `before` read below is DELIBERATELY ADVISORY. applyRoleChange's
+   * in-transaction compare-and-set (CONFLICT_ROLES_CHANGED) is the real
+   * protection against the TOCTOU between this read and the write; do not
+   * "optimise" the read away or reason as though it were authoritative.
+   *
+   * ------------------------------------------------------------------------
+   * THE OPAQUE-FAILURE RULE, and why this mutation is not just a write.
+   * ------------------------------------------------------------------------
+   * `sanitizeErrors` (trpc.ts) rewrites INTERNAL_SERVER_ERROR only — every
+   * FORBIDDEN message reaches the client verbatim, and its own comment says so.
+   * So a mutation that answers "why not" is an ORACLE, and this one sat next to
+   * resolveJcrcCandidate answering the same question the resolver had just been
+   * rewritten to stop answering:
+   *
+   *     setJcrcRole({ userID: "E1234567", grant: false })
+   *
+   * Revoking `jcrc` from somebody who does not hold it used to be a harmless
+   * SUCCESSFUL no-op, so the probe was non-destructive, repeatable and silent —
+   * and G3 answered `CANNOT_MODIFY_AN_ADMIN` for an admin. One call per target,
+   * perfectly reliable, and the admin roster falls out.
+   *
+   * TWO CHANGES CLOSE IT:
+   *
+   *  1. EVERY TARGET-DEPENDENT REFUSAL RETURNS ONE OPAQUE MESSAGE,
+   *     `SCRC_TARGET_UNAVAILABLE` — the same one for "no account", "never signed
+   *     in", "holds admin", "holds scrc" and "the change would be a no-op". The
+   *     REAL reason is written to the audit row every time, where only an admin
+   *     (`readAuditLog`) can read it. Client sees one bit; the record keeps five.
+   *  2. THE NO-OPS ARE FAILURES, NOT SUCCESSES. Success itself is a signal, so
+   *     granting `jcrc` to somebody who already holds it, and revoking it from
+   *     somebody who does not, both refuse. The ONLY distinguishable success is
+   *     therefore a genuine state change — which is loud, audited, reversible,
+   *     and visible in the roster the actor is already allowed to read.
+   *
+   * G3 IS NOT WEAKENED. It still fires, still audits, still refuses; this
+   * mutation simply pre-empts it with its own check and, as a backstop for the
+   * narrow race where a target gains `admin` mid-request, RE-MAPS the
+   * target-discriminating messages on the way out (TARGET_DISCRIMINATING below).
+   * Other callers of assertCanMutateRoles are untouched and still get the
+   * specific reason.
+   *
+   * HONEST RESIDUAL — what an `scrc` caller can STILL infer:
+   *
+   *  - Whether a target currently holds `jcrc`, to a certainty, in ONE call:
+   *    `grant: false` succeeding means they held it. That is not a leak — the
+   *    JCRC roster is exactly what listJcrcRoster hands this caller by design,
+   *    and it is the roster they are employed to manage.
+   *  - That a target is "unavailable" — i.e. SOME ONE of {no account, never
+   *    signed in, holds admin, holds scrc}. The partition is not resolvable
+   *    from the response: all four are one message, and all four are also what
+   *    resolveJcrcCandidate reports as NOT_AVAILABLE, so the two surfaces agree
+   *    and neither can be used to split the other's answer.
+   *
+   *    THAT AGREEMENT IS LOAD-BEARING AND WAS ONCE FALSE. While the resolver
+   *    still reported a hall-office account as FOUND, the PAIR of calls was a
+   *    sharper instrument than either one: a FOUND with holdsJcrc:false ruled
+   *    out never-signed-in, admin and already-jcrc, so a subsequent UNAVAILABLE
+   *    could only mean "holds scrc". Both surfaces must therefore screen the
+   *    SAME set. Before adding a read to this surface, check it against this
+   *    cause list — an opaque failure is only opaque relative to what else the
+   *    caller can ask.
+   *  - COST OF PROBING: unlike the resolver, every attempt here is a MUTATION
+   *    that writes a `denied` audit row naming the actor and the target. A sweep
+   *    of the hall is ~1200 rows under one actorUserID — the loudest thing this
+   *    role can do. That is the intended trade: the oracle is closed, and the
+   *    residual inference is expensive and self-reporting.
+   *  - NOT closed, and not closeable here: an actor who holds BOTH the hall
+   *    office and some other privilege could correlate. EXCLUSIVE_ROLE_PAIRS
+   *    already forbids the jcrc+scrc case, which is the one that mattered.
+   */
+  setJcrcRole: scrcProcedure
+    .input(
+      z.object({
+        userID: userIDSchema,
+        grant: z.boolean(),
+        reason: z.string().trim().max(500).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      requireCapability(caps(ctx.session.user.roles), "manageJcrcRoster");
+      await assertScrcEnabled(ctx.db);
+
+      const actorUserID = ctx.session.user.userID;
+      const actorSessionRoles = [...(ctx.session.user.roles ?? [])];
+
+      if (input.userID === actorUserID) {
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles: actorSessionRoles,
+          targetUserID: input.userID,
+          action: "denied",
+          ok: false,
+          denyReason: "SCRC_CANNOT_SELF_TARGET",
+        });
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "SCRC_CANNOT_SELF_TARGET",
+        });
+      }
+
+      /**
+       * Refuse opaquely, recording the REAL reason. `denyReason` is the
+       * server-side truth; the thrown message is the single bit the client gets.
+       * Deliberately mirrors resolveJcrcCandidate's record()/NOT_AVAILABLE
+       * split, so the two surfaces cannot be played against each other.
+       *
+       * RETURNS the error for the caller to `throw` rather than throwing
+       * itself: an `await`ed call typed `Promise<never>` does NOT narrow control
+       * flow in TypeScript, so `if (!row) await unavailable(...)` would leave
+       * `row` still nullable below and invite a `!` on exactly the lines that
+       * decide what this mutation does. `throw await unavailable(...)` narrows
+       * properly and keeps the audit write on the same statement.
+       */
+      const unavailable = async (denyReason: string): Promise<TRPCError> => {
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles: actorSessionRoles,
+          targetUserID: input.userID,
+          action: "denied",
+          ok: false,
+          denyReason,
+          reason: input.reason,
+        });
+        return new TRPCError({
+          code: "FORBIDDEN",
+          message: "SCRC_TARGET_UNAVAILABLE",
+        });
+      };
+
+      // N2: THE EXISTENCE GATE, which resolveJcrcCandidate enforces and this
+      // mutation did not. applyRoleChange ends in an `upsert`, so without this
+      // `setJcrcRole({ userID: "E9999999", grant: true })` MINTS a UserRole row
+      // holding `jcrc` for an id no session will ever match — a phantom grant
+      // that reports success, does nothing forever, and shows up in the roster
+      // and in every jcrc count as if it were a person (I-1). A UserRole row is
+      // written at account creation and topped up every session, so "has a row"
+      // is the same has-signed-in proxy the resolver uses.
+      const targetRow = await ctx.db.userRole.findUnique({
+        where: { userID: input.userID },
+        select: { roles: true, role: true },
+      });
+      if (!targetRow) throw await unavailable("TARGET_NEVER_SIGNED_IN");
+
+      const storedAll = targetRow.roles?.length
+        ? targetRow.roles
+        : targetRow.role
+          ? [targetRow.role]
+          : [];
+
+      // G3's question, asked HERE so G3's ANSWER never reaches this client.
+      if (storedAll.includes(ADMIN_ROLE)) {
+        throw await unavailable("TARGET_IS_ADMIN");
+      }
+      // G8's question, likewise. Without this the exclusion invariant would
+      // itself become an oracle for "who holds scrc" — which open question 3
+      // decided this role must NOT be able to enumerate.
+      if (storedAll.includes(SCRC_ROLE)) {
+        throw await unavailable("TARGET_HOLDS_SCRC");
+      }
+
+      // THE NO-OPS. Both used to succeed, and a success that changes nothing is
+      // a free, silent read of the target's state. Refusing turns the only
+      // distinguishable success into a real, audited state change.
+      const holdsJcrc = storedAll.includes(JCRC_ROLE);
+      if (input.grant && holdsJcrc) {
+        throw await unavailable("TARGET_ALREADY_JCRC");
+      }
+      if (!input.grant && !holdsJcrc) {
+        throw await unavailable("TARGET_NOT_JCRC");
+      }
+
+      const before = (await getUserRoles(ctx.db, input.userID)).filter(
+        isGrantableRole,
+      );
+      const requestedRoles = input.grant
+        ? [...new Set<string>([...before, JCRC_ROLE])]
+        : before.filter((r) => r !== JCRC_ROLE);
+
+      try {
+        const {
+          actorRoles,
+          before: guardedBefore,
+          after,
+          added,
+          removed,
+        } = await assertCanMutateRoles({
+          db: ctx.db,
+          actorUserID,
+          targetUserID: input.userID,
+          requestedRoles,
+        });
+
+        // Same threading rule as setUserRoles: `added`/`removed` are the
+        // AUTHORISED delta and applyRoleChange asserts on `removed` (I-8c), so a
+        // caller must not be able to skip that by passing only `after`.
+        await applyRoleChange({
+          db: ctx.db,
+          actorUserID,
+          actorRoles,
+          targetUserID: input.userID,
+          before: guardedBefore,
+          after,
+          added,
+          removed,
+          reason: input.reason,
+        });
+        // DELIBERATELY NOT applyRoleChange's returned role set, which
+        // setUserRoles does return. That set is the target's full grantable
+        // roles, so it would disclose `cca_head` — re-linking a person to a CCA
+        // headship the read-only tier now has redacted ids for — as a side
+        // effect of an unrelated write. `grant` is echoed instead of read back:
+        // the mutation succeeded, so the target's jcrc state is exactly what was
+        // asked for, and the panel refetches listJcrcRoster anyway.
+        return { userID: input.userID, holdsJcrc: input.grant };
+      } catch (err) {
+        // THE RACE BACKSTOP. The four checks above read the target's roles in an
+        // EARLIER statement; if the target gains `admin` or `scrc` between that
+        // read and the guards, G3 or G8 fires and its specific message would
+        // escape to the client — restoring the oracle through a window the
+        // attacker cannot steer but does not need to. So any TARGET-DEPENDENT
+        // message is flattened on the way out.
+        //
+        // ALLOWLIST, not a blanket catch: the actor-dependent refusals
+        // (CANNOT_GRANT_JCRC, NOT_A_ROLE_MANAGER, CAPABILITY_REQUIRED:*) are
+        // identical for EVERY target, so they disclose nothing about anyone and
+        // are far more useful to the operator left intact. CONFLICT_ROLES_CHANGED
+        // likewise reports a race, not a property of the target.
+        //
+        // The guards have ALREADY written their own audit row before throwing
+        // (assertCanMutateRoles' deny() is audited outside any transaction,
+        // I-15), so the real reason is on the record without writing a second.
+        if (err instanceof TRPCError && TARGET_DISCRIMINATING.has(err.message)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "SCRC_TARGET_UNAVAILABLE",
+          });
+        }
+        throw err;
+      }
+    }),
 
   /** The one single-user role mutation. Takes the DESIRED FINAL grantable set. */
   setUserRoles: roleManagerProcedure
     .input(
       z.object({
-        userID: userIDSchema,
+        // roleTargetUserIDSchema, NOT userIDSchema: this is the ONE mutation
+        // through which the EXT namespace can receive a role, and it is the
+        // only way to grant `scrc` to an allowlist-pinned hall-office account.
+        // Everything downstream is unchanged — G1..G8 still run, G7 now demands
+        // a LIVE AuthAllowlist row for an EXT target (a proof, not a shape),
+        // and the write still goes through applyRoleChange's transaction.
+        userID: roleTargetUserIDSchema,
         roles: roleSchema.array().max(8),
         reason: z.string().trim().max(500).optional(),
       }),
@@ -1691,7 +2566,14 @@ export const adminRouter = createTRPCRouter({
    * user base.
    */
   explainAccess: roleManagerProcedure
-    .input(z.object({ userID: userIDSchema, facilityID: z.number().int() }))
+    // Widened to the EXT namespace: read-only, roleManagerProcedure, and
+    // already audited on every call. It is the ONLY tool for triaging "why
+    // can't the hall office book room N", so leaving it E-format-only would
+    // make the one account this phase exists for the one account nobody can
+    // debug.
+    .input(
+      z.object({ userID: roleTargetUserIDSchema, facilityID: z.number().int() }),
+    )
     .query(async ({ ctx, input }) => {
       const [decision, requiredRoles, roles] = await Promise.all([
         // No email argument, deliberately: this evaluates AS the target, and
@@ -1856,11 +2738,300 @@ export const adminRouter = createTRPCRouter({
       return { mode: input.mode };
     }),
 
+  /* ---------------------------------------------------------------------- */
+  /* THE D-7 BREAK-GLASS ALLOWLIST (AuthAllowlist)                           */
+  /*                                                                         */
+  /* THE MOST DANGEROUS SURFACE IN THIS FILE, and the only one that creates  */
+  /* an IDENTITY rather than moving a privilege around on top of one. A row  */
+  /* here is what lets a non-@u.nus.edu address hold a session key at all.   */
+  /*                                                                         */
+  /* Read services/authAllowlist.ts before changing anything below — it      */
+  /* states the attack (05-verification.md:164) and the four mechanisms.     */
+  /* These procedures are M4, the LAST of the four, and the weakest: they    */
+  /* only govern the writes they can see. M1 (the ':' making the namespaces  */
+  /* provably disjoint) and M2 (re-validation at every READ) are what make a */
+  /* row hand-typed into Atlas mint nothing. Do not weaken these on the      */
+  /* grounds that M2 exists, and do not weaken M2 on the grounds that these  */
+  /* exist.                                                                  */
+  /*                                                                         */
+  /* adminProcedure throughout — NOT roleManagerProcedure and NOT            */
+  /* scrcProcedure. An scrc holder must not see or edit the collection that  */
+  /* issued its own identity.                                                */
+  /*                                                                         */
+  /* THERE IS DELIBERATELY NO UPDATE MUTATION. A pin is immutable; changing  */
+  /* which address owns a key is remove-then-add, i.e. two audit rows and    */
+  /* two deliberate acts.                                                    */
+  /* ---------------------------------------------------------------------- */
+
+  listAuthAllowlist: adminProcedure.query(async ({ ctx }) => {
+    const rows = await ctx.db.authAllowlist.findMany({
+      orderBy: { addedAt: "desc" },
+      // No cursor. This collection is meant to hold single digits; if it ever
+      // needs paging, that fact is itself the alert. The cap is a bound, not a
+      // page size.
+      take: 100,
+    });
+
+    // Hydrate what the operator actually needs to answer "is this pin doing
+    // anything, and to whom" — WITHOUT which the panel is a list of opaque
+    // strings and the natural next step is to go poke at Mongo by hand.
+    const emails = rows.map((r) => r.email);
+    const [users, roleRows] = await Promise.all([
+      ctx.db.user.findMany({
+        where: { email: { in: emails, mode: "insensitive" } },
+        // NEVER a bare findMany — passwordHash must not reach the client, and a
+        // passwordHash-less row throws on a full read (I-2). Same rule as
+        // listUsers.
+        select: { email: true, displayName: true, userID: true },
+      }),
+      ctx.db.userRole.findMany({
+        where: { userID: { in: rows.map((r) => r.pinnedUserID) } },
+        select: { userID: true, roles: true, role: true },
+      }),
+    ]);
+    const byEmail = new Map(
+      users.map((u) => [normalizeEmail(u.email), u] as const),
+    );
+    const byPin = new Map(roleRows.map((r) => [r.userID, r] as const));
+
+    return {
+      items: rows.map((r) => {
+        const u = byEmail.get(normalizeEmail(r.email));
+        const rr = byPin.get(r.pinnedUserID);
+        return {
+          email: r.email,
+          pinnedUserID: r.pinnedUserID,
+          /**
+           * M2 SURFACED TO THE OPERATOR. A stored pin outside the namespace
+           * mints no identity — the session path drops it silently — so
+           * without this flag the panel would show a row that looks live and
+           * is not, and the only symptom would be a user who cannot log in.
+           * It can only arise from a hand edit in Atlas or a code path that
+           * bypassed the zod schema; either way the operator should see it.
+           */
+          namespaceViolation: !isExtUserID(r.pinnedUserID),
+          note: r.note,
+          addedBy: r.addedBy,
+          addedAt: r.addedAt,
+          hasUser: Boolean(u),
+          displayName: u?.displayName ?? null,
+          /**
+           * True when the provisioned `User.userID` does NOT hold the pin.
+           * Cosmetic-looking, load-bearing: facilitiesBooking joins
+           * booking -> owner on `User.userID`, so a mismatch renders every
+           * hall-office booking with a blank owner name.
+           */
+          keyMismatch: Boolean(u && u.userID !== r.pinnedUserID),
+          roles: rr?.roles?.length ? rr.roles : rr?.role ? [rr.role] : [],
+        };
+      }),
+    };
+  }),
+
+  addAuthAllowlistEntry: adminProcedure
+    .input(
+      z.object({
+        email: z
+          .string()
+          .trim()
+          .email()
+          .max(254)
+          // I-12: THE shared normalizer, applied at the boundary so the stored
+          // value matches `User.email` byte for byte. `email_unique_ci` folds
+          // CASE but not WHITESPACE, so a stray space here is a row that can
+          // never be joined to its account.
+          .transform(normalizeEmail),
+        pinnedUserID: extUserIDSchema,
+        note: z.string().trim().max(200).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const actorUserID = ctx.session.user.userID;
+      const actorRoles = ctx.session.user.roles ?? [];
+
+      const refuse = async (reason: string, code: TRPCError["code"]) => {
+        // Audited BEFORE throwing, on the same argument writeAudit's other
+        // callers make (I-15): there is no state change to lose, and a probing
+        // attempt at the IDENTITY-ISSUING surface is exactly what must leave a
+        // trail.
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: input.pinnedUserID,
+          action: "denied",
+          reason: input.email,
+          ok: false,
+          denyReason: reason,
+        });
+        throw new TRPCError({ code, message: reason });
+      };
+
+      /* REFUSAL 1 — EMAIL_IS_CANONICAL.
+       * The address already HAS an identity: canonicalUserID derives one from
+       * it, and every UserRole/Booking/UserMatric row this human owns is filed
+       * under that. Pinning it to an EXT key would give ONE HUMAN TWO
+       * IDENTITIES, which is the duplicate-account failure the whole
+       * merge-by-canonical toolchain exists to clean up — except this time
+       * issued deliberately, by an admin, in one click.
+       *
+       * `isNusStudentEmail` rather than `canonicalUserID(...) !== null` because
+       * the two are exactly equivalent (asserted per fixture by the parity
+       * gate) and this reads as the question being asked. */
+      if (isNusStudentEmail(input.email)) {
+        await refuse("EMAIL_IS_CANONICAL", "BAD_REQUEST");
+      }
+
+      /* REFUSAL 2 — PIN_ALREADY_HAS_ROLES.
+       * DEFENCE IN DEPTH BEHIND M3. If a UserRole row already exists under
+       * this key, then either it is a live privileged identity (in which case
+       * this call is an attempt to re-aim it at a new address — THE attack,
+       * one namespace over) or it is residue from a removed pin (in which case
+       * the roles must be revoked through the audited role path first, so the
+       * new holder does not inherit them silently).
+       *
+       * The unique index (M3) already stops a SECOND row for the same pin.
+       * This refusal is what covers the case where the first row was deleted
+       * and its roles were not — the exact 07-cca-future.md §5 hazard that
+       * userAdmin's PINNED_ALLOWLIST_ACCOUNT refusal guards from the other
+       * direction. Two locks, opposite doors. */
+      if ((await getUserRoles(ctx.db, input.pinnedUserID)).length > 0) {
+        await refuse("PIN_ALREADY_HAS_ROLES", "CONFLICT");
+      }
+
+      /* REFUSAL 3 — the unique indexes, i.e. M3 SURFACING.
+       * Deliberately NOT a pre-read: a findFirst-then-create is a TOCTOU, and
+       * the index is the thing that actually decides. Catch P2002 and
+       * translate, so the operator gets a sentence instead of a Prisma dump —
+       * and so a MISSING index (create-auth-allowlist.mjs never run) shows up
+       * as "the second insert succeeded", which rbac-doctor's uniqueness check
+       * then reports from the data. */
+      try {
+        await ctx.db.authAllowlist.create({
+          data: {
+            email: input.email,
+            pinnedUserID: input.pinnedUserID,
+            note: input.note ?? null,
+            addedBy: actorUserID,
+          },
+        });
+      } catch (err) {
+        if ((err as { code?: string } | null)?.code !== "P2002") throw err;
+        // WHICH index rejected it is determined FROM THE DATA, not from
+        // `err.meta.target`. On the Mongo connector that field is unreliable —
+        // it can be the index name, the field list, or absent — and getting it
+        // wrong here means telling the operator to fix the wrong half of the
+        // row. Two indexed reads, on a path that has already failed and is
+        // about to throw, buys a message that is actually true.
+        const [emailTaken, pinTaken] = await Promise.all([
+          ctx.db.authAllowlist.findUnique({
+            where: { email: input.email },
+            select: { id: true },
+          }),
+          ctx.db.authAllowlist.findUnique({
+            where: { pinnedUserID: input.pinnedUserID },
+            select: { id: true },
+          }),
+        ]);
+        // If NEITHER probe finds a row, the conflicting document was removed
+        // between the failed insert and these reads. Refuse anyway — the write
+        // did not happen, and "retry" is the honest instruction.
+        await refuse(
+          emailTaken
+            ? "EMAIL_ALREADY_PINNED"
+            : pinTaken
+              ? "PIN_ALREADY_USED"
+              : "ALLOWLIST_CONFLICT",
+          "CONFLICT",
+        );
+      }
+
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles,
+        targetUserID: input.pinnedUserID,
+        action: "authAllowlist.add",
+        // The pinned ADDRESS goes in `reason`: RoleAuditLog has no email
+        // column, and "which address was handed this key" is the one fact this
+        // row exists to preserve.
+        reason: input.email,
+      });
+
+      // WITHOUT THIS the new pin is invisible for up to 15 seconds — including
+      // to the very next page the operator loads — and the natural response is
+      // to click Add again.
+      resetAuthAllowlistCache();
+      return { email: input.email, pinnedUserID: input.pinnedUserID };
+    }),
+
+  removeAuthAllowlistEntry: adminProcedure
+    .input(
+      z.object({
+        pinnedUserID: extUserIDSchema,
+        reason: z.string().trim().max(500).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const actorUserID = ctx.session.user.userID;
+      const actorRoles = ctx.session.user.roles ?? [];
+
+      const refuse = async (reason: string, code: TRPCError["code"]) => {
+        await writeAudit(ctx.db, {
+          actorUserID,
+          actorRoles,
+          targetUserID: input.pinnedUserID,
+          action: "denied",
+          ok: false,
+          denyReason: reason,
+        });
+        throw new TRPCError({ code, message: reason });
+      };
+
+      const row = await ctx.db.authAllowlist.findUnique({
+        where: { pinnedUserID: input.pinnedUserID },
+      });
+      if (!row) await refuse("NO_SUCH_PIN", "NOT_FOUND");
+
+      /* PIN_STILL_HOLDS_ROLES.
+       * Removing the pin revokes the IDENTITY but leaves the UserRole document
+       * standing under that key. Re-issuing the same pin to a different address
+       * later — or re-creating a User row on the old one — would then hand the
+       * new holder the old holder's roles with no grant path and therefore no
+       * escalation guard firing. That is 07-cca-future.md §5's hazard, and it
+       * is the same shape as the attack this whole collection is designed
+       * against.
+       *
+       * The remedy is two ordered, separately audited acts: revoke the roles
+       * through admin.setUserRoles, THEN remove the pin. Refusing here is what
+       * forces that order. */
+      if ((await getUserRoles(ctx.db, input.pinnedUserID)).length > 0) {
+        await refuse("PIN_STILL_HOLDS_ROLES", "CONFLICT");
+      }
+
+      await ctx.db.authAllowlist.delete({
+        where: { pinnedUserID: input.pinnedUserID },
+      });
+      await writeAudit(ctx.db, {
+        actorUserID,
+        actorRoles,
+        targetUserID: input.pinnedUserID,
+        action: "authAllowlist.remove",
+        reason: input.reason ?? row?.email,
+      });
+      // Revocation must be LIVE. Without this the removed identity keeps
+      // resolving for up to 15 seconds after the operator was told it was gone.
+      resetAuthAllowlistCache();
+      return { pinnedUserID: input.pinnedUserID };
+    }),
+
   listAuditLog: adminProcedure
     .input(
       z.object({
-        targetUserID: userIDSchema.optional(),
-        actorUserID: userIDSchema.optional(),
+        // Widened to the EXT namespace. Read-only, adminProcedure. Without it
+        // the audit trail FOR the hall office cannot be filtered — on the one
+        // surface whose entire purpose is oversight of this role, and for the
+        // one principal whose identity was issued by hand.
+        targetUserID: roleTargetUserIDSchema.optional(),
+        actorUserID: roleTargetUserIDSchema.optional(),
         action: z.string().max(32).optional(),
         batchId: z.string().max(64).optional(),
         limit: z.number().int().min(1).max(100).default(25),
@@ -2640,6 +3811,17 @@ export const adminRouter = createTRPCRouter({
               : `CANNOT_GRANT_${bad.toUpperCase()}`,
             hit.userID,
           );
+          continue;
+        }
+        // G8 at the QUEUE. redeemPendingGrants re-checks this at redemption
+        // against the target's roles at the time — that is the authoritative
+        // check, since a target can acquire the other half of the pair between
+        // now and their first login. This one is here so a row that can NEVER
+        // redeem is refused while there is still a human looking at the result,
+        // rather than failing silently months later on a login nobody watches.
+        const combination = forbiddenRoleCombination(row.roles);
+        if (combination) {
+          await deny(combination, hit.userID);
           continue;
         }
         if (row.roles.includes(ADMIN_ROLE)) {

--- a/src/server/api/routers/cca.ts
+++ b/src/server/api/routers/cca.ts
@@ -1,11 +1,22 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
-import { createTRPCRouter, identifiedProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  identifiedProcedure,
+  oversightProcedure,
+} from "~/server/api/trpc";
 import { getUserRoles } from "~/server/api/services/access";
 import { computeCapabilities, isEFormatUserID } from "~/server/api/services/roles";
-import { assertHeadsCca } from "~/server/api/services/ccaScope";
-import { resolveRoster } from "~/server/api/services/ccaRoster";
+import {
+  assertHeadsCca,
+  assertMayViewCcaRoster,
+} from "~/server/api/services/ccaScope";
+import { assertScrcEnabled } from "~/server/api/services/scrcFlag";
+import {
+  redactRosterForReadOnly,
+  resolveRoster,
+} from "~/server/api/services/ccaRoster";
 import { randomUUID } from "node:crypto";
 
 import { del } from "@vercel/blob";
@@ -33,13 +44,33 @@ import { canonicalUserID } from "~/lib/identity";
  * validator-guarded `CCA` collection is never written from here.
  *
  * THE ONE RULE IN THIS FILE: every procedure that takes a ccaID FROM THE CLIENT
- * MUST call assertHeadsCca before touching CCA-scoped data. The procedure
- * builder does NOT do it for you — identifiedProcedure only narrows identity. A
- * procedure here that forgets the guard is a full-roster IDOR across all 89
- * CCAs.
+ * MUST call assertHeadsCca — or, for a roster READ only, assertMayViewCcaRoster
+ * — before touching CCA-scoped data. The procedure builder does NOT do it for
+ * you — identifiedProcedure only narrows identity. A procedure here that forgets
+ * the guard is a full-roster IDOR across all 89 CCAs.
  *
+ *     grep -nE "assertHeadsCca|assertMayViewCcaRoster" src/server/api/routers/cca.ts
  *     grep -n "input.ccaID" src/server/api/routers/cca.ts
- *     → every hit must sit in a procedure whose body also names assertHeadsCca.
+ *     → every hit of the second must sit in a procedure whose body also names
+ *       one of the two guards.
+ *
+ * THE TWO ARE NOT INTERCHANGEABLE. assertMayViewCcaRoster is a strictly WIDER
+ * gate: it additionally admits the hall office (viewCcaRostersReadOnly), who may
+ * look at a roster and nothing else. It is therefore NOT a substitute for
+ * assertHeadsCca on a write, nor on a read that carries PII — using it on
+ * updateProfile, removeMembers, handoverHeads or memberDirectory (matric /
+ * telegram / bio) would hand those to a read-only role in one line. Writes and
+ * PII reads stay on assertHeadsCca; only getRoster and listHeads take the wider
+ * guard.
+ *
+ * AND THE WIDER GUARD IS NOT THE WHOLE STORY — BOTH OF THOSE TWO ALSO REDACT.
+ * A full roster carries every member's email, stored userID and raw membership
+ * keys (mostly A-format matrics), and listHeads carries every head's email, so
+ * "the guard let them in" is only half the boundary. Each branches on
+ * `scope.via === "readOnly"` and strips identifiers down to names, headship and
+ * grant dates for that tier alone; heads and managers are byte-identical to
+ * before. If you add a third procedure to this guard, it inherits the
+ * obligation: check `scope.via` and decide what the read-only tier may see.
  *
  * The gate is on `input.ccaID` SPECIFICALLY, not on the string "ccaID". listMine
  * touches ccaID a dozen times and needs no guard, because every id it handles
@@ -142,6 +173,14 @@ export const ccaRouter = createTRPCRouter({
    * THE security boundary for both /cca/[ccaID] and /admin/ccas. Neither page
    * pre-guards — a client can call this from the console on any page, so the
    * layouts are defence in depth only (I-7).
+   *
+   * Guarded by assertMayViewCcaRoster, NOT assertHeadsCca, and this is the only
+   * difference between the two: a roster is names + grant dates, so the hall
+   * office may read one without being able to touch anything. Admin, jcrc and a
+   * genuine head take branches 1 and 2 of that guard, which are byte-for-byte
+   * assertHeadsCca — so their answer, their `via` and their query count are
+   * unchanged, and they never touch the `scrc.enabled` flag read. The flag check
+   * for the read-only tier lives INSIDE the guard; do not repeat it here.
    */
   getRoster: identifiedProcedure
     // .positive(), not .nonnegative(): ccaID 0 is RESERVED (see cascade.ts) and
@@ -151,9 +190,22 @@ export const ccaRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const userID = ctx.session.user.userID;
       const roles = await getUserRoles(ctx.db, userID); // I-5 live read
-      const scope = await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+      const scope = await assertMayViewCcaRoster(
+        ctx.db,
+        { userID, roles },
+        input.ccaID,
+      );
       const roster = await resolveRoster(ctx.db, input.ccaID);
-      return { ...roster, via: scope.via };
+      // THE READ-ONLY TIER GETS NAMES, NOT IDENTIFIERS. A full roster carries
+      // every member's email, stored userID and raw membership keys (mostly
+      // A-format matrics); a caller who can enumerate all 89 CCAs would
+      // reassemble most of admin.listUsers from them. Keyed off `scope.via`,
+      // which only assertMayViewCcaRoster can set to "readOnly", so a head or a
+      // manager takes the untouched branch and sees exactly what they always
+      // have. See redactRosterForReadOnly.
+      const visible =
+        scope.via === "readOnly" ? redactRosterForReadOnly(roster) : roster;
+      return { ...visible, via: scope.via };
     }),
 
   /**
@@ -537,15 +589,37 @@ export const ccaRouter = createTRPCRouter({
    * the email and also match the stored key), while still returning the
    * authoritative CcaHead.userID that Remove needs.
    *
-   * Guarded by assertHeadsCca, so it works for a manager (manageCcaHeads) on any
-   * CCA and for a head on their own — the same gate as the rest of this router.
+   * Guarded by assertMayViewCcaRoster, so it works for a manager
+   * (manageCcaHeads) on any CCA, for a head on their own, and — through branch 3
+   * of that guard, behind the `scrc.enabled` switch — for the hall office
+   * read-only. It is the roster's other half: who leads this CCA is exactly the
+   * question the hall office asks.
+   *
+   * THE ANSWER IS NOT THE SAME FOR ALL THREE. A manager or a head gets name,
+   * EMAIL and grant date — unchanged, and identical to what /admin/ccas has
+   * always shown. The read-only tier gets name and grant date with the email
+   * NULLED, because 89 CCAs' worth of head addresses is a contact list, and
+   * building one out of a read-only capability is the disclosure requirement 8
+   * withholds. Matric, telegram and bio are absent for everyone here — those
+   * live in memberDirectory, which stays on assertHeadsCca.
+   *
+   * NOT a licence to write: Remove-head still goes through admin.setCcaHeads /
+   * cca.handoverHeads, both of which re-guard with assertHeadsCca.
    */
   listHeads: identifiedProcedure
     .input(z.object({ ccaID: z.number().int().positive() }))
     .query(async ({ ctx, input }) => {
       const userID = ctx.session.user.userID;
       const roles = await getUserRoles(ctx.db, userID); // I-5 live read
-      await assertHeadsCca(ctx.db, { userID, roles }, input.ccaID);
+      const scope = await assertMayViewCcaRoster(
+        ctx.db,
+        { userID, roles },
+        input.ccaID,
+      );
+      // Same rule as getRoster: the read-only tier gets NAMES, not addresses.
+      // 89 CCAs x their heads is a contact list, and assembling one is exactly
+      // what `viewCcaRostersReadOnly` promises not to allow.
+      const readOnly = scope.via === "readOnly";
 
       const heads = await ctx.db.ccaHead.findMany({
         where: { ccaID: input.ccaID },
@@ -584,9 +658,23 @@ export const ccaRouter = createTRPCRouter({
 
       return {
         heads: heads.map((h) => ({
-          userID: h.userID,
+          // NULLED FOR THE READ-ONLY TIER TOO, and the earlier defence for
+          // keeping it ("it is the row's own primary key") was simply wrong.
+          // `CcaHead.userID` is a canonical E-format id, and this very
+          // procedure derives the address from it four lines up:
+          // `E1234567` -> `e1234567@u.nus.edu`. Returning the id while nulling
+          // the email hands back the same contact list one derivation later, so
+          // a loop over listAllForOversight -> listHeads would still reassemble
+          // name + email for every head in the hall. It also contradicted
+          // redactRosterForReadOnly, which nulls `storedUserID` for exactly
+          // this reason — two paths, one rule.
+          //
+          // Nothing renders this for the read-only tier (the only caller is
+          // /admin/ccas' CcaHeadsManager, which is manager-gated), so nulling
+          // costs no UI. A manager or head is unaffected.
+          userID: readOnly ? null : h.userID,
           displayName: byKey.get(h.userID)?.displayName ?? null,
-          email: byKey.get(h.userID)?.email ?? null,
+          email: readOnly ? null : (byKey.get(h.userID)?.email ?? null),
           grantedAt: h.grantedAt,
         })),
       };
@@ -743,4 +831,62 @@ export const ccaRouter = createTRPCRouter({
         selfRemoved: revoked.includes(userID),
       };
     }),
+
+  /* --------------------------- OVERSIGHT (read-only) ---------------------- */
+
+  /**
+   * Every CCA's NAME, for the hall office's CCA picker. A name list and nothing
+   * else — no heads, no members, no counts.
+   *
+   * WHY A NEW PROCEDURE. The two existing "all the CCAs" lists are both out of
+   * reach and both for good reasons: admin.listCcas requires manageCcaHeads
+   * (admin.ts) — the capability that makes assertHeadsCca pass unconditionally,
+   * i.e. full write on all 89 CCAs — and ccaApplications.browse sits behind a
+   * DIFFERENT kill switch (`cca.applications.enabled`), so the CCA picker would
+   * go dark whenever applications are off. Neither is a usable CCA list for the
+   * hall office, and widening either would cost far more than it buys. The
+   * projection is deliberately IDENTICAL to admin.listCcas' so the two cannot
+   * drift into disagreeing about what a "CCA list" is.
+   *
+   * WHY oversightProcedure AND NOT identifiedProcedure, which every other
+   * procedure in this file uses. Those are object-scoped: the client names a
+   * ccaID and the guard is the entire boundary, so the builder answers nothing.
+   * This one takes NO input — there is no object to scope to — so the role gate
+   * IS the boundary and a role-gated builder is the honest way to say so.
+   *
+   * This list is NOT an authorization. It grants no read of any roster: every
+   * ccaID the picker hands back is authorised again, per-CCA, by
+   * assertMayViewCcaRoster inside getRoster / listHeads. A leaked name buys an
+   * attacker a number that is already public in the booking UI.
+   */
+  listAllForOversight: oversightProcedure.query(async ({ ctx }) => {
+    const userID = ctx.session.user.userID;
+    // I-5: LIVE read. session.user.roles is render-only and up to 30 days stale,
+    // so a demoted hall-office member would otherwise keep the picker.
+    const roles = await getUserRoles(ctx.db, userID);
+    const capabilities = computeCapabilities(roles);
+    if (!capabilities.viewCcaRostersReadOnly) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "CAPABILITY_REQUIRED:viewCcaRostersReadOnly",
+      });
+    }
+
+    // The switch is checked HERE rather than left to assertMayViewCcaRoster,
+    // because nothing below calls that guard — but on the SAME branch that
+    // guard puts it on, and not unconditionally as it was at first. An ADMIN
+    // holds reachScrcDashboard, so an admin can open /scrc before rollout; an
+    // unconditional check made every panel error for the one person entitled to
+    // inspect the surface before switching it on. `manageCcaHeads` is the
+    // manager tier here, i.e. exactly the callers who reach a roster through
+    // branch 1 of assertMayViewCcaRoster and never touch the flag.
+    if (!capabilities.manageCcaHeads) await assertScrcEnabled(ctx.db);
+
+    return {
+      ccas: await ctx.db.cCA.findMany({
+        select: { ccaID: true, ccaName: true, category: true },
+        orderBy: { ccaName: "asc" },
+      }),
+    };
+  }),
 });

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -1,17 +1,20 @@
+import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { del } from "@vercel/blob";
-import type { PrismaClient } from "@prisma/client";
+import type { Event, PrismaClient } from "@prisma/client";
 
 import {
   createTRPCRouter,
   identifiedProcedure,
   protectedProcedure,
   roleManagerProcedure,
+  oversightProcedure,
   requireMatric,
 } from "~/server/api/trpc";
 import { getUserRoles } from "~/server/api/services/access";
 import { computeCapabilities } from "~/server/api/services/roles";
 import { assertHeadsCca } from "~/server/api/services/ccaScope";
+import { assertScrcEnabled } from "~/server/api/services/scrcFlag";
 import { writeAudit } from "~/server/api/routers/admin";
 import {
   assertEventsEnabled,
@@ -32,6 +35,7 @@ import {
   eventIdInput,
   ccaIdInput,
   normalizeStatus,
+  EVENT_STATUSES,
   PROPOSAL_EDITABLE,
   PUBLIC_EDITABLE,
 } from "~/lib/schemas/event";
@@ -39,7 +43,7 @@ import {
 /**
  * The Events feature.
  *
- * THREE authorization CLASSES live here, deliberately in one router because they
+ * FOUR authorization CLASSES live here, deliberately in one router because they
  * are one feature, but each procedure states which it uses:
  *
  *   - HEAD-scoped (identifiedProcedure + assertHeadsCca on the event's ccaID):
@@ -48,6 +52,14 @@ import {
  *     string. `cca_head` is scope-free.
  *   - REVIEWER (roleManagerProcedure = admin + jcrc): the JCRC review queue and
  *     approve/reject. `decide` additionally re-reads roles live (I-5).
+ *   - OVERSIGHT (oversightProcedure = admin + jcrc + scrc): READ-ONLY. The hall
+ *     office watching the pipeline — listForOversight / getForOversight, every
+ *     status, no attendee data. It is additionally behind the `scrc.enabled`
+ *     kill switch, so the whole class can be turned off in 15s without a
+ *     redeploy, and it DELIBERATELY DOES NOT REACH `decide`: approve/reject is
+ *     REVIEWER-only, stays on roleManagerProcedure, and re-checks `reviewEvents`
+ *     live. Watching the queue and deciding it are separate powers; do not adopt
+ *     this builder for anything that writes.
  *   - RESIDENT (protectedProcedure, + requireMatric for signup): the public
  *     timeline, detail and signup. getPublic NEVER returns proposalUrl or the
  *     internal proposal description.
@@ -211,6 +223,61 @@ async function attachCcaNames(
   for (const r of rows) byID.set(r.ccaID, r.ccaName);
   return byID;
 }
+
+/**
+ * Fields `event.getForOversight` BLANKS for the hall office (the non-manager
+ * branch of the OVERSIGHT tier). Requirement 5 was "view events, read-only",
+ * which is a question about STATUS and SCHEDULE, not about the proposal or the
+ * reviewer's private notes:
+ *
+ *   description     the head's INTERNAL proposal text, written for the JCRC.
+ *                   getPublic already withholds it from residents for the same
+ *                   reason; the public-facing copy is `publicDescription`.
+ *   proposalUrl     the proposal PDF. prisma/schema.prisma states outright:
+ *                   reviewers + owning head only.
+ *   decisionReason  the reviewer's private feedback to the head on a rejection.
+ *
+ * AND EVERY CANONICAL-ID FIELD ON THE RECORD, which is a different reason and
+ * the one that is easy to miss. `createdBy`, `decidedBy` and `updatedBy` all
+ * hold a canonical E-format userID, and a canonical id IS an email address one
+ * derivation later (`E1234567` -> `e1234567@u.nus.edu`) — the same mistake that
+ * was made in cca.listHeads. A hall-office caller can page every event in the
+ * hall, so leaving any of the three in place hands over a directory of every
+ * head who has ever proposed an event and every reviewer who has ever decided
+ * one:
+ *
+ *   createdBy       the proposing head.
+ *   decidedBy       WHICH jcrc decided. That an event was approved is oversight;
+ *                   which individual signed it off is the JCRC's own business,
+ *                   and naming them invites exactly the pressure the separation
+ *                   exists to avoid.
+ *   updatedBy       whoever last touched the row.
+ *
+ * `ccaID` stays: it names an organisation, not a person, and the hall office
+ * already has the full CCA list. `decidedAt`, `publishedAt`, `createdAt` and
+ * `updatedAt` stay — "when did this move" is a pipeline fact and is the whole
+ * point of watching the pipeline.
+ *
+ * Blanked to null rather than deleted, so the response SHAPE is identical for
+ * both tiers and no client has to branch on field presence.
+ *
+ * An OBJECT spread over the record, not a list of keys assigned in a loop:
+ * `createdBy` is non-nullable in the schema (`String`, not `String?`), so a
+ * loop writing null could not typecheck without a cast, and a cast here would
+ * be a cast on precisely the line that decides what leaves the server. The
+ * `satisfies` clause still checks every key against `keyof Event`, so a typo or
+ * a renamed column fails the build instead of silently redacting nothing.
+ *
+ * TO RE-ENABLE A FIELD: delete its line here. That is the whole toggle.
+ */
+const SCRC_HIDDEN_EVENT_FIELDS = {
+  description: null,
+  proposalUrl: null,
+  decisionReason: null,
+  createdBy: null,
+  decidedBy: null,
+  updatedBy: null,
+} as const satisfies Partial<Record<keyof Event, null>>;
 
 /* resolveFacility lives in services/booking.ts — the interview-slot flow
  * resolves a facility the same way, and one definition is what keeps the two
@@ -890,6 +957,191 @@ export const eventRouter = createTRPCRouter({
               : (input.reason ?? undefined),
       });
       return { status: nextStatus as "approved" | "rejected", autoBook };
+    }),
+
+  /* ----------------------------- OVERSIGHT ------------------------------- */
+  /*
+   * READ-ONLY, admin + jcrc + scrc, and behind `scrc.enabled` on top of
+   * `events.enabled`. The pair below is the hall office's whole reach into
+   * events: see the pipeline, read one record, do nothing to it.
+   *
+   * WHY NOT JUST WIDEN listForReview/getForReview. Two reasons, either of which
+   * is sufficient. (1) They are the JCRC QUEUE: listForReview filters to
+   * `status: "submitted"` because a queue is work waiting to be done, whereas
+   * oversight wants drafts, approvals and cancellations too — different
+   * question, different answer. (2) They sit on roleManagerProcedure, the
+   * builder that also gates `decide`; widening it would hand approve/reject to
+   * the hall office as a side effect of wanting a list. Two small procedures
+   * cost less than that coupling.
+   *
+   * The gate is written out in both bodies rather than factored into a helper,
+   * following `decide` above, which likewise inlines its own live capability
+   * re-check. Order is fixed and load-bearing: assertEventsEnabled FIRST (the
+   * file rule — the switch is the boundary), then a LIVE role read, then the
+   * capability, then the scrc switch.
+   */
+
+  /**
+   * Every event, newest first, optionally filtered by status. PAGED.
+   *
+   * Projection is listForReview's PLUS `status` (normalised — the stored column
+   * is a nullable String). Nothing else: no proposalUrl, no internal proposal
+   * description, no attendee data, no PII. Oversight is "what is happening", not
+   * "who is going"; exportAttendees stays head-scoped. The `select` is explicit
+   * so the wide fields are never even READ, rather than read and then dropped —
+   * `description` and `proposalUrl` on every event in the hall is a lot of bytes
+   * to pull across just to throw away.
+   *
+   * ORDERED BY updatedAt DESC — MOST RECENTLY TOUCHED FIRST. This is a feed of
+   * what is happening, not a queue of what is waiting (that is listForReview),
+   * so an event proposed a year ago and edited this morning belongs at the TOP.
+   * It briefly ordered by `eventID desc` instead, on the mistaken belief that a
+   * cursor needs the sort key to be unique: it does not — the cursor is on `id`
+   * and only names WHERE to resume, while `orderBy` decides the sequence. This
+   * is the same pairing admin.listAuditLog already runs in production
+   * (`orderBy: { at: "desc" }` with `cursor: { id }`).
+   *
+   * The honest caveat of that pairing, which listAuditLog shares: `updatedAt` is
+   * not unique, so an event edited BETWEEN two page fetches moves in the
+   * ordering and can be seen twice or missed once. That is a stale-window
+   * artefact of cursor paging over a mutable sort key, not a correctness bug in
+   * the projection, and for a human scrolling an oversight feed it is the right
+   * trade against showing them a year-stale event first.
+   */
+  listForOversight: oversightProcedure
+    // EVENT_STATUSES is imported rather than retyped so the filter vocabulary
+    // cannot drift from normalizeStatus'. Note "canceled", one l.
+    .input(
+      z.object({
+        status: z.enum(EVENT_STATUSES).optional(),
+        limit: z.number().int().min(1).max(100).default(25),
+        cursor: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      // I-5: LIVE read. session.user.roles is render-only and up to 30 days
+      // stale, so a demoted hall-office member would otherwise keep reading.
+      const roles = await getUserRoles(ctx.db, userID);
+      const capabilities = computeCapabilities(roles);
+      if (!capabilities.viewEventsReadOnly) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "CAPABILITY_REQUIRED:viewEventsReadOnly",
+        });
+      }
+      // THE SWITCH GATES THE HALL OFFICE, NOT THE SURFACE. It was unconditional
+      // here at first, on the reasoning that a new procedure has no existing
+      // callers to break — true, and it missed that an ADMIN holds
+      // reachScrcDashboard and can therefore open /scrc BEFORE rollout, at which
+      // point every panel errored and the surface could not be inspected by the
+      // one person entitled to inspect it. Same shape as the branch ordering in
+      // assertMayViewCcaRoster: whoever could already do this is unaffected by
+      // the flag, and only the tier the flag exists for is held behind it.
+      if (!capabilities.reviewEvents) await assertScrcEnabled(ctx.db);
+
+      // KNOWN AND DELIBERATE: this filters the RAW column, while the returned
+      // `status` is normalizeStatus'd. Event.status is nullable with a default,
+      // and normalizeStatus maps null — and anything unrecognised — to "draft",
+      // so `status: "draft"` will NOT match a row stored as null even though
+      // that row comes back reading "draft". Left alone on purpose: an OR on
+      // `{ status: null }` would make "draft" mean something different here than
+      // it means in decide's NOT_UNDER_REVIEW check and in PROPOSAL_EDITABLE.
+      // The unfiltered list (no `status` input) shows every row regardless.
+      const rows = await ctx.db.event.findMany({
+        where: input.status ? { status: input.status } : {},
+        select: {
+          id: true,
+          eventID: true,
+          ccaID: true,
+          title: true,
+          startTime: true,
+          location: true,
+          updatedAt: true,
+          status: true,
+        },
+        take: input.limit + 1,
+        ...(input.cursor ? { cursor: { id: input.cursor }, skip: 1 } : {}),
+        orderBy: { updatedAt: "desc" }, // newest activity first — a feed, not a queue
+      });
+      const events = rows.slice(0, input.limit);
+      const nextCursor =
+        rows.length > input.limit
+          ? (events[events.length - 1]?.id ?? null)
+          : null;
+
+      const names = await attachCcaNames(
+        ctx.db,
+        events.map((e) => e.ccaID),
+      );
+      return {
+        events: events.map((e) => ({
+          eventID: e.eventID,
+          ccaID: e.ccaID,
+          ccaName: names.get(e.ccaID) ?? null,
+          title: e.title,
+          startTime: e.startTime,
+          location: e.location,
+          updatedAt: e.updatedAt,
+          status: normalizeStatus(e.status),
+        })),
+        nextCursor,
+      };
+    }),
+
+  /**
+   * One event's record, for the oversight detail view.
+   *
+   * A MANAGER GETS getForReview'S ANSWER, BYTE FOR BYTE. A hall-office caller
+   * gets the same record with four fields removed — see SCRC_HIDDEN_EVENT_FIELDS
+   * below. The body was originally identical for both, which meant `scrc` was
+   * handed `proposalUrl` (schema.prisma calls it "reviewers + owning head only")
+   * and the private decision trail, from a capability whose entire description
+   * is "view events, read-only".
+   *
+   * There is no getForOversight counterpart to `decide`: reading an event and
+   * deciding it are separate powers, and only the REVIEWER tier has the second.
+   */
+  getForOversight: oversightProcedure
+    .input(eventIdInput)
+    .query(async ({ ctx, input }) => {
+      await assertEventsEnabled(ctx.db);
+      const userID = ctx.session.user.userID;
+      const roles = await getUserRoles(ctx.db, userID); // I-5 live read
+      const capabilities = computeCapabilities(roles);
+      if (!capabilities.viewEventsReadOnly) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "CAPABILITY_REQUIRED:viewEventsReadOnly",
+        });
+      }
+      // `reviewEvents` IS the manager tier for events (admin || jcrc), so it is
+      // the honest discriminator here — both for the kill switch and for the
+      // projection below. See listForOversight for why the switch is checked on
+      // the non-manager branch only.
+      if (!capabilities.reviewEvents) await assertScrcEnabled(ctx.db);
+
+      const event = await ctx.db.event.findUnique({
+        where: { eventID: input.eventID },
+      });
+      if (!event) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "NO_SUCH_EVENT" });
+      }
+      const names = await attachCcaNames(ctx.db, [event.ccaID]);
+
+      const full = { ...event, status: normalizeStatus(event.status) };
+      if (capabilities.reviewEvents) {
+        return { event: full, ccaName: names.get(event.ccaID) ?? null };
+      }
+
+      // If the hall office is ever meant to read proposals, edit
+      // SCRC_HIDDEN_EVENT_FIELDS rather than deleting this branch — the branch
+      // is also what keeps the manager path provably untouched.
+      return {
+        event: { ...full, ...SCRC_HIDDEN_EVENT_FIELDS },
+        ccaName: names.get(event.ccaID) ?? null,
+      };
     }),
 
   /* ------------------------------ RESIDENT ------------------------------- */

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -305,7 +305,20 @@ export const userRouter = createTRPCRouter({
           // "" clears. See the D-5 note on `clearable` above — this is the ONE
           // place the branch-A/B decision is encoded.
           telegramHandle: clearable(input.telegramHandle),
-          block: input.block,
+          // OMITTED WHEN ABSENT, never written as null. `block` is optional on
+          // the shared schema (see the note there): `undefined` means "leave the
+          // stored value alone", and there is deliberately no value meaning
+          // "clear it". Spreading rather than assigning is what makes that true
+          // — `block: input.block` would hand Prisma `undefined`, which is a
+          // no-op today but is one refactor away from becoming a null write, and
+          // it would read as though omission were a supported way to blank the
+          // field. Same posture as `matric` in the admin router.
+          //
+          // A resident's payload always carries a block (EditProfileModal
+          // refuses a blank one before parsing), so this branch is reached ONLY
+          // by a profile-gate-exempt account — behaviour for all 1382 residents
+          // is byte-identical.
+          ...(input.block !== undefined ? { block: input.block } : {}),
         },
         // Mirror the read path's select — a bare update returns the whole row,
         // including passwordHash, straight into the browser and the React Query

--- a/src/server/api/routers/userAdmin.ts
+++ b/src/server/api/routers/userAdmin.ts
@@ -276,7 +276,7 @@ const updateSchema = z
         z
           .string()
           .refine((f): f is ProfileField =>
-            (REQUIRED_PROFILE_FIELDS as string[]).includes(f),
+            (REQUIRED_PROFILE_FIELDS as readonly string[]).includes(f),
           ),
       )
       .max(REQUIRED_PROFILE_FIELDS.length)
@@ -482,12 +482,30 @@ export const userAdminRouter = createTRPCRouter({
          * being held on — not a second opinion that could disagree with the
          * gate.
          */
-        profileGaps: computeProfileGaps({
-          displayName: target.displayName,
-          telegramHandle: target.telegramHandle,
-          block: target.block,
-          matric,
-        }),
+        profileGaps: computeProfileGaps(
+          {
+            displayName: target.displayName,
+            telegramHandle: target.telegramHandle,
+            block: target.block,
+            matric,
+          },
+          /* THE TARGET'S ROLES, NOT THE ACTOR'S. computeProfileGaps is
+           * role-aware (a hall-office account is exempt from block / telegram /
+           * matric — see MINIMAL_PROFILE_ROLES), and the question this field
+           * answers is "what is walling THIS user", so the roles that decide it
+           * are theirs. Passing `actorRoles` here would report the operator's
+           * exemption against someone else's profile.
+           *
+           * `roles` is the UNREDACTED set read at :418 — the `admin`-stripped
+           * copy below is for DISPLAY only, and filtering it before this call
+           * would make the answer depend on who is looking.
+           *
+           * Already in scope and already read, so this costs no extra query. If
+           * the roles could not be read (no canonical id) it is `[]`, which is
+           * never exempt — the strict set, i.e. over-prompt, never over-admit.
+           */
+          roles,
+        ),
         /**
          * WALL 2 — the post-merge completion flag, and a SEPARATE one.
          * MatricGate checks `needsProfileCompletion` (this row) BEFORE
@@ -923,13 +941,38 @@ export const userAdminRouter = createTRPCRouter({
                   )?.matric ?? null)
                 : null);
 
+            /* THE TARGET'S ROLES — see WALL 1's note. computeProfileGaps is
+             * role-aware, and the comment on condition 1 above requires this to
+             * be "the SAME function WALL 1 and the session callback gate on".
+             * SAME FUNCTION IS NOT ENOUGH IF IT IS FED A DIFFERENT ARGUMENT: an
+             * exempt account would report no gaps at WALL 1 and at the gate, but
+             * gaps here, so this block would refuse to resolve entries that
+             * nothing will ever fill — the resident-stranding trap
+             * unstick-profile-completion.mjs was written to release 18 people
+             * from, re-created one account at a time.
+             *
+             * Read here rather than beside `cid` so the query is issued ONLY on
+             * the rare path that has a live ProfileCompletion row to judge; the
+             * common save costs nothing. `cid` is non-null throughout this block
+             * (the `if (cid !== null)` above), so there is no absent identity
+             * being spent as a real one. A fault on this read is caught by the
+             * wrapper below exactly like the three queries beside it: the
+             * completion row is left LIVE and reported on the audit line, so the
+             * degrade direction is still over-prompt, never a wall taken down on
+             * a guess.
+             */
+            const targetRoles = await getUserRoles(ctx.db, cid);
+
             const stillGapped = new Set<string>(
-              computeProfileGaps({
-                displayName: updated.displayName,
-                telegramHandle: updated.telegramHandle,
-                block: updated.block,
-                matric: matricNow,
-              }),
+              computeProfileGaps(
+                {
+                  displayName: updated.displayName,
+                  telegramHandle: updated.telegramHandle,
+                  block: updated.block,
+                  matric: matricNow,
+                },
+                targetRoles,
+              ),
             );
             // Anything the gate vocabulary does not name is KEPT: this deploy
             // cannot judge a field it does not understand.

--- a/src/server/api/services/authAllowlist.ts
+++ b/src/server/api/services/authAllowlist.ts
@@ -1,0 +1,383 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type { CanonicalUserID } from "~/lib/identity";
+import { asExtUserID, canonicalUserID, normalizeEmail } from "~/lib/identity";
+
+/**
+ * THE D-7 BREAK-GLASS ALLOWLIST — the COLLECTION variant of
+ * 08-userid-keydrift.md §3 Branch C, and the read side of the `AuthAllowlist`
+ * model in prisma/schema.prisma.
+ *
+ * WHAT IT IS FOR. Hall office staff have `@nus.edu.sg` addresses. That domain
+ * is deliberately NOT admitted by the domain rule (src/lib/identity.ts explains
+ * why: it is the whole university rather than Raffles Hall, and under D-1
+ * admitting a domain auto-grants hall booking rights to every address in it).
+ * So a staff principal has `canonicalUserID(email) === null` and therefore no
+ * identity key at all — no roles, no bookings, nothing. One admin-issued row
+ * here PINS such an address to a stable key in the `EXT:` namespace.
+ *
+ * SERVER-ONLY. It touches Prisma. It must never be imported by a `"use client"`
+ * file — that is exactly why the pure predicates it composes (`EXT_ID`,
+ * `isExtUserID`, `asExtUserID`) live in src/lib/identity.ts and not here.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY `canonicalUserID` WAS NOT MADE TO CONSULT THIS
+ * ---------------------------------------------------------------------------
+ * 08-userid-keydrift.md §3 Branch C says canonicalUserID should consult the
+ * allowlist for addresses failing the domain rule. THAT IS NOT IMPLEMENTABLE.
+ * src/lib/identity.ts is declared PURE — no Prisma, no `~/env`, no
+ * `next/server` — because client components value-import from it, and
+ * `canonicalUserID` is synchronous at ~30 call sites. Making it async and impure
+ * would break all of them, break scripts/remediation/lib/identity.mjs (which
+ * cannot connect to anything), and put a database read behind
+ * verify-identity-parity.mjs's assertion that `canonicalUserID(e) !== null` is
+ * exactly `isNusStudentEmail(e)` — an equivalence that must stay pure.
+ *
+ * So resolution is a SEPARATE, COMPOSED step:
+ *
+ *     resolvePrincipalID(db, email) = canonicalUserID(email)
+ *                                  ?? await pinnedUserIDFor(db, email)
+ *
+ * canonicalUserID is untouched. This module is the only thing that knows the
+ * allowlist exists.
+ *
+ * ---------------------------------------------------------------------------
+ * THE ATTACK, AND THE FOUR MECHANISMS
+ * ---------------------------------------------------------------------------
+ * 05-verification.md §164: a single row
+ * `{ email: "attacker@gmail.com", pinnedUserID: "E1633673" }` would yield a
+ * session whose role key IS an admin's, inheriting every `UserRole` and
+ * `RoleAuditLog` row under it. There is NO grant path in that story, so NO
+ * escalation guard fires: `auth.ts` and `access.ts` both do a bare
+ * `db.userRole.findUnique({ where: { userID } })`, and whatever string lands in
+ * `session.user.userID` simply IS the authorization key. Nothing downstream can
+ * save you. Four independent mechanisms, in the order they fire:
+ *
+ *   M1  NAMESPACE DISJOINTNESS BY CONSTRUCTION. `NUS_STUDENT_EMAIL`'s capture
+ *       class is `[A-Z0-9._%-]`, which excludes ':'. `EXT_ID` requires one.
+ *       canonicalUserID therefore CANNOT return a string matching EXT_ID, for
+ *       any input, ever. Not a convention — a property of the two regexes,
+ *       asserted per fixture by verify-identity-parity.mjs.
+ *   M2  READ-SIDE ENFORCEMENT, HERE. `pinnedUserIDFor` runs `asExtUserID` on
+ *       the value it READ BACK OUT OF MONGO and returns the ABSENT value if it
+ *       fails. THIS IS THE MECHANISM THAT SURVIVES A COMPROMISED WRITE PATH: a
+ *       row typed by hand in Atlas, or written by some future code path that
+ *       skipped the zod schema, mints NO IDENTITY AT ALL. M4 alone would not
+ *       give you that — it only governs the writes it can see.
+ *   M3  UNIQUENESS, ENFORCED IN MONGO. `pinnedUserID` carries an explicitly
+ *       created unique index (scripts/remediation/create-auth-allowlist.mjs).
+ *       A Prisma `@unique` on Mongo with no such index is decoration.
+ *   M4  THE WRITE IS adminProcedure, AUDITED, AND REFUSES THREE SHAPES
+ *       (admin.addAuthAllowlistEntry): EMAIL_IS_CANONICAL, a non-EXT pin (zod),
+ *       and PIN_ALREADY_HAS_ROLES.
+ *
+ * M2 is not redundant with M4. Deleting it because "the write already checks"
+ * is the change that re-opens the attack.
+ *
+ * ---------------------------------------------------------------------------
+ * COST, AND WHY THE HOT PATH IS UNCHANGED
+ * ---------------------------------------------------------------------------
+ * `resolvePrincipalID`'s `??` short-circuits: for a canonical @u.nus.edu
+ * address — which is all live traffic, ~1382 accounts — it returns WITHOUT
+ * TOUCHING THE DATABASE. auth.ts's session-callback rule 2 ("steady state must
+ * issue ZERO reads beyond the two indexed findUniques") is preserved exactly.
+ * Only a NON-canonical session pays, and it pays one `findUnique` on a unique
+ * index over a collection holding single-digit rows, behind a 15s cache.
+ *
+ * IT MUST NEVER THROW. auth.ts's session-callback rule 1: a rejected session
+ * callback FORCE-LOGS-OUT the user, and on the hot path that is a mass
+ * availability event. Everything here is wrapped and degrades to the ABSENT
+ * identity — fail CLOSED, which reproduces today's behaviour exactly (today
+ * these addresses already resolve to null).
+ */
+
+/** Matches ccaScope.ts's flag cache and every SystemFlag cache in access.ts. */
+const CACHE_TTL_MS = 15_000;
+
+/**
+ * TWO MAPS, NOT ONE, AND THE SPLIT IS A SECURITY DECISION.
+ *
+ * `pinnedUserIDFor` is reachable from UNAUTHENTICATED endpoints — `maySignIn`
+ * on both sign-in paths, and the password-reset request route. So the KEY SPACE
+ * OF THE MISS CACHE IS ATTACKER-CONTROLLED: anyone can make this module observe
+ * an address that has never existed. The key space of the HIT cache is not — a
+ * hit requires a real `AuthAllowlist` row, and that collection is written only
+ * by an audited adminProcedure and is meant to hold single digits.
+ *
+ * A SINGLE SHARED MAP LETS THE ATTACKER-CONTROLLED HALF EVICT THE OTHER. The
+ * first version of this was one map with `if (size >= MAX) cache = new Map()` —
+ * wholesale replacement, not eviction. Cycling more than MAX addresses through
+ * the reset route therefore wiped the map every MAX requests, and each wipe took
+ * the handful of REAL pinned identities with it. Nothing broke — every read
+ * degrades to a query — but the cache stopped existing during exactly the
+ * traffic it most needed to absorb, and the session path (which shares this
+ * module) paid a database round-trip per request for the duration. Cache
+ * behaviour under adversarial load should not be "turn the cache off".
+ *
+ * Split, a flood of unknown addresses can only churn `missCache`. A pinned
+ * identity's cached hit is unreachable from that traffic, by construction.
+ *
+ * Both maps are still BOUNDED and now evict OLDEST-FIRST (JS Map iterates in
+ * insertion order, and `cacheGet` re-inserts on a hit, which makes that
+ * recency order). Bounded because an unbounded map on a lambda is a memory
+ * leak; oldest-first because dropping one stale entry is the correct response
+ * to pressure and dropping everything is not.
+ */
+const HIT_CACHE_MAX = 200;
+const MISS_CACHE_MAX = 200;
+
+type CacheEntry = { at: number; id: CanonicalUserID | null };
+let hitCache = new Map<string, CacheEntry>();
+let missCache = new Map<string, CacheEntry>();
+
+/**
+ * Test/ops seam, and — more importantly — the thing every allowlist WRITE must
+ * call. Without it, adding or removing a pin would take up to CACHE_TTL_MS to
+ * be observable, and a REMOVAL that is not observable is a revocation that has
+ * not happened.
+ *
+ * Clears BOTH maps. A newly added pin's address is almost certainly sitting in
+ * `missCache` from whatever attempt prompted the operator to add it, so
+ * clearing only the hits would leave the new identity invisible for 15s on the
+ * one path that matters.
+ */
+export function resetAuthAllowlistCache(): void {
+  hitCache = new Map();
+  missCache = new Map();
+}
+
+/** Evict oldest-first until there is room for one more. */
+function evictOldest(map: Map<string, CacheEntry>, max: number): void {
+  while (map.size >= max) {
+    const oldest = map.keys().next();
+    if (oldest.done) return;
+    map.delete(oldest.value);
+  }
+}
+
+function cacheGet(email: string): CacheEntry | undefined {
+  const map = hitCache.has(email)
+    ? hitCache
+    : missCache.has(email)
+      ? missCache
+      : null;
+  if (!map) return undefined;
+
+  const hit = map.get(email)!;
+  if (Date.now() - hit.at >= CACHE_TTL_MS) {
+    map.delete(email);
+    return undefined;
+  }
+  // Re-insert to move this key to the END of the iteration order, which is what
+  // makes `evictOldest` above LEAST-RECENTLY-USED rather than
+  // least-recently-written. Without it a pinned address read a thousand times
+  // would still age out ahead of a miss written once.
+  map.delete(email);
+  map.set(email, hit);
+  return hit;
+}
+
+function cacheSet(email: string, id: CanonicalUserID | null): void {
+  // A hit and a miss for the same key must not coexist — the answer changed, so
+  // the other map's copy is stale. Cheap, and it keeps `cacheGet`'s two-map
+  // lookup unambiguous.
+  const target = id === null ? missCache : hitCache;
+  const other = id === null ? hitCache : missCache;
+  other.delete(email);
+  evictOldest(target, id === null ? MISS_CACHE_MAX : HIT_CACHE_MAX);
+  target.set(email, { at: Date.now(), id });
+}
+
+/**
+ * The pinned principal key for an address, or the ABSENT value.
+ *
+ * HITS AND MISSES ARE BOTH CACHED. A miss is the COMMON case here — every
+ * legacy non-NUS `User` row that still holds a session resolves to null — so
+ * caching only hits would leave exactly the population this function exists to
+ * be cheap for paying a query every request.
+ *
+ * THE ERROR PATH IS DELIBERATELY NOT CACHED, the same way isCcaManagementEnabled
+ * does it: the next request retries rather than pinning a wrong answer for 15
+ * seconds on a transient Atlas hiccup. Pinning "absent" would sign an
+ * allowlisted user out for 15s per fault; pinning it after a write is worse.
+ *
+ * M2 LIVES ON THE RETURN STATEMENT. `asExtUserID(row.pinnedUserID)` re-validates
+ * the namespace on the value we just read, so a row whose pin is `E1633673`
+ * yields NOTHING — not an identity, not an error, not a partial. The structured
+ * console.error is how such a row becomes visible: it can only have arrived by
+ * a hand edit in Atlas or by a code path that bypassed the zod schema, and both
+ * of those are worth an alert.
+ */
+export async function pinnedUserIDFor(
+  db: PrismaClient,
+  rawEmail: string | null | undefined,
+): Promise<CanonicalUserID | null> {
+  // I-12: THE shared normalizer, never a private copy. A private
+  // `.toLowerCase()` here would miss the `.trim()`, and `AuthAllowlist.email`
+  // must match `User.email` byte for byte (email_unique_ci folds CASE but not
+  // WHITESPACE). verify-identity-parity.mjs bans private derivations by source
+  // scan for exactly this reason.
+  const email = normalizeEmail(rawEmail);
+  if (!email) return null;
+
+  const cached = cacheGet(email);
+  if (cached) return cached.id;
+
+  try {
+    const row = await db.authAllowlist.findUnique({
+      where: { email },
+      select: { pinnedUserID: true },
+    });
+    if (!row) {
+      cacheSet(email, null);
+      return null;
+    }
+
+    // ---- M2 ------------------------------------------------------------
+    const pin = asExtUserID(row.pinnedUserID);
+    if (pin === null) {
+      console.error(
+        JSON.stringify({
+          evt: "allowlist_pin_namespace_violation",
+          email,
+          pin: row.pinnedUserID,
+        }),
+      );
+      // Cache the refusal like any other miss. The row is not going to start
+      // being valid within 15 seconds, and a poisoned row must not become a
+      // per-request query amplifier on top of everything else.
+      cacheSet(email, null);
+      return null;
+    }
+
+    cacheSet(email, pin);
+    return pin;
+  } catch (err) {
+    // FAIL CLOSED, UNCACHED. Never rethrow — auth.ts rule 1.
+    console.error(
+      JSON.stringify({
+        evt: "allowlist_lookup_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+/**
+ * Batch form, for admin.listUsers. Same M2 filter, applied PER ROW.
+ *
+ * Keyed by NORMALIZED email on both sides — the caller must normalize its
+ * lookups too, or a stored `" Ngocanh.Mai@nus.edu.sg"` will silently miss.
+ *
+ * Deliberately BYPASSES THE CACHE in both directions: it is called once per
+ * admin page render on a ≤100-row page, so the hit rate would be near zero, and
+ * seeding the shared map from an admin listing would let one operator's page
+ * load decide what the session path sees for the next 15 seconds. The session
+ * path's cache should be filled by the session path.
+ */
+export async function pinnedUserIDsFor(
+  db: PrismaClient,
+  rawEmails: readonly (string | null | undefined)[],
+): Promise<Map<string, CanonicalUserID>> {
+  const out = new Map<string, CanonicalUserID>();
+  const emails = [...new Set(rawEmails.map(normalizeEmail).filter(Boolean))];
+  if (emails.length === 0) return out;
+
+  try {
+    const rows = await db.authAllowlist.findMany({
+      where: { email: { in: emails } },
+      select: { email: true, pinnedUserID: true },
+    });
+    for (const row of rows) {
+      const pin = asExtUserID(row.pinnedUserID);
+      if (pin === null) {
+        console.error(
+          JSON.stringify({
+            evt: "allowlist_pin_namespace_violation",
+            email: row.email,
+            pin: row.pinnedUserID,
+          }),
+        );
+        continue;
+      }
+      out.set(normalizeEmail(row.email), pin);
+    }
+  } catch (err) {
+    // Fail closed: an admin page that renders "no canonical id" is a visible,
+    // recoverable inconvenience. Throwing here would 500 the whole user list.
+    console.error(
+      JSON.stringify({
+        evt: "allowlist_batch_lookup_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+  return out;
+}
+
+/**
+ * THE resolution step. `canonicalUserID` first, ALWAYS.
+ *
+ * THE ORDER IS THE HOT PATH, not a preference. For every @u.nus.edu address the
+ * left operand is non-null and the right one is never evaluated, so no query is
+ * issued and no cache is consulted — which is what keeps auth.ts's rule 2
+ * ("ZERO reads in steady state") true after this change. Swapping the operands
+ * would put a database read in front of every authenticated request in the app.
+ *
+ * The env-var allowlist (`AUTH_EMAIL_ALLOWLIST`, in auth.ts's passesDomainRule)
+ * is DELIBERATELY NOT CONSULTED HERE. It survives as break-glass for an outage
+ * in which the database is the broken thing, and it confers SIGN-IN ONLY: an
+ * env-allowlisted address still resolves to the absent identity, holds no roles
+ * and cannot book. That asymmetry is the whole point of keeping both.
+ */
+export async function resolvePrincipalID(
+  db: PrismaClient,
+  rawEmail: string | null | undefined,
+): Promise<CanonicalUserID | null> {
+  return canonicalUserID(rawEmail) ?? (await pinnedUserIDFor(db, rawEmail));
+}
+
+/**
+ * Does a LIVE pin exist for this key? Used by one caller: guard G7's EXT branch
+ * in assertCanMutateRoles.
+ *
+ * G7 asks "can any session ever produce this target key" — it is a REACHABILITY
+ * guard, not an authorization one (see its comment in routers/admin.ts). For an
+ * E-format id the shape test answers that. For an EXT id it does not: the shape
+ * is admin-supplied, and a grant keyed on `EXT:TYPO` would silently write a row
+ * no session matches, which is precisely the failure G7 exists to prevent. So
+ * the EXT branch demands PROOF OF A LIVE ROW instead — strictly stronger than
+ * the shape test it sits beside.
+ *
+ * UNCACHED, on purpose. It gates a WRITE, and it is reached at most once per
+ * role mutation. Reading a 15-second-old answer to "does this pin still exist"
+ * on the path that grants privileges is a trade with no upside.
+ *
+ * Fails CLOSED (false) on fault: a role grant that cannot prove its target is
+ * reachable must not proceed.
+ */
+export async function allowlistPinExists(
+  db: PrismaClient,
+  pinnedUserID: string,
+): Promise<boolean> {
+  // Re-validate the shape before spending a query. A caller that hands us
+  // something outside the namespace has already made a mistake, and we must not
+  // let a `findUnique` on an arbitrary string be the thing that decides.
+  if (asExtUserID(pinnedUserID) === null) return false;
+  try {
+    const row = await db.authAllowlist.findUnique({
+      where: { pinnedUserID },
+      select: { id: true },
+    });
+    return row !== null;
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        evt: "allowlist_pin_exists_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return false;
+  }
+}

--- a/src/server/api/services/ccaRoster.ts
+++ b/src/server/api/services/ccaRoster.ts
@@ -35,7 +35,13 @@ export type RosterResolved = {
   kind: "resolved";
   /** THE dedupe key. Collapses a person's A-format and canonical keys. */
   userId: string;
-  email: string;
+  /**
+   * NULLABLE ONLY BECAUSE OF THE READ-ONLY TIER. Resolution always produces a
+   * real address — a row without one cannot resolve — so for a head or a
+   * manager this is never null. `redactRosterForReadOnly` below blanks it for
+   * the hall office, and this type is what forces every renderer to cope.
+   */
+  email: string | null;
   displayName: string | null;
   storedUserID: string | null;
   isHead: boolean;
@@ -77,6 +83,76 @@ export type Roster = {
   counts: { heads: number; members: number; total: number };
   drift: RosterDrift;
 };
+
+/* -------------------------------------------------------------------------- */
+/* The read-only (hall office) projection                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Strip every IDENTIFIER off a roster, leaving names, headship and grant dates.
+ *
+ * WHY THIS EXISTS. A full `Roster` carries each member's EMAIL, their stored
+ * `userID`, and — in `membershipKeys` and an unresolved entry's `key` — the raw
+ * UserCCA membership strings, which are mostly A-FORMAT MATRIC NUMBERS. A caller
+ * who can list all 89 CCAs and read every roster can therefore reassemble most
+ * of `admin.listUsers` plus a pile of matrics, one CCA at a time. That is
+ * exactly the disclosure `viewCcaRostersReadOnly` promises not to be, and it is
+ * what requirement 8 withholds from the hall office.
+ *
+ * So the read-only tier gets the answer to "who is in this CCA" — a list of
+ * NAMES, who leads it, and when they were made a head — and nothing that lets
+ * it contact, key, or cross-reference those people. Heads and managers are
+ * untouched: `assertMayViewCcaRoster` hands them `via: "headship"` or
+ * `"manageCcaHeads"`, the caller does not call this, and their response is
+ * byte-identical to what it was before this function existed.
+ *
+ * UNRESOLVED ROWS ARE KEPT, NOT DROPPED, and their `key` is replaced with an
+ * opaque per-response token rather than blanked. Dropping them would silently
+ * disagree with `counts` and with `drift`, which is the 07 §3 anti-pattern this
+ * whole module was built to avoid — the hall office should still see THAT a CCA
+ * has three unmatchable membership records, because that is a data-quality fact
+ * about the CCA and not a fact about a person. The token keeps each row
+ * distinct so React keys and the amber rendering still work; it is deliberately
+ * NOT derived from the real key, so it cannot be reversed or correlated between
+ * two requests.
+ *
+ * `drift` and `counts` pass through UNCHANGED. They are aggregates over records,
+ * not disclosures about people.
+ *
+ * WHAT IS DELIBERATELY LEFT IN, having been considered: `userId`. It is a
+ * MongoDB ObjectId — not a canonical E-id, so no address can be derived from it,
+ * which is the whole reason `email`, `storedUserID` and `membershipKeys` had to
+ * go. It IS a stable cross-CCA correlator ("the same person appears in these
+ * four rosters"), but `displayName` already correlates just as well and is the
+ * point of the feature, and `rosterEntryKey` needs it for React keys. Removing
+ * it would buy nothing and break the rendering.
+ */
+export function redactRosterForReadOnly(roster: Roster): Roster {
+  let hidden = 0;
+  const redact = (e: RosterEntry): RosterEntry =>
+    e.kind === "resolved"
+      ? {
+          ...e,
+          email: null,
+          storedUserID: null,
+          // Every key that resolved to this person — A-format matric included.
+          membershipKeys: [],
+        }
+      : {
+          ...e,
+          key: `hidden-${++hidden}`,
+          // The User.ids that claimed an ambiguous key. Investigating a
+          // duplicate account is JCRC work, and the ids are useless without
+          // the admin surface that resolves them.
+          candidateUserIds: [],
+        };
+
+  return {
+    ...roster,
+    heads: roster.heads.map(redact),
+    members: roster.members.map(redact),
+  };
+}
 
 /**
  * The shape user.findRaw yields under our projection. Untyped BSON: every field
@@ -335,8 +411,14 @@ export async function resolveRoster(
 
   /* ---- output ---- */
 
+  // `email` is nullable ONLY for the read-only projection, which is applied
+  // downstream of this sort (redactRosterForReadOnly maps over already-ordered
+  // arrays and preserves their order), so at this point it is always a real
+  // address. `?? e.userId` is a total-function fallback for the type, not a
+  // reachable branch — and it keeps the comparator deterministic if that ever
+  // stops being true.
   const label = (e: RosterEntry) =>
-    e.kind === "resolved" ? (e.displayName ?? e.email) : e.key;
+    e.kind === "resolved" ? (e.displayName ?? e.email ?? e.userId) : e.key;
 
   // Sorted SERVER-side: the union's insertion order is not stable between
   // renders. Unresolved last, so the amber block reads as a footer rather than

--- a/src/server/api/services/ccaScope.ts
+++ b/src/server/api/services/ccaScope.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import type { PrismaClient } from "@prisma/client";
 
 import { computeCapabilities } from "./roles";
+import { assertScrcEnabled } from "./scrcFlag";
 
 /* -------------------------------------------------------------------------- */
 /* The object-scoped guard                                                     */
@@ -9,8 +10,16 @@ import { computeCapabilities } from "./roles";
 
 export type CcaScope = {
   ccaID: number;
-  /** How the caller got in. Recorded so the UI can say "viewing as JCRC". */
-  via: "headship" | "manageCcaHeads";
+  /**
+   * How the caller got in. Recorded so the UI can say "viewing as JCRC".
+   *
+   * `readOnly` is produced ONLY by assertMayViewCcaRoster (never by
+   * assertHeadsCca), so a `via` of "readOnly" can never accompany a write. The
+   * UI must treat it as strictly weaker than the other two; RosterPanel already
+   * does, because it branches on `via === "manageCcaHeads"` positively rather
+   * than switching exhaustively.
+   */
+  via: "headship" | "manageCcaHeads" | "readOnly";
 };
 
 export type CcaActor = {
@@ -60,6 +69,62 @@ export async function assertHeadsCca(
   // requireCapability's CAPABILITY_REQUIRED:<key>. NOT_FOUND would be better
   // non-disclosure but would lie about a CCA that exists, and a ccaID is not a
   // secret — it is public in the booking UI.
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message: "NOT_A_HEAD_OF_THIS_CCA",
+  });
+}
+
+/**
+ * READ ONLY. NEVER call this from a procedure that writes, and never merge it
+ * with assertHeadsCca.
+ *
+ * assertHeadsCca is THE write guard: it also gates cca.updateProfile,
+ * cca.removeMembers, cca.handoverHeads, cca.memberDirectory (matric/telegram/
+ * bio) and event.publish / cancelEvent / exportAttendees. Widening it by one
+ * capability would hand all of that to whoever holds that capability, which is
+ * why the hall office got a SECOND function instead of a wider first one. The
+ * two must stay separate even though branches 1 and 2 below are duplicated
+ * from it — the duplication is the point, and it is four lines.
+ *
+ * ORDER IS LOAD-BEARING. Branches 1 and 2 are byte-for-byte the decision
+ * assertHeadsCca makes, and they come FIRST, so an admin, a jcrc or a genuine
+ * head reaches exactly the same answer by exactly the same route and NEVER
+ * touches the `scrc.enabled` flag read. Only a caller who would otherwise have
+ * been refused falls through to branch 3, so flipping the switch off cannot
+ * affect anybody who could already read the roster.
+ *
+ * `actor.roles` MUST be a live getUserRoles() read (I-5), same as
+ * assertHeadsCca — see its comment for why.
+ */
+export async function assertMayViewCcaRoster(
+  db: PrismaClient,
+  actor: CcaActor,
+  ccaID: number,
+): Promise<CcaScope> {
+  const capabilities = computeCapabilities(actor.roles);
+
+  // 1 + 2: identical to assertHeadsCca, in the same order, for the same reason.
+  if (capabilities.manageCcaHeads) {
+    return { ccaID, via: "manageCcaHeads" };
+  }
+
+  const row = await db.ccaHead.findUnique({
+    where: { userID_ccaID: { userID: actor.userID, ccaID } },
+    select: { id: true },
+  });
+  if (row) return { ccaID, via: "headship" };
+
+  // 3: the read-only tier (hall office). Behind the kill switch, and behind it
+  // HERE rather than in the callers, so the flag cannot be forgotten by the
+  // next procedure that adopts this guard.
+  if (capabilities.viewCcaRostersReadOnly) {
+    await assertScrcEnabled(db);
+    return { ccaID, via: "readOnly" };
+  }
+
+  // Same message and same non-disclosure argument as assertHeadsCca. A caller
+  // refused here learns nothing it would not have learned there.
   throw new TRPCError({
     code: "FORBIDDEN",
     message: "NOT_A_HEAD_OF_THIS_CCA",

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import { z } from "zod";
-import { canonicalUserID, isCanonicalResidentID } from "~/lib/identity";
+import { EXT_ID, canonicalUserID, isCanonicalResidentID } from "~/lib/identity";
 
 /**
  * Role VOCABULARY + the stored-baseline machinery (RBAC v2, 02-backend-authz.md
@@ -27,9 +27,34 @@ export type { CanonicalUserID } from "~/lib/identity";
 
 /**
  * Single source of truth for role identifiers.
- * Adding a role = add it here and to ASSIGNABLE_BY, and nothing else.
+ *
+ * THIS COMMENT USED TO SAY "adding a role = add it here and to ASSIGNABLE_BY,
+ * and nothing else". That was false, and it was false in the silent direction:
+ * a role added to ROLES alone is DROPPED at the read boundary by
+ * normalizeStoredRoles (it keeps only grantable roles plus the baseline), so it
+ * would be stored, invisible and inert, and nothing would say so. The accurate
+ * checklist, derived by walking the actual consumers:
+ *
+ *   1. ROLES (here)                    — or normalizeStoredRoles cannot type it
+ *   2. GRANTABLE_ROLES                 — or normalizeStoredRoles DROPS it on
+ *                                        every read, and assertCanMutateRoles
+ *                                        never sees it in the actor's set
+ *   3. ASSIGNABLE_BY + REVOCABLE_FROM_OTHERS_BY — who may grant/revoke it, and
+ *                                        what IT may grant/revoke
+ *   4. FACILITY_ROLES                  — only if a facility may require it
+ *   5. computeCapabilities             — what it can actually DO; a role with no
+ *                                        capability is a badge, not a power
+ *   6. a procedure builder in server/api/trpc.ts — so a router can gate on it
+ *   7. the badge maps in src/app/_components/RoleBadges.tsx and
+ *      src/app/admin/_components/RoleBadge.tsx — or the UI renders the raw
+ *      string, and the hardcoded `as` unions in the admin components (which are
+ *      casts, so they will NOT fail to compile) start lying
+ *   8. ROLE_VOCAB in scripts/remediation/lib/rbac.mjs — or rbac-doctor.mjs
+ *      reports every legitimate grant as an out-of-vocabulary stray and exits 1
+ *
+ * PRECEDENCE is deliberately NOT on that list. See its own comment.
  */
-export const ROLES = ["admin", "jcrc", "cca_head", "resident"] as const;
+export const ROLES = ["admin", "jcrc", "cca_head", "resident", "scrc"] as const;
 // The v1 pseudo-role "user" is DELETED from the vocabulary (00-overview.md
 // §2.2); `resident` is the floor. Do not re-add it — an unused enum member is a
 // read-boundary hazard (07-cca-future.md §1.4).
@@ -38,6 +63,27 @@ export type Role = (typeof ROLES)[number];
 export const ADMIN_ROLE = "admin" as const;
 export const JCRC_ROLE = "jcrc" as const;
 export const CCA_HEAD_ROLE = "cca_head" as const;
+/**
+ * Hall Office / SCRC. A STAFF-SIDE role, not a student-leadership one, and the
+ * narrowest privileged role in the vocabulary.
+ *
+ * GRANTABLE BY ADMIN ONLY — it appears in no ASSIGNABLE_BY entry but admin's,
+ * which is what stops it self-propagating. Its one power OVER OTHER USERS is
+ * `jcrc`: ASSIGNABLE_BY.scrc / REVOCABLE_FROM_OTHERS_BY.scrc are exactly
+ * ["jcrc"], because appointing the JCRC is the hall office's actual job. It
+ * gets read-only oversight of CCA rosters and events on top of that, and
+ * NOTHING else — in particular NOT manageCcaHeads, which would hand it
+ * assertHeadsCca and with it every CCA write and the attendee PII export.
+ *
+ * KNOWN, ACCEPTED CONSEQUENCE, stated here because it is not obvious from the
+ * capability list: because it may grant `jcrc`, an scrc holder can appoint a
+ * confederate who then holds the whole manager tier. The chain TERMINATES there
+ * (ASSIGNABLE_BY.jcrc is [], so no path reaches `admin`, manageFacilityAccess,
+ * deleteUsers, readAuditLog or manageEnforcementFlag). It is contained by the
+ * self-target refusal in admin.setJcrcRole, the `scrc.enabled` kill switch, and
+ * an audit row per grant carrying the actor's roles.
+ */
+export const SCRC_ROLE = "scrc" as const;
 /**
  * Baseline capability of every verified NUS account. STORED and auto-assigned
  * (I-8), never GRANTABLE: it is written only by ensureBaseline, the register
@@ -83,8 +129,15 @@ export const DEFAULT_ROLE = "user" as const;
  * `resident` is not a sanction — I-8b repairs it at the target's next page
  * load. A booking ban is a separate affirmative flag (00-overview.md §3.4),
  * never the absence of the baseline.
+ *
+ * `scrc` IS here, and its membership is MANDATORY rather than a design choice.
+ * normalizeStoredRoles — the read boundary every consumer goes through — keeps
+ * a stored string only if it is grantable or is the baseline. Omit `scrc` from
+ * this list and the role is written to Mongo, dropped on every read, absent
+ * from the session, absent from the actor set assertCanMutateRoles computes
+ * ASSIGNABLE_BY from, and therefore completely inert with no error anywhere.
  */
-export const GRANTABLE_ROLES = ["admin", "jcrc", "cca_head"] as const;
+export const GRANTABLE_ROLES = ["admin", "jcrc", "cca_head", "scrc"] as const;
 export type GrantableRole = (typeof GRANTABLE_ROLES)[number];
 
 /**
@@ -92,8 +145,19 @@ export type GrantableRole = (typeof GRANTABLE_ROLES)[number];
  * pulled the two domains apart: `resident` is requirable but not grantable, and
  * `admin` is grantable but must NEVER be stored in requiredRoles (it is an
  * implicit bypass; storing it invites someone to delete it and lock admins out).
+ *
+ * `scrc` is here for the WRITE path, not the read path: canBookWithRoles does a
+ * plain string intersection and would honour any stored value, but
+ * admin.setFacilityAccess validates against this enum, so without the entry the
+ * admin UI physically cannot write ["jcrc","scrc"] onto the SCRC Room and the
+ * change would have to be made by hand in Atlas — unaudited.
  */
-export const FACILITY_ROLES = ["resident", "jcrc", "cca_head"] as const;
+export const FACILITY_ROLES = [
+  "resident",
+  "jcrc",
+  "cca_head",
+  "scrc",
+] as const;
 export type FacilityRole = (typeof FACILITY_ROLES)[number];
 
 /** Values allowed in `RoleAuditLog.action` (prisma/schema.prisma). */
@@ -175,6 +239,41 @@ export const AUDIT_ACTIONS = [
   "user.detail.read",
   "user.profile.update",
   "user.delete",
+  // The SECOND read in this list, and it is here for exactly the
+  // `user.detail.read` reason: admin.resolveJcrcCandidate is a per-target
+  // disclosure primitive (identifier in, a named person out) reachable by every
+  // scrc holder, and it is the ONLY enumeration-shaped surface `scrc` has. The
+  // grant/revoke it precedes is already audited by applyRoleChange's "set" row,
+  // so without this one a hall-office member can probe who exists — email by
+  // email — and leave no trace at all unless they then act.
+  //
+  // There is deliberately NO "scrc.jcrc.grant" / ".revoke": the write goes
+  // through applyRoleChange, which hardcodes action "set" and denormalises
+  // actorRoles onto the row, so `actorRoles contains "scrc"` already selects
+  // every hall-office role change. A distinct action would mean either editing
+  // the chokepoint or writing a duplicate row — both worse than a query.
+  //
+  // 19 characters, under the 32-char cap admin.listAuditLog's filter imposes.
+  "scrc.candidate.read",
+  // D-7 BREAK-GLASS PIN SURFACE (admin.addAuthAllowlistEntry /
+  // removeAuthAllowlistEntry, adminProcedure only). These two are the ONLY
+  // actions in this list that create or destroy an IDENTITY rather than a
+  // privilege: an AuthAllowlist row is what lets a non-@u.nus.edu address hold
+  // a session key at all (see prisma/schema.prisma's AuthAllowlist model and
+  // services/authAllowlist.ts). Everything else here presupposes an identity
+  // and moves roles around on top of it.
+  //
+  // `targetUserID` carries the EXT pin and `reason` carries the pinned address,
+  // so "who was handed an identity, by whom, when" is one query. Denials are
+  // written as `denied` with denyReason EMAIL_IS_CANONICAL /
+  // PIN_ALREADY_HAS_ROLES / EMAIL_ALREADY_PINNED / PIN_ALREADY_USED /
+  // PIN_STILL_HOLDS_ROLES — the shapes the write refuses (M4).
+  //
+  // There is deliberately NO "authAllowlist.update": a pin is immutable, so
+  // re-aiming a key at a different address is remove-then-add, i.e. two rows.
+  // 18 and 21 characters, both under the 32-char cap.
+  "authAllowlist.add",
+  "authAllowlist.remove",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
@@ -185,6 +284,18 @@ export type AuditAction = (typeof AUDIT_ACTIONS)[number];
  * default-OPEN and cannot interpret `resident`. Writing it there would be
  * meaningless at best and would displace a real value at worst.
  * Removed entirely in doc 06.
+ *
+ * `scrc` is EXCLUDED FOR THE SAME REASON, and this is the one place in the
+ * whole scrc change where doing the obvious thing would touch live traffic.
+ * legacyMirror returns the FIRST match, so putting `scrc` anywhere above `jcrc`
+ * would mirror a jcrc+scrc holder as "scrc" — a scalar the still-deployed
+ * pre-v2 access.ts cannot interpret — and a rollback would silently demote a
+ * sitting JCRC member out of the SCRC Room and out of /admin. Putting it below
+ * `cca_head` is harmless and also pointless. Leaving it out is correct: a plain
+ * scrc holder mirrors to "" (falsy, benign, exactly the resident treatment) and
+ * a jcrc+scrc holder still mirrors to "jcrc".
+ *
+ * Must stay identical to PRECEDENCE in scripts/remediation/lib/rbac.mjs.
  */
 export const PRECEDENCE = ["admin", "jcrc", "cca_head"] as const;
 
@@ -228,15 +339,23 @@ export function legacyMirror(roles: readonly string[]): string | null {
  * `resident` maps to [] and appears in no other entry, in either direction, at
  * any level — I-8e. `user` is retained as a key only so a legacy row still
  * carrying the dead scalar resolves to [] instead of undefined.
+ *
+ * `scrc` (hall office) is the FIRST non-admin key with a non-empty entry, and
+ * it is exactly ["jcrc"] — narrower than admin's, and narrower than the role
+ * itself: `scrc` cannot grant `scrc`, so the role cannot self-propagate and
+ * only an admin can ever create another hall-office account. It appears in
+ * admin's list for the same reason `jcrc` does. Read SCRC_ROLE's comment for
+ * the escalation closure this opens and what contains it.
  */
 export const ASSIGNABLE_BY: Record<string, readonly GrantableRole[]> =
   Object.assign(
     Object.create(null) as Record<string, readonly GrantableRole[]>,
     {
-      admin: ["admin", "jcrc"] as const,
+      admin: ["admin", "jcrc", "scrc"] as const,
       jcrc: [] as const,
       cca_head: [] as const,
       resident: [] as const,
+      scrc: ["jcrc"] as const,
       user: [] as const,
     },
   );
@@ -246,6 +365,12 @@ export const ASSIGNABLE_BY: Record<string, readonly GrantableRole[]> =
  * ASSIGNABLE_BY even though D-3 currently makes them identical, because they
  * answer different questions and will diverge again if a role is ever made
  * grant-but-not-revoke. `resident` is absent here too (I-8e).
+ *
+ * `scrc: ["jcrc"]` deliberately MATCHES its ASSIGNABLE_BY entry: a hall office
+ * that can appoint the JCRC but not un-appoint it would push every removal back
+ * to an admin, and the whole point of the role is that it does not need one.
+ * Note it still cannot revoke `scrc` — not from others and, via G5's self-branch
+ * plus this map, not meaningfully from anyone but itself.
  */
 export const REVOCABLE_FROM_OTHERS_BY: Record<
   string,
@@ -253,13 +378,78 @@ export const REVOCABLE_FROM_OTHERS_BY: Record<
 > = Object.assign(
   Object.create(null) as Record<string, readonly GrantableRole[]>,
   {
-    admin: ["admin", "jcrc"] as const,
+    admin: ["admin", "jcrc", "scrc"] as const,
     jcrc: [] as const,
     cca_head: [] as const,
     resident: [] as const,
+    scrc: ["jcrc"] as const,
     user: [] as const,
   },
 );
+
+/* -------------------------------------------------------------------------- */
+/* Mutually exclusive roles                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Role pairs NOBODY may hold at once. A FIFTH invariant, alongside the sticky
+ * baseline, the last-admin guard, the compare-and-set and CH-1.
+ *
+ * ONE PAIR TODAY: `jcrc` + `scrc`. This is not tidiness — it closes a hole that
+ * the capability matrix cannot see, because the leak is in the UNION of two
+ * individually-sound role definitions:
+ *
+ *   - `roleManagerProcedure` admits anyone holding `jcrc`. So a jcrc+scrc holder
+ *     reaches `setUserRoles`, whose payload is a CLIENT-SUPPLIED FINAL ROLE SET
+ *     — defeating the entire reason `setJcrcRole` constructs its set on the
+ *     server — plus `previewBulkImport` / `commitBulkChunk` and
+ *     `createPendingGrants`.
+ *   - `assignableBy(["jcrc","scrc"])` unions ASSIGNABLE_BY.jcrc ([]) with
+ *     ASSIGNABLE_BY.scrc (["jcrc"]) to give ["jcrc"], which is non-empty, so
+ *     `bulkAssign` and `createPendingGrants` both compute TRUE for them.
+ *
+ * Composed: one person who holds both can bulk-grant `jcrc` to hundreds of
+ * accounts in a single call, or queue deferred grants that redeem later — and
+ * NONE of those paths reads the `scrc.enabled` kill switch, because the switch
+ * is checked in the three scrc procedures and nowhere else. The switch would be
+ * off and the grant power would still be live. The original plan left this as an
+ * "operational rule: do not grant scrc to a jcrc holder". An operational rule is
+ * not a mechanism, and this one is a mechanism.
+ *
+ * ENFORCED ON THE RESULTING SET, NOT THE DELTA, at every writer of
+ * `UserRole.roles`: assertCanMutateRoles (audited denial — covers setUserRoles,
+ * setJcrcRole, bulk import, bulk undo and their previews), applyRoleChange (a
+ * backstop assert for a hand-written caller), createPendingGrants (refused at
+ * creation) and redeemPendingGrants (re-checked at redemption against the
+ * target's CURRENT stored roles, because a grant is a bearer credential that
+ * outlives the state it was created in). Checking the delta instead would let a
+ * payload that merely OMITS the conflicting role slip past — the same shape of
+ * mistake G4 exists to prevent.
+ *
+ * `resident` is in no pair and must never be: it is the sticky baseline, so a
+ * pair containing it would make some role set unreachable rather than forbidden.
+ */
+export const EXCLUSIVE_ROLE_PAIRS = [[JCRC_ROLE, SCRC_ROLE]] as const;
+
+/**
+ * The deny reason if `roles` contains a forbidden pair, else null.
+ *
+ * Returns a STRING rather than throwing, because its four call sites need four
+ * different failure modes — an audited `deny()`, an INTERNAL_SERVER_ERROR
+ * assert, a Zod-level refusal and a quiet skip on the never-throws session path.
+ * Lives here rather than in admin.ts so the redemption path in this file can use
+ * it without closing the auth.ts import cycle.
+ */
+export function forbiddenRoleCombination(
+  roles: readonly string[],
+): string | null {
+  for (const [a, b] of EXCLUSIVE_ROLE_PAIRS) {
+    if (roles.includes(a) && roles.includes(b)) {
+      return `CANNOT_HOLD_${a.toUpperCase()}_AND_${b.toUpperCase()}`;
+    }
+  }
+  return null;
+}
 
 export function isRole(v: string): v is Role {
   return (ROLES as readonly string[]).includes(v);
@@ -357,6 +547,53 @@ export const userIDSchema = z
   .trim()
   .toUpperCase()
   .regex(E_FORMAT, "Must be an E-format NUSNET id");
+
+/**
+ * An `EXT:` allowlist pin as an INPUT — the other half of the principal key
+ * space (08-userid-keydrift.md §3 Branch C, prisma/schema.prisma's
+ * `AuthAllowlist`).
+ *
+ * `.trim().toUpperCase()` first, mirroring `userIDSchema` above so the two
+ * behave identically on whitespace and case: a pasted "  ext:ngocanh_mai " must
+ * either resolve or be refused, never be quietly stored as a third spelling of
+ * one key.
+ *
+ * The pattern is `EXT_ID` from ~/lib/identity, IMPORTED AND NOT RESTATED —
+ * scripts/remediation/verify-identity-parity.mjs bans private identity
+ * derivations by source scan, and a second copy of this regex is precisely the
+ * thing that rots.
+ */
+export const extUserIDSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(EXT_ID, "Must be an EXT: allowlist id");
+
+/**
+ * The role-mutation TARGET: `userIDSchema` PLUS the EXT namespace, and NOTHING
+ * ELSE WIDENS.
+ *
+ * LIVES HERE, BESIDE `userIDSchema`, FOR THE SAME REASON THAT ONE DOES: this
+ * module is runtime-pure and therefore importable by client components, and
+ * `src/app/admin/_components/audit/AuditLogTable.tsx` parses its filter inputs
+ * with this exact schema so the client cannot be stricter than the server
+ * (I-12; a client guard that rejects what the server accepts fails open,
+ * 09 §2.6). Defining it in routers/admin.ts instead would drag `node:crypto`
+ * and `~/env` into the browser bundle.
+ *
+ * The APPLICATION of it is enumerated, and the enumeration is the containment —
+ * see the note beside `setUserRoles` in routers/admin.ts. It is applied at
+ * exactly three server sites (`setUserRoles`, `explainAccess`, `listAuditLog`'s
+ * filters). Every other target site — bulk import's `resolveIdentifier`,
+ * pending grants, CCA-head grants, and the hall office's own `setJcrcRole` —
+ * stays on the bare `userIDSchema`, so the EXT namespace is unreachable from a
+ * pasted spreadsheet.
+ *
+ * `.or()` and NOT a rewritten regex: `userIDSchema`'s `.trim().toUpperCase()`
+ * transform is load-bearing at all 11 of its existing sites and a hand-merged
+ * pattern would drop it.
+ */
+export const roleTargetUserIDSchema = userIDSchema.or(extUserIDSchema);
 
 /* -------------------------------------------------------------------------- */
 /* I-8b — the stored baseline's self-heal                                      */
@@ -536,7 +773,7 @@ export async function ensureBaseline(
  * grants would sit until purgeExpiredPendingGrants silently deleted them.
  * Shipping the writer without the reader is worse than shipping neither.
  *
- * FOUR PROPERTIES, all load-bearing:
+ * FIVE PROPERTIES, all load-bearing:
  *
  *  1. NEVER THROWS. Same rule as ensureBaseline — it is awaited (indirectly) on
  *     the NextAuth session path, and a rejection there force-logs-out the user.
@@ -559,6 +796,14 @@ export async function ensureBaseline(
  *  4. `pendingCheckedAt` IS STAMPED UNCONDITIONALLY, including the no-grant and
  *     expired cases. That stamp is what makes the steady-state cost of this
  *     whole feature exactly zero queries after one run per user.
+ *
+ *  5. THE EXCLUSION INVARIANT IS RE-CHECKED AT REDEMPTION, against the TARGET'S
+ *     current roles (EXCLUSIVE_ROLE_PAIRS). Property 3's argument applied to the
+ *     other side of the grant: this is the one writer of UserRole.roles that
+ *     does not pass through applyRoleChange, so G8 cannot see it, and a pending
+ *     `jcrc` queued before the target was made `scrc` would otherwise create the
+ *     forbidden pair silently at their next login. Costs one findUnique on a
+ *     path that runs once per user, ever.
  */
 export async function redeemPendingGrants(
   db: PrismaClient,
@@ -603,9 +848,33 @@ export async function redeemPendingGrants(
           : [],
     );
     const canAssign = assignableBy(granterRoles);
-    const granted = grant.roles.filter(
+    let granted = grant.roles.filter(
       (r) => isGrantableRole(r) && canAssign.has(r),
     );
+
+    // Property 5. THE EXCLUSION INVARIANT, re-checked HERE against the target's
+    // CURRENT stored roles — not against the roles they had when the grant was
+    // queued, which is the same argument property 3 makes about the granter.
+    // This path is the fourth writer of UserRole.roles and the ONE that does not
+    // go through applyRoleChange, so G8 cannot cover it; without this, a pending
+    // `jcrc` created before someone was made `scrc` would quietly produce the
+    // forbidden pair at their next login, with no actor present to refuse.
+    //
+    // The whole grant is refused rather than partially applied: a bearer
+    // credential that silently degrades to a subset is worse than one that fails
+    // and says so, and `refused` below already carries the reason onto the audit
+    // row. `$addToSet` is additive, so there is nothing to roll back.
+    const targetRow = await db.userRole.findUnique({ where: { userID } });
+    const targetStored = normalizeStoredRoles(
+      targetRow?.roles?.length
+        ? targetRow.roles
+        : targetRow?.role
+          ? [targetRow.role]
+          : [],
+    );
+    const conflict = forbiddenRoleCombination([...targetStored, ...granted]);
+    if (conflict) granted = [];
+
     const refused = grant.roles.filter((r) => !granted.includes(r));
 
     if (granted.length > 0) {
@@ -638,10 +907,14 @@ export async function redeemPendingGrants(
       rolesBefore: grant.roles,
       rolesAfter: granted,
       ok: granted.length > 0,
+      // The conflict is reported AHEAD of the granter check, because when both
+      // fire the exclusion is the real reason and "the granter may no longer
+      // assign this" would send an investigator to the wrong person.
       denyReason:
-        refused.length > 0
+        conflict ??
+        (refused.length > 0
           ? `GRANTER_NO_LONGER_MAY_ASSIGN:${refused.join("+")}`
-          : null,
+          : null),
       batchId: grant.batchId,
     });
     await stampPendingChecked(db, userID);
@@ -873,11 +1146,79 @@ export type Capabilities = {
    * because it is the only irreversible write in the admin surface.
    */
   deleteUsers: boolean;
+
+  /* ---- Hall Office / SCRC (scrc) ---------------------------------------- */
+
+  /**
+   * May reach /scrc AT ALL — the hall office's own surface.
+   *
+   * COARSE, exactly like reachDashboard and reachCcaDashboard: it answers "is
+   * this surface for you", never "may you do the thing on it". Every procedure
+   * the page calls re-asserts its own capability and the `scrc.enabled` switch.
+   *
+   * DELIBERATELY NOT reachDashboard. /scrc is a top-level route with its own
+   * layout precisely so that `scrc` never needs reachDashboard, which would
+   * drag in AdminShell, the manager-only admin.getStats overview, and every
+   * /admin/* child layout that trusts its parent.
+   */
+  reachScrcDashboard: boolean;
+  /**
+   * May list, grant and revoke `jcrc` through the /scrc surface — appointing
+   * the JCRC is the hall office's job.
+   *
+   * This is the capability form of ASSIGNABLE_BY.scrc = ["jcrc"], not a second
+   * source of truth: the actual write still goes through assertCanMutateRoles
+   * and applyRoleChange, which re-read the actor's roles live (I-5) and consult
+   * the maps. This field only gates reaching the three procedures.
+   *
+   * It is NOT `listUsers`. admin.listUsers pages the whole hall; the hall
+   * office gets admin.listJcrcRoster (the jcrc roster only, admins filtered
+   * OUT rather than redacted) plus a one-identifier-in, one-person-out
+   * resolver, which is the narrowest pair that supports both grant and revoke.
+   */
+  manageJcrcRoster: boolean;
+  /**
+   * May read ANY CCA's roster (heads + members), read-only.
+   *
+   * Deliberately a SECOND capability rather than widening `viewAnyCcaRoster`,
+   * which gates /admin/ccas — a page that also manages CCA heads. Consulted
+   * only by `assertMayViewCcaRoster`. Do NOT pass it to `assertHeadsCca`.
+   *
+   * NEVER a licence to WRITE a roster, and never a licence to read PII.
+   * "Roster" here means NAMES, headship and grant dates — and holding this
+   * capability alone is NOT what makes that true. A raw roster carries every
+   * member's email, stored userID and raw membership keys (mostly A-format
+   * matric numbers), so cca.getRoster and cca.listHeads REDACT those away on
+   * the `via: "readOnly"` branch; without that, a holder who can enumerate all
+   * 89 CCAs would reassemble most of admin.listUsers plus a pile of matrics
+   * from a capability whose name says read-only. cca.memberDirectory
+   * (matric/telegram/bio) is not reachable from here at all — it stays on
+   * assertHeadsCca.
+   *
+   * So: this field opens a DOOR, and the two procedures behind it decide what
+   * walks through. Any third procedure that adopts assertMayViewCcaRoster
+   * inherits the same obligation.
+   */
+  viewCcaRostersReadOnly: boolean;
+  /**
+   * May read events of ANY status, including submitted and unpublished ones,
+   * through event.listForOversight / getForOversight.
+   *
+   * NEVER `reviewEvents`. The approve/reject mutation stays on
+   * roleManagerProcedure AND re-checks reviewEvents live, so this field cannot
+   * reach it even by accident. No attendee data is exposed by either oversight
+   * procedure — that is event.exportAttendees, which is head-scoped.
+   */
+  viewEventsReadOnly: boolean;
 };
 
 export function computeCapabilities(roles: readonly string[]): Capabilities {
   const admin = roles.includes(ADMIN_ROLE);
   const manager = admin || roles.includes(JCRC_ROLE);
+  // Hall office. Deliberately NOT folded into `manager`: `scrc` must compute
+  // FALSE for every manager-tier field below, and the only safe way to
+  // guarantee that is for `manager` to stay literally `admin || jcrc`.
+  const scrc = roles.includes(SCRC_ROLE);
   return {
     reachDashboard: manager,
     listUsers: manager,
@@ -905,5 +1246,54 @@ export function computeCapabilities(roles: readonly string[]): Capabilities {
     reviewEvents: manager,
     manageUserProfiles: manager,
     deleteUsers: admin,
+    // SCRC_ROLE's first appearance in a capability. Admin is included in all
+    // four so an admin can exercise and inspect the hall-office surface
+    // without holding the role; `manager` in the two read-only fields is a
+    // WIDENING OF NOTHING — admin and jcrc already reach both surfaces through
+    // manageCcaHeads / reviewEvents, so those two fields are additive for
+    // `scrc` and behaviour-identical for everyone else.
+    reachScrcDashboard: admin || scrc,
+    manageJcrcRoster: admin || scrc,
+    viewCcaRostersReadOnly: manager || scrc,
+    viewEventsReadOnly: manager || scrc,
   };
 }
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time proof for the profile gate's exemption list                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `src/lib/profileCompleteness.ts` names the roles that are exempt from the
+ * strict profile gate. It CANNOT import SCRC_ROLE from this file — it is
+ * value-imported by `"use client"` components and must stay server-import-free —
+ * so it duplicates the role string as a key of MINIMAL_PROFILE_ROLES.
+ *
+ * THIS LINE IS WHAT MAKES THAT DUPLICATION SAFE. Typing the key list as
+ * `readonly Role[]` turns a typo ("srcc") or an invented role ("hall_office")
+ * into a `tsc --noEmit` error at build time. Without it the exemption would be
+ * SILENTLY INERT: the gate would keep holding the hall office, the symptom would
+ * be "they are still stuck at /profile", and nothing anywhere would point at the
+ * misspelled key.
+ *
+ * The import is safe in the other direction too: `~/lib/profileCompleteness` has
+ * no server imports at all (no Prisma, no `~/env`, no `next/server`), so this
+ * file stays runtime-pure exactly as its header requires — the same reasoning
+ * that already permits the `~/lib/identity` import at the top.
+ *
+ * NOTE THE CAST, WHICH IS TO `keyof typeof` AND NOT TO `Role[]`. Writing
+ * `Object.keys(MINIMAL_PROFILE_ROLES) as Role[]` — the obvious form — would be
+ * INERT: it asserts the conclusion instead of checking it, and a misspelled key
+ * would compile clean. Casting to the object's OWN key union and then ASSIGNING
+ * that to `readonly Role[]` is what makes the compiler do the work: the
+ * assignment fails if any key is not a member of ROLES.
+ */
+import { MINIMAL_PROFILE_ROLES } from "~/lib/profileCompleteness";
+const _minimalRolesAreRealRoles: readonly Role[] = Object.keys(
+  MINIMAL_PROFILE_ROLES,
+) as (keyof typeof MINIMAL_PROFILE_ROLES)[];
+// Referenced so `@typescript-eslint/no-unused-vars` stays quiet without an
+// eslint-disable comment. Same escape hatch as `void KILL_SWITCH_NOTE` in
+// src/server/api/routers/ccaAdmin.ts. The declaration above is the assertion;
+// this statement only keeps it alive.
+void _minimalRolesAreRealRoles;

--- a/src/server/api/services/roles.ts
+++ b/src/server/api/services/roles.ts
@@ -274,6 +274,20 @@ export const AUDIT_ACTIONS = [
   // 18 and 21 characters, both under the 32-char cap.
   "authAllowlist.add",
   "authAllowlist.remove",
+  // IDENTITY RE-KEY (scripts/remediation/rekey-to-ext-identity.mjs). Written
+  // once per migrated account, and it is THE ONLY THING THAT TIES THE TWO KEYS
+  // TOGETHER.
+  //
+  // That matters more here than for any other action in this list, because
+  // `RoleAuditLog` is deliberately NOT re-keyed by that script — those rows
+  // state what was true at the time and rewriting them would make the log
+  // assert history that did not happen. The consequence is that an account's
+  // audit trail is SPLIT across its old key and its pin, and this row is the
+  // join: `rolesBefore: [<old key>]`, `rolesAfter: [<pin>]`, `targetUserID`
+  // the pin. Without it the pre-migration half of a person's history is
+  // unreachable by anyone who only knows their current id.
+  // 13 characters, well under the 32-char cap.
+  "identity.rekey",
 ] as const;
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 

--- a/src/server/api/services/scrcFlag.ts
+++ b/src/server/api/services/scrcFlag.ts
@@ -1,0 +1,73 @@
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+/* -------------------------------------------------------------------------- */
+/* The Hall Office (SCRC) kill switch                                          */
+/* -------------------------------------------------------------------------- */
+
+const SCRC_FLAG_KEY = "scrc.enabled";
+const FLAG_TTL_MS = 15_000;
+
+let scrcFlagCache: { at: number; on: boolean } | null = null;
+
+/**
+ * I-11 applied to the /scrc surface, with the SAME deliberate divergence from
+ * the three switches in access.ts that isCcaManagementEnabled makes.
+ *
+ * Those switches gate whether NEW enforcement applies to an EXISTING path, so
+ * they fail OPEN — an unreachable flag means "behave as the app did yesterday",
+ * which for them is no gate. That is right for enforcement and WRONG here.
+ *
+ * This switch gates a NEW surface whose central operation is GRANTING `jcrc` —
+ * i.e. the one path by which a non-admin can create a manager-tier account.
+ * "Behave as yesterday" for a surface that did not exist yesterday means
+ * DISABLED. So an unreachable flag returns false, and the absence of the row
+ * returns false: the whole hall-office surface is inert until someone
+ * deliberately writes `scrc.enabled = "on"`, which is also how it is turned off
+ * again in 15 seconds without a redeploy.
+ *
+ * Lives in its own module rather than in ccaScope.ts because it is neither a
+ * CCA concern nor an enforcement mode, and because ccaScope.ts's
+ * resetCcaManagementCache() is scoped to its own flag.
+ */
+export async function isScrcEnabled(db: PrismaClient): Promise<boolean> {
+  if (scrcFlagCache && Date.now() - scrcFlagCache.at < FLAG_TTL_MS) {
+    return scrcFlagCache.on;
+  }
+  try {
+    const row = await db.systemFlag.findUnique({
+      where: { key: SCRC_FLAG_KEY },
+    });
+    const on = row?.value === "on";
+    scrcFlagCache = { at: Date.now(), on };
+    return on;
+  } catch {
+    // Fail CLOSED, and deliberately NOT cached — the next request retries
+    // rather than pinning "disabled" for 15s on a transient Atlas hiccup.
+    return false;
+  }
+}
+
+/** Test/ops seam: drop the per-lambda cache so the next read hits the row. */
+export function resetScrcFlagCache(): void {
+  scrcFlagCache = null;
+}
+
+/**
+ * Assert the switch is on. Called at the top of EVERY scrc-reachable procedure
+ * and on the `scrc` branch of assertMayViewCcaRoster — the page-level check is
+ * cosmetic (there is deliberately none in /scrc/layout.tsx, following the
+ * manage-ccas precedent), this one is the boundary.
+ *
+ * Note where it is NOT called: computeCapabilities, which is synchronous,
+ * DB-free and imported by client components, and the booking path, which is
+ * governed purely by the FacilityAccess row for facility 17.
+ */
+export async function assertScrcEnabled(db: PrismaClient): Promise<void> {
+  if (!(await isScrcEnabled(db))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "SCRC_DISABLED",
+    });
+  }
+}

--- a/src/server/api/services/userAdmin.ts
+++ b/src/server/api/services/userAdmin.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { canonicalUserID, type CanonicalUserID } from "~/lib/identity";
 import { getUserRoles } from "./access";
+import { resolvePrincipalID } from "./authAllowlist";
 import { ADMIN_ROLE } from "./roles";
 
 /**
@@ -152,9 +153,35 @@ export async function loadAdminUserTarget(
   return {
     userObjectId: row.id,
     email: row.email,
-    // I-1. Derived here and nowhere else. `row.userID` is NOT consulted for
-    // this — it is carried alongside, for display and for the mismatch check.
-    canonicalUserID: canonicalUserID(row.email),
+    /**
+     * I-1 STILL HOLDS: this is derived from the EMAIL and from nowhere else.
+     * `row.userID` is NOT consulted for it — that column is carried alongside,
+     * for display and for the mismatch check, because on ~515 rows it holds an
+     * A-format matric and on the split-identity rows it holds ANOTHER LIVE
+     * HUMAN'S key.
+     *
+     * It now resolves the `EXT:` namespace too, so an allowlist-pinned account's
+     * admin record is keyed exactly the way the session keys it. Three
+     * consequences, each verified rather than assumed:
+     *
+     *  - userAdmin.get reads the target's roles under the right key, so the
+     *    role-aware profile gate agrees with the session. WITHOUT THIS the
+     *    role-awareness is inert for exactly the accounts it was added for, and
+     *    the admin surface reports "missing matric/block/telegram" for a user
+     *    the gate is not holding — a false alarm on the one page whose job is
+     *    diagnosing the gate.
+     *  - assertMayManageUserProfileOf's CANNOT_MODIFY_AN_UNKEYED_ACCOUNT branch
+     *    stops firing, so A JCRC CAN NOW EDIT A PINNED ACCOUNT'S displayName /
+     *    block / bio. ACCEPTED, and stated here rather than discovered: it is
+     *    identical to how every resident is already treated (`scrc` is not
+     *    `admin`), it does not reach roles, matric-as-identity or email, and
+     *    the alternative — leaving `cid` null — breaks the bullet above and
+     *    re-opens the delete hazard below by a different door.
+     *  - computeDeleteRefusals' ABSENT_CANONICAL_ID and LEGACY_KEY_MISMATCH
+     *    stop firing, which makes DELETE reachable. That is why
+     *    PINNED_ALLOWLIST_ACCOUNT exists — see it.
+     */
+    canonicalUserID: await resolvePrincipalID(db, row.email),
     legacyUserID: row.userID,
     displayName: row.displayName,
     telegramHandle: row.telegramHandle,
@@ -344,6 +371,7 @@ export type DeleteRefusal =
   | "ABSENT_CANONICAL_ID"
   | "LEGACY_KEY_MISMATCH"
   | "SHARED_CANONICAL_ID"
+  | "PINNED_ALLOWLIST_ACCOUNT"
   | `SOLE_HEAD_OF_CCA:${number}`;
 
 /**
@@ -444,6 +472,42 @@ export async function computeDeleteRefusals(
   // reusing it would print "this account has no matric record" as the reason a
   // delete was refused.
   if (cid === null) out.push("ABSENT_CANONICAL_ID");
+
+  // --- the identity was ISSUED BY AN ALLOWLIST PIN --------------------------
+  // A pinned account is now DELETABLE as far as every other refusal here is
+  // concerned: loadAdminUserTarget resolves the EXT namespace, so cid is
+  // non-null (ABSENT_CANONICAL_ID does not fire) and provisioning writes the
+  // pin into `User.userID` (LEGACY_KEY_MISMATCH does not fire either). Without
+  // this refusal the delete would go through.
+  //
+  // AND `deleteUserAccountCascade` DOES NOT KNOW ABOUT AuthAllowlist. It cleans
+  // thirteen collections and that is not one of them, so the delete would leave
+  // the pin standing. Re-creating a `User` row on that address — which anyone
+  // could then do, because maySignIn still admits it — RE-ATTACHES the identity,
+  // and with it any UserRole document the cascade did not reach. That is
+  // 07-cca-future.md §5's hazard exactly, and it is the same shape as the attack
+  // the whole collection is designed against: a key spent by a party who was
+  // never granted it.
+  //
+  // REFUSING RATHER THAN EXTENDING THE CASCADE, deliberately. The pin is an
+  // ADMIN-ISSUED CREDENTIAL. Destroying it should be a separate, deliberate,
+  // audited act on the surface that issued it (admin.removeAuthAllowlistEntry),
+  // not a silent side effect inside a thirteen-collection transaction that also
+  // carries a retention special case for Bookings. The operator's path is:
+  // revoke the roles, remove the pin, then delete the account — three audit
+  // rows instead of one.
+  //
+  // PAIRED WITH removeAuthAllowlistEntry's PIN_STILL_HOLDS_ROLES, which refuses
+  // the OPPOSITE order. Two locks on opposite doors: you cannot delete the
+  // account while the pin lives, and you cannot remove the pin while it holds
+  // roles. The only way through is the one that leaves a complete trail.
+  if (cid !== null) {
+    const pin = await db.authAllowlist.findUnique({
+      where: { pinnedUserID: cid },
+      select: { id: true },
+    });
+    if (pin) out.push("PINNED_ALLOWLIST_ACCOUNT");
+  }
 
   // --- self -----------------------------------------------------------------
   // Without this an admin can delete themselves straight out of the last-admin

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -13,8 +13,9 @@ import { ZodError } from "zod";
 
 import { auth } from "~/server/auth";
 import { db } from "~/server/db";
-import { ADMIN_ROLE, JCRC_ROLE } from "~/server/api/services/roles";
+import { ADMIN_ROLE, JCRC_ROLE, SCRC_ROLE } from "~/server/api/services/roles";
 import { isMatricRequired } from "~/server/api/services/access";
+import { isMinimalProfileRole } from "~/lib/profileCompleteness";
 
 /**
  * 1. CONTEXT
@@ -209,9 +210,30 @@ export const identifiedProcedure = protectedProcedure.use(({ ctx, next }) => {
  * posts alike. `rbac.booking.enforcement` does not reach this path, so without
  * a switch of its own the only remedy would be a redeploy. See
  * isMatricRequired.
+ *
+ * THE ONE EXEMPTION (`isMinimalProfileRole`) comes from the SAME predicate the
+ * strict profile gate uses — src/lib/profileCompleteness.ts — not a second list
+ * of roles that would drift from it. A hall-office (`scrc`) account is staff: it
+ * has no matriculation number to hold, so without this the day anyone flips the
+ * unrelated `rbac.matric.enforcement` switch to "enforce" the hall office
+ * silently loses BOOKING (facilitiesBooking's createBooking and updateBooking
+ * are both matricProcedure) — the exact capability this role exists to grant,
+ * lost months later from a switch nobody connected to it.
+ *
+ * Reading `ctx.session.user.roles` here is sound and precedented: `requireRoles`
+ * below does exactly the same, and the session role list is a LIVE per-request
+ * database read (I-4, the session callback in auth.ts), so there is no
+ * stale-privilege window.
+ *
+ * ORDER MATTERS for cost, not correctness: the two synchronous checks run before
+ * the flag read, so an exempt caller never issues the `isMatricRequired` query.
  */
 export const matricProcedure = protectedProcedure.use(async ({ ctx, next }) => {
-  if (!ctx.session.user.hasMatric && (await isMatricRequired(ctx.db))) {
+  if (
+    !ctx.session.user.hasMatric &&
+    !isMinimalProfileRole(ctx.session.user.roles ?? []) &&
+    (await isMatricRequired(ctx.db))
+  ) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "MATRIC_REQUIRED",
@@ -222,11 +244,22 @@ export const matricProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 
 /**
  * Composable matric gate, so role + matric can be layered in either order.
- * Same rule as `matricProcedure`, including the kill switch, expressed as a
- * middleware for callers that build their own chain.
+ * Same rule as `matricProcedure`, including the kill switch AND including the
+ * `isMinimalProfileRole` exemption — the two MUST agree, or which of the two
+ * spellings a router happened to use would decide whether the hall office can
+ * book. See matricProcedure above for why the exemption exists at all.
+ *
+ * Built with `t.middleware`, so `ctx.session` is typed as the ROOT context and
+ * is nullable here; the roles are therefore read as `ctx.session?.user?.roles ??
+ * []`, which is the same optional-chained shape the `hasMatric` check beside it
+ * already uses. An absent session yields `[]`, which is never exempt.
  */
 export const requireMatric = t.middleware(async ({ ctx, next }) => {
-  if (!ctx.session?.user?.hasMatric && (await isMatricRequired(ctx.db))) {
+  if (
+    !ctx.session?.user?.hasMatric &&
+    !isMinimalProfileRole(ctx.session?.user?.roles ?? []) &&
+    (await isMatricRequired(ctx.db))
+  ) {
     throw new TRPCError({ code: "FORBIDDEN", message: "MATRIC_REQUIRED" });
   }
   // `next()` with NO argument, deliberately, here and in every middleware below.
@@ -362,3 +395,32 @@ export const adminProcedure = protectedProcedure
 
 /** May reach role management at all: admin or jcrc. The D-2 dashboard gate. */
 export const roleManagerProcedure = roleProcedure(JCRC_ROLE);
+
+/**
+ * May reach the HALL OFFICE surface: admin or scrc. NOT a role-manager.
+ *
+ * A separate builder rather than `roleProcedure(JCRC_ROLE, SCRC_ROLE)` — and
+ * emphatically not a widening of roleManagerProcedure above, which gates ~25
+ * procedures including listUsers, setUserRoles, every bulk-import and
+ * pending-grant surface, explainAccess, systemHealth and the whole CCA-head
+ * manager. Admitting `scrc` there would hand the hall office the entire manager
+ * tier in one character. This builder gates exactly three procedures
+ * (listJcrcRoster / resolveJcrcCandidate / setJcrcRole), each of which ALSO
+ * asserts `manageJcrcRoster` and the `scrc.enabled` switch.
+ *
+ * A jcrc is deliberately NOT admitted: appointing the JCRC is hall-office work,
+ * and D-3 already says a jcrc may not grant jcrc.
+ */
+export const scrcProcedure = roleProcedure(SCRC_ROLE);
+
+/**
+ * READ-ONLY oversight of CCAs and events: admin, jcrc or scrc.
+ *
+ * Wider than either of the two above, and safe only because everything behind
+ * it is a read with no PII: the CCA roster (names, no matric/telegram/bio) and
+ * event records (no attendees). The write and PII procedures on the same data —
+ * cca.memberDirectory, cca.updateProfile, event.decide, event.exportAttendees —
+ * keep their existing, narrower builders and their own guards. Do not adopt
+ * this builder for anything that writes.
+ */
+export const oversightProcedure = roleProcedure(JCRC_ROLE, SCRC_ROLE);

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -14,13 +14,17 @@ import { z } from "zod";
 import { env } from "~/env";
 import { db } from "~/server/db";
 import { verifyPassword } from "~/lib/password";
-import { computeProfileGaps } from "~/lib/profileCompleteness";
-import type { CanonicalUserID } from "~/lib/identity";
 import {
-  canonicalUserID,
-  isNusStudentEmail,
-  normalizeEmail,
-} from "~/lib/identity";
+  REQUIRED_PROFILE_FIELDS,
+  computeProfileGaps,
+  requiredProfileFieldsFor,
+} from "~/lib/profileCompleteness";
+import type { CanonicalUserID } from "~/lib/identity";
+// `canonicalUserID` is deliberately NOT imported here any more: the session
+// callback resolves through resolvePrincipalID below, which composes it with
+// the allowlist. Importing it again would invite a second, half-aware
+// derivation of the session key.
+import { isNusStudentEmail, normalizeEmail } from "~/lib/identity";
 import {
   BASELINE_ROLE,
   ADMIN_ROLE,
@@ -32,6 +36,15 @@ import {
   getAuthEnforcement,
   isMatricRequired,
 } from "~/server/api/services/access";
+// The D-7 break-glass ALLOWLIST — the collection half. Read its header before
+// touching either call site below: it is the only thing in this app that can
+// turn an address the domain rule rejects into an authorization key, and the
+// mechanism that keeps that safe (M2, namespace re-validation at every read)
+// lives there, not here.
+import {
+  pinnedUserIDFor,
+  resolvePrincipalID,
+} from "~/server/api/services/authAllowlist";
 // The ONE derivation of "does another live User row resolve to this NUSNET id".
 // Imported rather than restated: a second copy is a second chance to write the
 // equality-on-email version, which misses the whitespace variants that are
@@ -39,11 +52,26 @@ import {
 import { findCanonicalIdCollisions } from "~/server/api/services/userAdmin";
 
 /**
- * D-7 + I-12. THE eligibility predicate for sign-in, and the only one. The
- * domain rule itself lives in ~/lib/identity — this wrapper adds nothing but
- * the break-glass allowlist, which is SIGN-IN ONLY: an allowlisted non-NUS
- * address still has canonicalUserID() === null, so it receives no stored
- * baseline (I-8d), holds no roles and cannot book.
+ * D-7 + I-12. THE domain half of the eligibility predicate. The rule itself
+ * lives in ~/lib/identity — this wrapper adds nothing but the ENV-VAR
+ * break-glass allowlist.
+ *
+ * THE ENV ALLOWLIST IS SIGN-IN ONLY, AND STILL IS. An address admitted by
+ * `AUTH_EMAIL_ALLOWLIST` still has `canonicalUserID() === null`, so it receives
+ * no stored baseline (I-8d), holds no roles and cannot book. `resolvePrincipalID`
+ * — the function that decides what key a session gets — does NOT consult this
+ * variable, only the `AuthAllowlist` COLLECTION. That asymmetry is deliberate
+ * and is the whole reason both survive:
+ *
+ *   env var    admits a sign-in during an outage in which THE DATABASE is the
+ *              broken thing. Confers no identity, so it cannot be a privilege
+ *              escalation vector — there is nothing to escalate.
+ *   collection admits a sign-in AND mints an `EXT:` principal key. It is
+ *              administered through an audited adminProcedure, revocable in
+ *              seconds, and every read of it re-validates the namespace.
+ *
+ * If you ever make the env var mint a key, you have created an unaudited,
+ * un-revocable, deploy-time identity source. Do not.
  *
  * Read from process.env rather than ~/env because src/env.js is outside this
  * change's scope; unset means "no exceptions", which is the safe default.
@@ -78,6 +106,22 @@ async function maySignIn(
   const email = normalizeEmail(rawEmail);
   if (!email) return false;
   if (passesDomainRule(email)) return true;
+
+  // The COLLECTION half of the break-glass (08 §3 Branch C). Reached ONLY for
+  // an address the domain rule and the env allowlist have both already
+  // rejected, so no @u.nus.edu sign-in pays for it.
+  //
+  // WITHOUT THIS LINE the admin-provisioned staff accounts are admitted today
+  // only by accident: `rbac.auth.enforcement` defaults to "off", and in that
+  // mode the fall-through below returns true for every non-empty address. The
+  // day someone flips that switch to "enforce" — which is the whole point of
+  // the switch existing — the hall office is locked out. Relying on a kill
+  // switch staying off is not a design.
+  //
+  // Fails CLOSED: pinnedUserIDFor returns the absent value on any fault and
+  // never throws, so a database outage degrades this to "not allowlisted",
+  // which is exactly the behaviour that predates the collection.
+  if ((await pinnedUserIDFor(db, email)) !== null) return true;
 
   const mode = await getAuthEnforcement(db);
   if (mode === "enforce") return false;
@@ -421,7 +465,31 @@ export const authOptions = {
         // I-1: anchored derivation via the ONE shared helper, replacing an
         // unanchored .replace() with no .trim() that returned garbage-but-truthy
         // keys like "ALICE@GMAIL.COM" for non-NUS addresses.
-        const userID = canonicalUserID(token.email);
+        //
+        // resolvePrincipalID = canonicalUserID(email) ?? pinnedUserIDFor(...).
+        //
+        // COSTS NOTHING IN STEADY STATE. The `??` short-circuits, so for every
+        // @u.nus.edu address — which is all live traffic — the right operand is
+        // never evaluated and NO query is issued. Rule 2 above ("ZERO reads
+        // beyond the two indexed findUniques") is preserved exactly. Only a
+        // non-canonical session pays, and it pays one findUnique on a unique
+        // index over a collection holding single-digit rows, behind a 15s cache.
+        // Those sessions previously early-returned below with zero queries, so
+        // this is +1 for them and +0 for everyone else.
+        //
+        // IT CANNOT THROW. resolvePrincipalID wraps its read and degrades to the
+        // absent identity — rule 1 above, and the degraded behaviour is
+        // byte-identical to what this line did before the allowlist existed.
+        //
+        // THE PIN IS DELIBERATELY NOT STAMPED ON THE TOKEN. `jwt` above writes
+        // only id/email/name and MUST STAY THAT WAY. session.maxAge is 30 days
+        // and updateAge is 24h, so a pin baked into the token would mean
+        // REMOVING AN AuthAllowlist ROW DOES NOT REVOKE THE IDENTITY FOR UP TO
+        // A MONTH — and that identity carries `scrc`. This is the same argument
+        // this file already makes for `roles` (I-4) and `matricRequired`
+        // (I-11); resolving live is what makes revocation take effect in 15
+        // seconds instead of 30 days.
+        const userID = await resolvePrincipalID(db, token.email);
         session.user.userID = userID;
         // D-C: the identity fact, derived HERE and nowhere else (no new query —
         // it is line 302's value, named). Deliberately NOT flag-aware: unlike
@@ -655,27 +723,15 @@ export const authOptions = {
         // history, not a live prompt, and reads as [] too, so a user who has
         // already filled the form is never re-prompted even though the row is
         // kept for the audit trail.
-        session.user.profileNeedsFields =
+        // READ HERE, PUBLISHED BELOW. The value cannot be assigned yet: it is
+        // now filtered by the user's ROLES (see where it lands, just after
+        // `session.user.roles`), and the role set does not exist until the
+        // self-heal has run. Splitting the read from the publish keeps the
+        // `resolvedAt` semantics next to the query they describe.
+        const rawNeedsFields =
           completionRow && completionRow.resolvedAt == null
             ? (completionRow.needsFields ?? [])
             : [];
-
-        // STRICT PROFILE GATE. Computed live from the profile fields + matric
-        // above, using the SAME rules the client dialog mirrors, so the two
-        // never disagree about who is gated. `userDoc` may be null if the read
-        // faulted — treat that as "no data to prove completeness", i.e. gated,
-        // EXCEPT it degrades safely: computeProfileGaps on all-null returns the
-        // full set, which routes to /profile where the user can fix it (never a
-        // hard lockout). A transient fault therefore over-prompts, not
-        // over-admits.
-        const profileGaps = computeProfileGaps({
-          displayName: userDoc?.displayName ?? null,
-          telegramHandle: userDoc?.telegramHandle ?? null,
-          block: userDoc?.block ?? null,
-          matric: record?.matric ?? null,
-        });
-        session.user.profileMissingFields = profileGaps;
-        session.user.profileIncomplete = profileGaps.length > 0;
 
         // Legacy-tolerant read for the D-6 dual-write window. Removing this
         // fallback belongs to doc 06 — dropping it early silently demotes any
@@ -701,6 +757,18 @@ export const authOptions = {
           // Pass the EMAIL, not the id: ensureBaseline canonicalizes internally
           // so the write cannot be reached without an @u.nus.edu address having
           // been presented (I-8d — provenance, not shape).
+          //
+          // FOR AN `EXT:` PRINCIPAL THIS BLOCK RUNS ON EVERY REQUEST, FOREVER,
+          // AND THAT IS BY DESIGN — not a bug for the next reader to "fix".
+          // 08 §3.4: an allowlist-pinned identity receives NO `resident`
+          // baseline, so `stored` never contains it and this condition is
+          // always true for them. The call costs one function invocation and
+          // NOTHING ELSE: ensureBaseline canonicalizes the email itself, gets
+          // null for an @nus.edu.sg address, and returns false at its `!userID`
+          // clause BEFORE issuing any query or any write. That the baseline is
+          // withheld mechanically — by the email failing to canonicalize —
+          // rather than by an `if (isExt)` somewhere is exactly what makes it
+          // trustworthy; see isCanonicalResidentID's note in ~/lib/identity.
           const healed = await ensureBaseline(db, token.email);
           if (healed) stored = [...stored, BASELINE_ROLE];
           // If it did NOT heal we do NOT synthesise the role. The stored value
@@ -716,6 +784,74 @@ export const authOptions = {
         session.user.roles = roles;
         session.user.isAdmin = roles.includes(ADMIN_ROLE);
 
+        /* ---- WALL 2: the POST-MERGE completion prompt ----------------------
+         * ROLE-AWARE, AND IT HAS TO BE, because MatricGate checks THIS BEFORE
+         * the strict profile gate below (`needsProfileCompletion` gates
+         * `needsProfileDetails`) and routes to /onboarding/complete-profile.
+         *
+         * Without the filter, an exempt account carrying a ProfileCompletion
+         * row that names `matric` / `block` / `telegramHandle` would be held at
+         * that page permanently: the fields it demands are exactly the ones the
+         * exemption says they will never have, so there is no input that clears
+         * the prompt. `profileIncomplete` being false would not help — the gate
+         * never reaches it. That is the resident-stranding trap
+         * unstick-profile-completion.mjs was written to release 18 people from,
+         * re-created for a population that cannot escape it at all.
+         *
+         * LATENT TODAY, FIXED ANYWAY. Only the merge scripts write
+         * ProfileCompletion rows, and an EXT identity cannot have been merged
+         * (nothing else canonicalises to a pin). But "unreachable" here rests on
+         * a property of a different subsystem, and the cost of not depending on
+         * that is four lines.
+         *
+         * THE FILTER IS CONSERVATIVE IN THE SAME DIRECTION userAdmin's WALL 2
+         * is: a name this deploy's vocabulary does not recognise is KEPT, never
+         * dropped, because a deploy cannot judge a field it does not understand.
+         * Only a field that IS in the strict vocabulary AND is not required of
+         * THIS user is removed. For every non-exempt account the required set
+         * IS the strict vocabulary, so this filter is the identity function and
+         * all 1382 residents behave byte-identically.
+         */
+        const requiredForUser = new Set<string>(requiredProfileFieldsFor(roles));
+        const strictVocabulary = new Set<string>(REQUIRED_PROFILE_FIELDS);
+        session.user.profileNeedsFields = rawNeedsFields.filter(
+          (f) => !strictVocabulary.has(f) || requiredForUser.has(f),
+        );
+
+        // STRICT PROFILE GATE. Computed live from the profile fields + matric
+        // above, using the SAME rules the client dialog mirrors, so the two
+        // never disagree about who is gated. `userDoc` may be null if the read
+        // faulted — treat that as "no data to prove completeness", i.e. gated,
+        // EXCEPT it degrades safely: computeProfileGaps on all-null returns the
+        // full set, which routes to /profile where the user can fix it (never a
+        // hard lockout). A transient fault therefore over-prompts, not
+        // over-admits.
+        //
+        // MOVED BELOW THE ROLE RESOLUTION. computeProfileGaps is now ROLE-AWARE
+        // (src/lib/profileCompleteness.ts: MINIMAL_PROFILE_ROLES — hall office
+        // staff hold no matric, live in no block, and have no reason to publish
+        // a Telegram handle to residents), so the gate must read the SAME live
+        // role set the rest of this callback does. Nothing between the old
+        // position and this one reads profileGaps, so the move is inert for
+        // every existing user.
+        //
+        // DO NOT compute a second, earlier role set to keep this where it was.
+        // That is a second derivation of the same fact in the same function and
+        // it WILL drift — and when it drifts, the session gate and the tRPC
+        // walls in userAdmin.ts stop agreeing about who is held, which is the
+        // exact state unstick-profile-completion.mjs exists to clean up.
+        const profileGaps = computeProfileGaps(
+          {
+            displayName: userDoc?.displayName ?? null,
+            telegramHandle: userDoc?.telegramHandle ?? null,
+            block: userDoc?.block ?? null,
+            matric: record?.matric ?? null,
+          },
+          roles,
+        );
+        session.user.profileMissingFields = profileGaps;
+        session.user.profileIncomplete = profileGaps.length > 0;
+
         // D-8 pending-grant redemption. `pendingCheckedAt` is stamped
         // unconditionally by redeemPendingGrants as its final step (INCLUDING
         // the no-grants and expired cases), which is what makes this check cost
@@ -729,6 +865,17 @@ export const authOptions = {
         // does not need to be visible in THIS request (the claimant has just
         // signed up and is being redirected anyway), and awaiting it would put a
         // multi-write path in front of every first page load.
+        //
+        // FOR AN `EXT:` PRINCIPAL BEFORE ITS FIRST ROLE GRANT there is no
+        // UserRole row at all, so `roleRow` is null, `pendingCheckedAt` is
+        // undefined and this fires on every request. It costs one findUnique on
+        // PendingRoleGrant plus one FAILING update, both swallowed — and,
+        // importantly, IT CANNOT CREATE A STRAY UserRole ROW: stampPendingChecked
+        // uses `update`, not `upsert`, inside its own try/catch, so a missing
+        // document throws P2025 into that catch rather than inserting an empty,
+        // role-less row under the pin. Two wasted queries per request for one
+        // account until the `scrc` grant lands, after which the row exists and
+        // this stamps once and never runs again.
         if (roleRow?.pendingCheckedAt == null) {
           void redeemPendingGrants(db, userID).catch(() => {
             /* contained */


### PR DESCRIPTION
Adds a `scrc` role for hall office staff, and the `EXT:` identity mechanism it needs in order to exist at all.

## What SCRC can do

- **View CCAs and events, read-only.** New `viewCcaRostersReadOnly` / `viewEventsReadOnly` capabilities and a new `assertMayViewCcaRoster` guard. `assertHeadsCca` is byte-identical — it also gates CCA writes, event publish/cancel and attendee export, so widening it was never an option.
- **Book the SCRC Room and every other room.** All 47 `FacilityAccess` rows now include `scrc`. Residents booking nothing is intentional and unchanged.
- **Grant and revoke `jcrc`.** Through a dedicated mutation that builds the role set server-side, so it cannot express the removal of any other role.
- **Nothing else.** All 19 forbidden capabilities compute `false` for a plain `["resident","scrc"]` holder.

## The escalation closure — please read this before approving

`scrc` grants `jcrc`. A `jcrc` holder has the full manager tier. So **SCRC can, via a second person, reach everything it is directly forbidden**: all-user listing, matric/Telegram PII, CCA writes, event approval.

It does **not** reach `admin`, `manageFacilityAccess`, `deleteUsers`, `readAuditLog` or `manageEnforcementFlag`. That boundary was attacked across six review rounds and held.

This is inherent to the requirement, not a defect. What contains it: self-targeting is blocked, every grant is audited with `actorRoles`, and `jcrc`+`scrc` is now **impossible to hold** — enforced on the resulting role set at every writer of `UserRole.roles`, `redeemPendingGrants` included, with no admin override. That union would otherwise unlock `bulkAssign`, and no kill switch covers it.

## The identity mechanism

Staff addresses are `@nus.edu.sg`, which `canonicalUserID()` returns null for. `AuthAllowlist` pins an approved email to a unique `EXT:<SLUG>`; `resolvePrincipalID` composes `canonicalUserID` rather than replacing it, keeping `identity.ts` pure and synchronous for its client importers.

The attack this must prevent is a row pinning an attacker's address to an admin's key — it would mint an admin session with no grant path, so no escalation guard would fire. It is now **unrepresentable**: `canonicalUserID`'s capture class contains no colon and `EXT_ID` requires one, so the two key spaces cannot intersect for any input. `verify-identity-parity.mjs` asserts it per fixture in both implementations.

⚠️ **This depends on there being no URL-decoding on a userID path.** `%` is in the localpart class, so `ext%3ax@u.nus.edu` would decode into the EXT namespace. There is none today. Adding one reopens the attack.

## Accepted residuals

- The reset-password route's **timing** still separates a provisioned address from an unknown one — only eligible-and-registered reaches the mail send. Status, body and headers are identical and rejections are now metered (5/email, 20/IP per 15min). Padding it would destroy the only signal that mail delivery is broken.
- An admin can still grant `admin` to an EXT pin. `rbac-doctor` REDs it — detection, not prevention.
- Audit rows sit **inside** the transaction in two scripts, diverging from the house rule. Justified there because both are re-runnable by construction, so rollback is free and "acted" and "audited" cannot come apart.

## Rollout state (already applied to prod DB)

- ✅ `AuthAllowlist` + both unique indexes created. Index census diffed before/after: only delta is the 3 new entries, 107→110, **`User.email_unique_ci` intact**.
- ✅ Mai Ngoc Anh provisioned as `EXT:NGOCANH_MAI`.
- ✅ All 47 facilities grant `scrc`, each audited in the same transaction as its change.
- ⬜ `scrc.enabled` deliberately **OFF** — arm it after eyeballing `/scrc`.
- ⬜ Roles not yet granted; needs this deployed (`/admin/users`, deliberately not a script).
- ⬜ Vincent Koh has an existing account with 68 bookings under `VKTJ66`; a re-key script is in review.

**No schema migration.** `prisma db push` would drop `User.email_unique_ci`; the indexes are created by `create-auth-allowlist.mjs`.

## Verification

`tsc --noEmit` clean · `lint` 0 errors · `build` clean · `verify-identity-parity.mjs` 123 comparisons, 20 fixtures.

Not verified: `/scrc` and `/admin/allowlist` have never been opened in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVNSpLeZWbVQtWpuCYKyQk
