### PR TITLE
Show a resident the interview slot they booked, on the CCA page

### DIFF
--- a/src/app/ccas/_components/BookedSlot.tsx
+++ b/src/app/ccas/_components/BookedSlot.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { AlertTriangle, CalendarClock, MapPin, Users } from "lucide-react";
+
+import { formatSlot } from "../_lib/status";
+
+/**
+ * The details of an interview slot a resident has already booked — time, room,
+ * and the two things that change what they should do about it: whether anyone
+ * else is in the room with them, and whether the CCA has since cancelled it.
+ *
+ * One component for both surfaces (the CCA detail page and My Applications) so
+ * the two cannot drift: a resident who books on one page and checks on the other
+ * must see the same sentence. `capacity`/`seatsLeft`/`canceled` are optional
+ * because myApplications sends the bare {slotID, startTime, endTime, location}
+ * shape; getCca sends the richer one.
+ */
+export default function BookedSlot({
+  slot,
+}: {
+  slot: {
+    startTime: number | null;
+    endTime: number | null;
+    location: string | null;
+    capacity?: number;
+    seatsLeft?: number;
+    canceled?: boolean;
+  };
+}) {
+  // `capacity` is already through slotCapacity() on the server, so this is a
+  // comparison and NOT another place the "absent means 1" default lives —
+  // undefined here means "the caller didn't send seat data", not "capacity 1".
+  const group = slot.capacity !== undefined && slot.capacity > 1;
+
+  return (
+    <div className="space-y-1">
+      <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-700">
+        <span className="inline-flex items-center gap-1.5 font-medium">
+          <CalendarClock className="h-4 w-4 text-gray-400" />
+          {formatSlot(slot.startTime, slot.endTime)}
+        </span>
+        {slot.location && (
+          <span className="inline-flex items-center gap-1 text-gray-600">
+            <MapPin className="h-3.5 w-3.5 text-gray-400" />
+            {slot.location}
+          </span>
+        )}
+      </p>
+
+      {/* Same warning SlotPicker gives BEFORE booking, repeated after: turning up
+          to what you thought was a 1:1 and finding three other people in the room
+          is a bad surprise either way. */}
+      {group && (
+        <p className="text-xs text-amber-700">
+          <Users className="mr-1 inline h-3 w-3 align-[-2px]" />
+          Group interview · up to {slot.capacity} people
+          {slot.seatsLeft !== undefined && (
+            <>
+              {" "}
+              — {slot.seatsLeft} seat{slot.seatsLeft === 1 ? "" : "s"} left
+            </>
+          )}
+        </p>
+      )}
+
+      {slot.canceled && (
+        <p className="text-xs font-medium text-red-600">
+          <AlertTriangle className="mr-1 inline h-3 w-3 align-[-2px]" />
+          The CCA cancelled this slot — pick another time.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/ccas/_components/CcaApplyPanel.tsx
+++ b/src/app/ccas/_components/CcaApplyPanel.tsx
@@ -13,6 +13,7 @@ import {
   isTerminalStatus,
 } from "~/lib/schemas/ccaApplication";
 import { statusBadgeClass, residentStatusLabel } from "../_lib/status";
+import BookedSlot from "./BookedSlot";
 import SlotPicker from "./SlotPicker";
 import ImageLightbox from "~/app/_components/ImageLightbox";
 
@@ -314,6 +315,19 @@ function Card({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * /ccas/applications is otherwise reachable only from the avatar dropdown, which
+ * nobody finds — so every state that already shows scheduling controls offers it
+ * (submitted and scheduled alike), not just the booked one.
+ */
+function ViewAllApplicationsButton() {
+  return (
+    <Button variant="outline" asChild>
+      <Link href="/ccas/applications">View all applications</Link>
+    </Button>
+  );
+}
+
 type AppShape = RouterOutputs["ccaApplications"]["getCca"]["application"];
 
 /**
@@ -345,6 +359,17 @@ function ApplicationInProgress({
 }) {
   const scheduled = app.status === "interview_scheduled";
   const [picking, setPicking] = useState(false);
+  // Set the moment a booking lands so the panel can say "booked ✓" rather than
+  // the neutral "Your interview" — the confirmation the resident just did
+  // something, which the status pill alone doesn't give. It is deliberately not
+  // persisted: reopening the picker means they're changing their mind, so it
+  // clears there and on a plain page load.
+  const [justBooked, setJustBooked] = useState(false);
+
+  const openPicker = () => {
+    setJustBooked(false);
+    setPicking(true);
+  };
 
   return (
     <Card>
@@ -357,15 +382,22 @@ function ApplicationInProgress({
           >
             {residentStatusLabel(app.status)}
           </span>
-          <p className="mt-2 text-sm text-gray-600">
-            {app.status === "submitted" &&
-              (openSeatCount > 0
-                ? "Your application is in. Book an interview slot below."
-                : "Your application is in. The CCA will open interview slots soon.")}
-            {scheduled && "Your interview is booked."}
-            {app.status === "interviewed" &&
-              "Your interview's done — the CCA will be in touch with a decision."}
-          </p>
+          {/* The slot panel below carries the scheduled case, with the details a
+              bare sentence never had — but only if the slot row came back. It
+              can be missing (the pointer outlived the row), and that state used
+              to read "Your interview is booked.", so keep saying at least that
+              rather than leaving the pill on its own with no sentence at all. */}
+          {(!scheduled || !app.slot) && (
+            <p className="mt-2 text-sm text-gray-600">
+              {app.status === "submitted" &&
+                (openSeatCount > 0
+                  ? "Your application is in. Book an interview slot below."
+                  : "Your application is in. The CCA will open interview slots soon.")}
+              {scheduled && "Your interview is booked."}
+              {app.status === "interviewed" &&
+                "Your interview's done — the CCA will be in touch with a decision."}
+            </p>
+          )}
         </div>
         {!scheduled && (
           <button
@@ -378,13 +410,32 @@ function ApplicationInProgress({
         )}
       </div>
 
+      {/* What was booked. Only the status pill used to say anything at all, so a
+          resident had to go hunting for the date, time and room they had just
+          chosen; this is the same renderer My Applications uses. */}
+      {scheduled && app.slot && !picking && (
+        <div className="mt-4 rounded-md border border-emerald-200 bg-emerald-50/60 p-3">
+          <p
+            className={`text-[11px] font-medium uppercase tracking-wide ${
+              justBooked ? "text-emerald-700" : "text-gray-500"
+            }`}
+          >
+            {justBooked ? "Interview booked ✓" : "Your interview"}
+          </p>
+          <div className="mt-1.5">
+            <BookedSlot slot={app.slot} />
+          </div>
+        </div>
+      )}
+
       {(app.status === "submitted" || scheduled) && (
         <div className="mt-4 border-t border-gray-100 pt-4">
           {!picking ? (
             <div className="flex flex-wrap items-center gap-3">
               {scheduled ? (
                 <>
-                  <Button variant="outline" onClick={() => setPicking(true)}>
+                  <ViewAllApplicationsButton />
+                  <Button variant="outline" onClick={openPicker}>
                     Reschedule interview
                   </Button>
                   <button
@@ -396,16 +447,22 @@ function ApplicationInProgress({
                   </button>
                 </>
               ) : openSeatCount > 0 ? (
-                <Button
-                  onClick={() => setPicking(true)}
-                  className="inline-flex items-center gap-1.5"
-                >
-                  <CalendarClock className="h-4 w-4" /> Book an interview
-                </Button>
+                <>
+                  <Button
+                    onClick={openPicker}
+                    className="inline-flex items-center gap-1.5"
+                  >
+                    <CalendarClock className="h-4 w-4" /> Book an interview
+                  </Button>
+                  <ViewAllApplicationsButton />
+                </>
               ) : (
-                <p className="text-sm text-gray-500">
-                  No interview slots are open yet.
-                </p>
+                <>
+                  <p className="text-sm text-gray-500">
+                    No interview slots are open yet.
+                  </p>
+                  <ViewAllApplicationsButton />
+                </>
               )}
             </div>
           ) : (
@@ -413,9 +470,16 @@ function ApplicationInProgress({
               ccaID={ccaID}
               applicationID={app.applicationID}
               currentSlotID={app.interviewSlotID}
+              // Refetch BEFORE closing the picker. `app` is still the pre-book
+              // data until getCca comes back, so closing first shows the panel
+              // built from it: the OLD time under a green "Interview booked ✓"
+              // after a reschedule, or "Book an interview slot below" as if the
+              // booking never happened. react-query awaits a mutation's
+              // onSuccess, so the picker simply stays on "Booking…" instead.
               onDone={async () => {
-                setPicking(false);
                 await onChanged();
+                setPicking(false);
+                setJustBooked(true);
               }}
               onCancel={() => setPicking(false)}
             />

--- a/src/app/ccas/_components/MyApplicationsList.tsx
+++ b/src/app/ccas/_components/MyApplicationsList.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { CalendarClock, ChevronRight, MapPin } from "lucide-react";
+import { CalendarClock, ChevronRight } from "lucide-react";
 
 import { api, type RouterOutputs } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
-import { formatSlot, statusBadgeClass, residentStatusLabel } from "../_lib/status";
+import { statusBadgeClass, residentStatusLabel } from "../_lib/status";
+import BookedSlot from "./BookedSlot";
 import SlotPicker from "./SlotPicker";
 
 type MyApp =
@@ -104,18 +105,9 @@ function MyApplicationRow({ app }: { app: MyApp }) {
 
       {/* Booked interview */}
       {scheduled && app.slot && (
-        <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
-          <span className="inline-flex items-center gap-1.5">
-            <CalendarClock className="h-4 w-4 text-gray-400" />
-            {formatSlot(app.slot.startTime, app.slot.endTime)}
-          </span>
-          {app.slot.location && (
-            <span className="inline-flex items-center gap-1">
-              <MapPin className="h-3.5 w-3.5 text-gray-400" />
-              {app.slot.location}
-            </span>
-          )}
-        </p>
+        <div className="mt-2">
+          <BookedSlot slot={app.slot} />
+        </div>
       )}
 
       {app.status === "rejected" && app.decisionReason && (
@@ -131,9 +123,15 @@ function MyApplicationRow({ app }: { app: MyApp }) {
               ccaID={app.ccaID}
               applicationID={app.applicationID}
               currentSlotID={app.interviewSlotID}
+              // Refetch BEFORE closing the picker, same ordering as the CCA
+              // detail panel: `app` is still the pre-book row until
+              // myApplications comes back, so closing first shows the OLD time
+              // under an unchanged "Interview booked" pill after a reschedule.
+              // react-query awaits a mutation's onSuccess, so the picker holds
+              // on "Booking…" through the refetch instead.
               onDone={async () => {
-                setPicking(false);
                 await refresh();
+                setPicking(false);
               }}
               onCancel={() => setPicking(false)}
             />

--- a/src/server/api/routers/ccaApplications.ts
+++ b/src/server/api/routers/ccaApplications.ts
@@ -282,10 +282,58 @@ export const ccaApplicationsRouter = createTRPCRouter({
       const hasOpenApplication =
         latest !== null && !isTerminalStatus(latest.status);
       const isMember = membership !== null;
-      const heads = await resolveHeadContacts(
-        ctx.db,
-        headRows.map((h) => h.userID),
-      );
+
+      // The booked slot, fetched by slotID with NO endTime filter: `futureSlots`
+      // above is the "what can I still book" list, and a slot the resident has
+      // already booked must keep rendering after it has passed — that is exactly
+      // when they want to check what they turned up to. canceledAt is READ, never
+      // filtered on (a `canceledAt: null` WHERE clause misses rows where the
+      // field is ABSENT); it is a consistency guard rather than a live state,
+      // because ccaApplicationsHead.cancelSlot reverts every scheduled occupant
+      // to `submitted` and nulls the pointer in the same locked section, so a
+      // still-scheduled application should never point at a canceled slot.
+      //
+      // Runs alongside resolveHeadContacts rather than before it: both depend on
+      // the Promise.all above, and serialising them would add a round trip to
+      // every CCA page load.
+      const [bookedRaw, heads] = await Promise.all([
+        latest?.interviewSlotID != null
+          ? ctx.db.ccaInterviewSlot.findUnique({
+              where: { slotID: latest.interviewSlotID },
+              select: {
+                slotID: true,
+                startTime: true,
+                endTime: true,
+                location: true,
+                capacity: true,
+                canceledAt: true,
+              },
+            })
+          : Promise.resolve(null),
+        resolveHeadContacts(
+          ctx.db,
+          headRows.map((h) => h.userID),
+        ),
+      ]);
+      // Shaped exactly like myApplications' `slot` (plus capacity/seatsLeft/
+      // canceled) so BookedSlot can render either one. seatsLeft counts the
+      // caller's OWN seat as taken, matching availableSlots — the number means
+      // "seats still free", not "seats free besides yours", on both surfaces.
+      const bookedSlot = bookedRaw
+        ? {
+            slotID: bookedRaw.slotID,
+            startTime: bookedRaw.startTime,
+            endTime: bookedRaw.endTime,
+            location: bookedRaw.location,
+            capacity: slotCapacity(bookedRaw.capacity),
+            seatsLeft: Math.max(
+              0,
+              slotCapacity(bookedRaw.capacity) -
+                (occupancy.get(bookedRaw.slotID) ?? 0),
+            ),
+            canceled: bookedRaw.canceledAt !== null,
+          }
+        : null;
 
       return {
         ccaID: cca.ccaID,
@@ -295,7 +343,7 @@ export const ccaApplicationsRouter = createTRPCRouter({
         logoUrl: profile?.logoUrl ?? null,
         bannerUrl: profile?.bannerUrl ?? null,
         isMember,
-        application: latest,
+        application: latest ? { ...latest, slot: bookedSlot } : null,
         // The client still shows an Apply button and the server re-checks — this
         // just drives the default affordance.
         canApply: !isMember && !hasOpenApplication,


### PR DESCRIPTION
## The problem

A resident who booked a CCA interview saw four words on `/ccas/[ccaID]` — **"Your interview is booked."** — and nothing else. No date, no time, no room.

Those details existed only on `/ccas/applications`, and nothing links to that page except the avatar dropdown (`header.tsx:128`). So in practice people booked a slot and then had no way to find out what they had booked.

## What this does

**Server** — `getCca` now sends the booked slot alongside the application. It is fetched by `slotID` with **no `endTime` filter**, unlike the `futureSlots` list beside it: that list answers "what can I still book", while this one has to keep rendering after the slot has passed, which is exactly when someone wants to check what they turned up to. `canceledAt` is read and never filtered on — a `canceledAt: null` WHERE clause misses rows where the field is ABSENT, the same Prisma+Mongo trap the rest of the file documents. It shares a `Promise.all` with `resolveHeadContacts`, so the CCA page gains no round trip.

**`BookedSlot.tsx` (new)** — one renderer for both surfaces (CCA detail page and My Applications) so the two cannot drift: booking on one page and checking on the other must show the same sentence. It repeats `SlotPicker`'s group-interview warning *after* the fact, because turning up to what you thought was a 1:1 and finding three other people in the room is a bad surprise whenever you learn it.

**Apply panel** — the slot appears in place of the old sentence the moment the booking lands, headed "Interview booked ✓". Both the scheduled and submitted states now carry a **View all applications** button.

## Two ordering details, both load-bearing

- **Both pickers now await the refetch BEFORE closing.** `app` is still the pre-booking payload until the query comes back, so closing first rendered the OLD time under a green "Interview booked ✓" after a reschedule, and rendered "Book an interview slot below" after a first booking, as if it had silently failed. react-query awaits a mutation's `onSuccess`, so the picker holds on "Booking…" instead. The My Applications half of this predates the change and is fixed here too.
- **The status paragraph still renders when a scheduled application has no slot row.** The slot panel is gated on the row coming back, and the pointer can outlive it, which would otherwise leave the pill alone with no sentence at all — worse than what this replaces.

## Scope

Read-path and UI only. No schema change, no migration, no new procedure, no kill switch.

## Testing

`npx tsc --noEmit` clean; `npm run lint` unchanged from baseline (13 pre-existing warnings, none in these files).

**Not yet exercised in a browser** — the booking, reschedule and cancel paths should be clicked through against real data before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ZrmREVH6CAD9iwPWotKw
